### PR TITLE
process(sdlc): add exclusive task-claim/lock protocol to prevent parallel duplicate work

### DIFF
--- a/.specify/memory/sdlc.md
+++ b/.specify/memory/sdlc.md
@@ -76,13 +76,27 @@ LOOP:
    - /speckit.maqa-github-projects.populate
 3. Validate: all Depends-on items are state=done before assigning
 4. Assign items to engineer slots (max 3 concurrent):
+   BEFORE writing anything, verify BOTH:
+   a. The target engineer slot is null in engineer_slots
+   b. No other slot already has this item-id assigned (duplicate-assignment guard)
+   If either check fails: skip this item and log a warning comment on Issue #1.
+   THEN, atomically write to .maqa/state.json:
+   - features[id].state       = "assigned"   ← NOT "in_progress"
+   - features[id].assigned_to = SLOT
+   - features[id].assigned_at = <ISO-8601 now>
+   - features[id].worktree_path = <path>
+   - engineer_slots[SLOT]     = id
+   THEN (after state.json is written):
    - /speckit.worktree.create
-   - Write to .maqa/state.json: slot, item_id, state, worktree_path
    - Move GitHub Projects card: Todo → In Progress
-   - Comment on item Issue: "[BADGE] Assigned to <SLOT>. Worktree: <path>"
+   - Comment on item Issue: "[BADGE] Assigned <id> to <SLOT>. Worktree: <path>"
+   - Comment on Issue #1 with assignment summary
 5. Monitor .maqa/state.json every 2 min:
+   - assigned (>10 min old, not yet in_progress) → re-post assignment comment;
+     if still assigned after another 10 min: reset state=todo, clear slot, alert
+   - in_progress → no action needed (engineer confirmed pickup)
    - in_review → move card to In Review
-   - done → move card to Done, free slot, assign next item
+   - done → move card to Done, free slot (set engineer_slots[SLOT]=null), assign next item
    - blocked → post [NEEDS HUMAN] to report issue, continue others
 6. When all queue items are done or blocked:
    BATCH AUDIT (before generating next queue):
@@ -130,10 +144,16 @@ Owns each feature end-to-end from assignment through merged PR.
 LOOP (one feature per iteration):
 
 1. PICK UP
-   Poll .maqa/state.json every 2 min for item assigned to my slot (AGENT_ID)
+   Poll .maqa/state.json every 2 min for an item where:
+     features[id].assigned_to == MY_AGENT_ID
+     features[id].state       == "assigned"          ← must be "assigned", not "todo"
+   If no such item exists: wait and re-poll. Do NOT self-select from the queue.
    Read: worktree_path from state.json
+   Wait up to 2 min for the worktree to be created by coordinator, then:
    cd into worktree: cd <worktree_path>
-   Wait 1 min and re-poll if worktree doesn't exist yet
+   CONFIRM PICKUP — write to .maqa/state.json atomically:
+     features[id].state = "in_progress"
+   Post on item Issue: "[BADGE] Confirmed pickup of <id>. Starting implementation."
    Read: docs/aide/items/<item>.md → .specify/specs/<feature>/spec.md
         → tasks.md → docs/design/<feature>.md → examples/ → docs/
 
@@ -453,22 +473,29 @@ Badges: `[🎯 COORDINATOR]`, `[🔨 ENGINEER-N]`, `[🔍 QA]`, `[🔄 SCRUM-MAS
 
 `.maqa/state.json` — the team's shared state. Written atomically.
 
+**Ownership rule**: the Coordinator is the ONLY agent that writes to
+`engineer_slots` and that advances item state from `todo → assigned` or from
+`assigned → in_progress`. Engineers write ONLY their own narrow transitions:
+`in_progress → in_review` and `in_review → done`. No agent self-selects work
+from the queue; assignment is always performed by the Coordinator.
+
 ```json
 {
-  "version": "1.0",
+  "version": "1.1",
   "current_queue": "queue-001",
   "engineer_slots": {
-    "ENGINEER-1": null,
-    "ENGINEER-2": null,
-    "ENGINEER-3": null
+    "ENGINEER-1": "<item-id or null>",
+    "ENGINEER-2": "<item-id or null>",
+    "ENGINEER-3": "<item-id or null>"
   },
   "last_sm_review": null,
   "last_pm_review": null,
   "batches_since_competitive_analysis": 0,
   "features": {
     "<item-id>": {
-      "state": "in_progress | in_review | done | blocked",
+      "state": "backlog | todo | assigned | in_progress | in_review | done | blocked",
       "assigned_to": "ENGINEER-1",
+      "assigned_at": "<ISO-8601 timestamp set by coordinator>",
       "worktree_path": "../<project>.<feature-branch>",
       "pr_number": null,
       "pr_merged": false
@@ -476,6 +503,38 @@ Badges: `[🎯 COORDINATOR]`, `[🔨 ENGINEER-N]`, `[🔍 QA]`, `[🔄 SCRUM-MAS
   }
 }
 ```
+
+### Assignment lifecycle (prevents parallel work on same item)
+
+```
+todo
+ │
+ │  Coordinator writes atomically:
+ │    features[id].state       = "assigned"
+ │    features[id].assigned_to = "ENGINEER-N"
+ │    features[id].assigned_at = <now>
+ │    engineer_slots[ENGINEER-N] = id
+ │  Then posts GitHub comment: "[BADGE] Assigned <id> to ENGINEER-N. Worktree: <path>"
+ ▼
+assigned
+ │
+ │  Engineer verifies BOTH conditions before starting:
+ │    features[id].assigned_to == MY_AGENT_ID
+ │    features[id].state       == "assigned"
+ │  If either condition is false: wait and re-poll (do NOT start work)
+ │  Engineer writes: features[id].state = "in_progress"
+ ▼
+in_progress  →  in_review  →  done
+```
+
+**Duplicate-assignment guard (Coordinator)**: before writing `assigned`, verify
+`engineer_slots` has no other entry pointing at the same item. If the item is
+already assigned to a different slot, skip it and log a warning to Issue #1.
+
+**Stale-assignment guard (Coordinator)**: if `state == "assigned"` and
+`assigned_at` is > 10 minutes old with no transition to `in_progress`, the
+coordinator re-posts the assignment comment and, after a second 10-minute window,
+sets state back to `todo` and clears the slot (the engineer session may have died).
 
 ---
 

--- a/docs/aide/team.yml
+++ b/docs/aide/team.yml
@@ -169,19 +169,35 @@ roles:
   states:
     - backlog
     - todo
+    - assigned
     - in_progress
     - in_review
     - done
     - blocked
   merge_owner: engineer
   state_file: .maqa/state.json
+  state_file_version: "1.1"
+  state_ownership:
+    coordinator_writes:
+      - "backlog -> todo"
+      - "todo -> assigned"
+      - "assigned -> todo (stale recovery after 20 min)"
+      - "done: free slot (set engineer_slots[SLOT]=null)"
+    engineer_writes:
+      - "assigned -> in_progress (confirm pickup only)"
+      - "in_progress -> in_review"
+      - "in_review -> done"
+      - "in_progress -> blocked"
+    note: "Engineers NEVER self-select from the queue. Coordinator is sole assigner."
   state_machine:
     "backlog -> todo": "coordinator validates dependencies are done"
-    "todo -> in_progress": "coordinator assigns and creates worktree"
+    "todo -> assigned": "coordinator: duplicate-assignment guard passes, writes atomically, creates worktree, posts comment"
+    "assigned -> in_progress": "engineer confirms pickup after verifying assigned_to==MY_SLOT"
     "in_progress -> in_review": "engineer validates, CI green, PR open"
     "in_review -> in_progress": "QA requests changes"
     "in_review -> done": "QA approves + CI green + engineer merges + smoke test passes"
-    "in_progress -> backlog": "blocked after 2 retries"
+    "in_progress -> blocked": "blocked after 2 retries"
+    "assigned -> todo": "stale assignment recovery by coordinator (>20 min, no pickup)"
 
 dependencies:
   enforcement: strict


### PR DESCRIPTION
[🔄 SCRUM-MASTER] ## SDLC Improvement — Task Locking / Exclusive Assignment

**Issue observed**: The current process has no mechanism to prevent two engineer
sessions from simultaneously picking up the same work item. Engineers poll
`.maqa/state.json` and look for items `assigned_to == MY_SLOT`, but the
coordinator writes `state = in_progress` and the assignment in one non-atomic
step. Any timing window between the coordinator writing and an engineer reading
could allow two sessions to start the same item, wasting compute and causing
conflicting PRs.

**Root cause**: No `assigned` intermediate state; no duplicate-assignment guard;
no coordinator-owns-writes rule; engineers could theoretically self-select work.

---

### Changes

#### `.specify/memory/sdlc.md`

1. **New `assigned` state** between `todo` and `in_progress`.
   - Coordinator writes `state=assigned` + `assigned_at` atomically *before* creating the worktree.
   - Engineer confirms pickup by writing `state=in_progress` only after verifying `assigned_to == MY_AGENT_ID AND state == assigned`.

2. **Coordinator duplicate-assignment guard**: before writing `assigned`, verify no other slot already holds the same item-id.

3. **Stale-assignment recovery**: if `state=assigned` and `assigned_at` > 10 min with no `in_progress` transition, coordinator re-posts the comment; after another 10 min it resets to `todo` and clears the slot (handles dead sessions).

4. **Explicit ownership rule**: the Coordinator is the *only* agent that writes to `engineer_slots` and advances state from `todo → assigned`. Engineers write only `in_progress`, `in_review`, `done`, `blocked`.

5. **Engineer PICK UP step rewritten**: engineers must see `state == "assigned"` and `assigned_to == MY_AGENT_ID` before starting — no self-selection from queue.

6. **State.json schema bumped** to `version: "1.1"` with new `assigned_at` field.

#### `docs/aide/team.yml`

- Added `assigned` to state list.
- Added `state_ownership` block documenting which agent writes which transitions.
- Updated `state_machine` with new transitions and stale-recovery edge.
- Added `state_file_version: "1.1"`.

---

**Expected improvement**: Zero duplicate-assignment incidents; no wasted parallel work on the same spec; coordinator retains full assignment authority.