### PR TITLE
feat(007-helm-chart-controller-deploy): Helm chart RBAC+Deployment, install/uninstall, integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,21 @@ jobs:
             exit 1
           fi
 
+  # ── Integration tests: reconcilers via fake client (no cluster needed) ────────
+  integration:
+    name: integration tests
+    needs: preflight
+    if: needs.preflight.outputs.has_gomod == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run integration tests
+        run: go test ./test/integration/... -tags integration -race -count=1 -timeout 120s
+
   # ── golangci-lint (only when go.mod exists) ─────────────────────────────────
   golangci-lint:
     name: golangci-lint

--- a/ITEM.md
+++ b/ITEM.md
@@ -1,133 +1,114 @@
-# Item 006: Controller Manager, BundleReconciler, and PipelineReconciler
+# Item 007: Helm Chart Controller Deployment + RBAC + Integration Test
 
 > **Queue**: queue-003 (Stage 2)
-> **Branch**: `006-controller-manager-and-reconcilers`
-> **Depends on**: 005 (merged — CRD types complete)
-> **Dependency mode**: merged
-> **Assignable**: immediately
-> **Contributes to**: All journeys (controller foundation)
+> **Branch**: `007-helm-chart-controller-deploy`
+> **Depends on**: 006 (branch must exist on remote)
+> **Dependency mode**: branch
+> **Assignable**: after 006 branch exists on remote
+> **Contributes to**: J1 (Quickstart — install step)
 
 ---
 
 ## Goal
 
-Wire the full controller-runtime Manager in `cmd/kardinal-controller/main.go` and
-implement two reconcilers: `BundleReconciler` (sets `status.phase = Available` on new
-Bundles) and `PipelineReconciler` (sets `status.conditions` on new Pipelines, validates
-environment names).
-
-No real promotion logic. Establishes the reconciler loop, status patching via the
-`status` subresource with optimistic locking, and structured zerolog logging.
+Update the Helm chart skeleton from Stage 0 to add the controller Deployment,
+ServiceAccount, ClusterRole, ClusterRoleBinding, and Service. Add a `make install`
+target that applies the chart to the current cluster. Add an integration test that
+applies a Bundle and Pipeline to a kind cluster and verifies status fields.
 
 ---
 
 ## Spec Reference
 
 `docs/aide/roadmap.md` — Stage 2: Bundle and Pipeline Reconcilers (No-Op Baseline)
-`docs/design/design-v2.1.md` — Architecture section
+`docs/design/design-v2.1.md` — Deployment architecture section
 
 ---
 
 ## Deliverables
 
-### 1. `cmd/kardinal-controller/main.go` — full Manager setup
+### 1. `chart/kardinal-promoter/templates/` — controller Deployment and RBAC
 
-Replace the Stage 0 stub with a working controller-runtime Manager:
+Add to the chart:
+- `deployment.yaml` — controller Deployment:
+  - `image: {{ .Values.image.repository }}:{{ .Values.image.tag }}`
+  - `args: ["--leader-elect=true", "--zap-log-level={{ .Values.logLevel }}"]`
+  - `livenessProbe.httpGet.path: /healthz`, port: 8081
+  - `readinessProbe.httpGet.path: /readyz`, port: 8081
+  - `resources.requests`: cpu=100m, memory=64Mi; `limits`: cpu=500m, memory=128Mi
+  - `serviceAccountName: kardinal-controller`
+  - `securityContext.runAsNonRoot: true`
+- `serviceaccount.yaml` — ServiceAccount `kardinal-controller`
+- `clusterrole.yaml` — ClusterRole with rules for:
+  - `pipelines, bundles, policygates, promotionsteps` — verbs: get, list, watch, create, update, patch, delete
+  - `pipelines/status, bundles/status, policygates/status, promotionsteps/status` — verbs: get, update, patch
+  - `leases` (coordination.k8s.io) — verbs: get, list, watch, create, update, patch, delete
+  - `events` — verbs: create, patch
+- `clusterrolebinding.yaml` — binds ClusterRole to ServiceAccount
+- `service.yaml` — Service exposing metrics port 8080
 
-```go
-// Wire:
-// - controller-runtime Manager with leader election via Kubernetes Lease
-// - Health probe endpoint on :8081 (/healthz + /readyz)
-// - Metrics endpoint on :8080
-// - Configurable log level via --zap-log-level flag (zerolog level)
-// - Register BundleReconciler and PipelineReconciler with the Manager
-// - Signal handling (SIGTERM/SIGINT → graceful shutdown)
+### 2. `chart/kardinal-promoter/values.yaml` — update values
+
+Add/update:
+```yaml
+image:
+  repository: ghcr.io/pnz1990/kardinal-promoter/controller
+  tag: latest
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+logLevel: info
+
+leaderElect: true
+metricsBindAddress: ":8080"
+healthProbeBindAddress: ":8081"
 ```
 
-Required flags:
-- `--leader-elect` (bool, default false)
-- `--zap-log-level` (string, default "info"; values: "debug", "info", "warn", "error")
-- `--metrics-bind-address` (string, default ":8080")
-- `--health-probe-bind-address` (string, default ":8081")
+### 3. `Makefile` — add `install` and `uninstall` targets
 
-Use `github.com/rs/zerolog` for logging. Inject logger into context via `zerolog.Ctx(ctx)`.
-Do NOT use `fmt.Println` or `log.Printf`.
+```makefile
+install: manifests ## Install CRDs and chart into current cluster
+    kubectl apply -f config/crd/bases/
+    helm upgrade --install kardinal chart/kardinal-promoter \
+        --namespace kardinal-system --create-namespace
 
-### 2. `pkg/reconciler/bundle/reconciler.go` — BundleReconciler
-
-```go
-// BundleReconciler watches Bundle objects.
-// On each reconcile:
-// 1. Get the Bundle
-// 2. If status.phase is empty, set it to Available
-// 3. Patch status via status subresource (use client.MergeFrom + client.Status().Patch)
-// 4. Emit structured log event: bundle name, type, target Pipeline
-// 5. Return reconcile.Result{}
-//
-// Error handling: wrap all errors with fmt.Errorf("context: %w", err)
-// Idempotency: if phase is already set, skip patching (no-op)
+uninstall: ## Remove chart from cluster
+    helm uninstall kardinal -n kardinal-system || true
+    kubectl delete -f config/crd/bases/ || true
 ```
 
-Create: `pkg/reconciler/bundle/reconciler.go`
+### 4. Integration test: `test/integration/controller_test.go`
 
-### 3. `pkg/reconciler/pipeline/reconciler.go` — PipelineReconciler
+Write an integration test using `go test -tags integration` that:
+1. Creates a fake client or uses the envtest framework
+2. Applies a Pipeline CRD object
+3. Applies a Bundle CRD object
+4. Runs the reconcilers in-process (not via a real cluster)
+5. Verifies within 5 seconds:
+   - `Bundle.status.phase == "Available"`
+   - `Pipeline.status.conditions[0].type == "Ready"`
+   - `Pipeline.status.conditions[0].status == "False"`
 
-```go
-// PipelineReconciler watches Pipeline objects.
-// On each reconcile:
-// 1. Get the Pipeline
-// 2. Validate: all environment names are unique; all dependsOn references name
-//    environments in the same Pipeline
-// 3. If validation fails: set status.conditions = [{type: Ready, status: False,
-//    reason: ValidationFailed, message: <error>}]
-// 4. If validation passes: set status.conditions = [{type: Ready, status: False,
-//    reason: Initializing, message: "Pipeline initialized, awaiting first Bundle"}]
-// 5. Patch status via status subresource
-// 6. Emit structured log event: pipeline name, environment count
-// 7. Return reconcile.Result{}
-//
-// Idempotency: if conditions are already correct, skip patching
-```
+Use `sigs.k8s.io/controller-runtime/pkg/envtest` OR the fake client approach.
+Either is acceptable. If using envtest, add a Makefile target `test-integration` that
+sets `KUBEBUILDER_ASSETS` correctly.
 
-Create: `pkg/reconciler/pipeline/reconciler.go`
+**Build tag**: `//go:build integration` on the test file.
+**Test command**: `go test ./test/integration/... -tags integration -race`
 
-### 4. Unit tests (TDD — write tests first)
-
-`pkg/reconciler/bundle/reconciler_test.go`:
-- `TestBundleReconciler_SetsAvailablePhase`: creates a Bundle with empty phase, reconciles, verifies phase=Available
-- `TestBundleReconciler_Idempotent`: Bundle already has phase=Available, reconcile is a no-op (no status patch called)
-- Table-driven, use `testify/assert` and `testify/require`
-- Use `sigs.k8s.io/controller-runtime/pkg/client/fake` for the fake client
-
-`pkg/reconciler/pipeline/reconciler_test.go`:
-- `TestPipelineReconciler_SetsInitializingCondition`: new Pipeline with 3 envs, reconciles, verifies Ready=False/Initializing
-- `TestPipelineReconciler_DuplicateEnvironmentNames`: Pipeline with duplicate env names gets ValidationFailed condition
-- `TestPipelineReconciler_DependsOnNonExistentEnv`: Pipeline with bad dependsOn gets ValidationFailed condition
-- `TestPipelineReconciler_Idempotent`: already has correct conditions, reconcile is no-op
-- Table-driven
-
-### 5. `go test ./pkg/reconciler/...` must pass
-
-All tests green before opening PR.
-
-### 6. Update `examples/quickstart/pipeline.yaml` and `examples/quickstart/bundle.yaml`
-
-Ensure the quickstart examples use the correct field names from Stage 1 CRD types.
-If the files already use correct names, no change needed. Verify with `kubectl apply --dry-run=client`.
+This must pass in the PR CI (add `go test ./test/integration/... -tags integration` to CI).
 
 ---
 
 ## Acceptance Criteria (from roadmap Stage 2)
 
-- [ ] Controller builds and starts (`go build ./cmd/kardinal-controller/`)
-- [ ] `BundleReconciler` sets `status.phase = Available` on a newly created Bundle (verified in test)
-- [ ] `PipelineReconciler` sets `status.conditions[0].type = Ready` on a new Pipeline (verified in test)
-- [ ] `PipelineReconciler` rejects Pipelines with duplicate environment names (test)
-- [ ] `PipelineReconciler` rejects Pipelines where `dependsOn` references non-existent envs (test)
-- [ ] All reconcilers are idempotent: running twice produces no extra patches (test)
-- [ ] `go test ./pkg/reconciler/... -race` passes
-- [ ] `go vet ./...` passes
-- [ ] `make build` produces `bin/kardinal-controller`
+- [ ] `helm lint chart/kardinal-promoter` passes
+- [ ] Chart templates render without errors: `helm template kardinal chart/kardinal-promoter`
+- [ ] Controller Deployment, ServiceAccount, ClusterRole, ClusterRoleBinding, Service are all present in chart
+- [ ] `make install` runs without error on a cluster with CRDs installed
+- [ ] Integration test: apply Bundle and Pipeline, verify status within 5 seconds
+- [ ] `go test ./test/integration/... -tags integration -race` passes
+- [ ] `go vet ./...` clean
 - [ ] Copyright header on all new files
 - [ ] No banned filenames
 
@@ -135,14 +116,14 @@ If the files already use correct names, no change needed. Verify with `kubectl a
 
 ## Journey Contribution
 
-This item begins the path toward J1 (Quickstart) by creating the controller that
-reacts to Bundle creation. After Stage 2, J1 step 4 (`kubectl apply -f pipeline.yaml`)
-will result in a Pipeline with `Ready=False` conditions visible via kubectl.
+This item enables J1 step 1 (Quickstart): `helm install kardinal oci://...`
+After this item, the chart can be installed and the controller will start watching
+Pipeline and Bundle objects.
 
 Journey validation step for PR body:
 ```bash
-# Run the reconciler tests and show output
-go test ./pkg/reconciler/... -race -v 2>&1 | tail -30
+helm template kardinal chart/kardinal-promoter | grep -E "kind: (Deployment|ClusterRole|ServiceAccount)"
+go test ./test/integration/... -tags integration -race -v 2>&1 | tail -30
 ```
 
 ---
@@ -150,23 +131,21 @@ go test ./pkg/reconciler/... -race -v 2>&1 | tail -30
 ## Anti-patterns to Avoid
 
 - Do NOT add `util.go`, `helpers.go`, or `common.go`
-- Do NOT import `kro` in go.mod
-- Do NOT use `fmt.Println` — use `zerolog.Ctx(ctx)`
-- Do NOT mutate Deployments/Services directly
-- Use `fmt.Errorf("context: %w", err)` for all error wrapping
-- Every reconciler must be idempotent — safe to re-run after crash
+- Do NOT mutate Deployments or Services in controller code
+- Use `fmt.Errorf("context: %w", err)` for error wrapping
+- Helm values must all be templated — no hardcoded image names in templates
 
 ---
 
 ## Notes for Engineer
 
-The existing `pkg/reconciler/policygate/` and `pkg/reconciler/promotionstep/` packages
-are stubs from Stage 0. Do NOT modify them — they are for Stages 4 and 6.
+Item 007 depends on item 006's branch existing on remote (not necessarily merged).
+You can start work on the Helm chart templates in parallel with 006's implementation.
+The integration test should import the reconcilers from `pkg/reconciler/bundle/` and
+`pkg/reconciler/pipeline/` which come from item 006's branch.
 
-Create NEW packages: `pkg/reconciler/bundle/` and `pkg/reconciler/pipeline/`.
+If 006 is not yet merged when you open this PR, set `dependency_mode: branch` in
+state.json. The coordinator will handle ordering.
 
-The controller-runtime fake client (`sigs.k8s.io/controller-runtime/pkg/client/fake`)
-is already in go.mod from the Stage 0 scaffold. Use `fake.NewClientBuilder().WithScheme(scheme).WithObjects(obj).Build()`.
-
-For status patching: use `r.Status().Patch(ctx, obj, patch)` NOT `r.Update()`.
-Status is a subresource — regular Update will not persist status fields.
+The chart skeleton from item 003 already has `chart/kardinal-promoter/`. Do NOT create
+a new chart — update the existing one.

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ GOPROXY          ?= https://proxy.golang.org
 # Docker image
 IMG ?= kardinal-promoter:dev
 
-.PHONY: all build build-controller build-cli test lint vet generate manifests \
-        install docker-build helm-lint \
+.PHONY: all build build-controller build-cli test test-integration lint vet generate manifests \
+        install uninstall docker-build helm-lint \
         test-e2e test-e2e-journey-1 test-e2e-journey-2 test-e2e-journey-3 \
         test-e2e-journey-4 test-e2e-journey-5 \
         kind-up kind-down tools help
@@ -36,6 +36,9 @@ build-cli:
 ## Test
 test:
 	$(GO) test ./... -race -count=1 -timeout 120s
+
+test-integration: ## Run integration tests (fake client, no cluster required)
+	$(GO) test ./test/integration/... -tags integration -race -count=1 -timeout 120s
 
 test-cover:
 	$(GO) test ./... -race -coverprofile=coverage.out -covermode=atomic
@@ -59,9 +62,16 @@ manifests: $(CONTROLLER_GEN)
 	$(CONTROLLER_GEN) crd paths="./api/..." output:crd:artifacts:config=config/crd/bases
 	$(CONTROLLER_GEN) rbac:roleName=manager-role paths="./api/..." output:rbac:artifacts:config=config/rbac
 
-## Install CRDs into current cluster
-install: manifests
+## Install CRDs and chart into current cluster
+install: manifests ## Install CRDs and chart into current cluster
 	kubectl apply -f config/crd/bases/
+	helm upgrade --install kardinal chart/kardinal-promoter \
+		--namespace kardinal-system --create-namespace
+
+## Remove chart and CRDs from cluster
+uninstall: ## Remove chart from cluster
+	helm uninstall kardinal -n kardinal-system || true
+	kubectl delete -f config/crd/bases/ || true
 
 ## Docker
 docker-build:

--- a/chart/kardinal-promoter/templates/deployment.yaml
+++ b/chart/kardinal-promoter/templates/deployment.yaml
@@ -37,7 +37,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            - --leader-elect={{ .Values.leaderElect }}
             - --zap-log-level={{ .Values.logLevel }}
+            - --metrics-bind-address={{ .Values.metricsBindAddress }}
+            - --health-probe-bind-address={{ .Values.healthProbeBindAddress }}
           ports:
             - name: metrics
               containerPort: {{ .Values.service.metricsPort }}

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -49,6 +49,15 @@ securityContext:
 # -- Controller log level (debug, info, warn, error)
 logLevel: info
 
+# -- Enable leader election for controller manager
+leaderElect: true
+
+# -- Address the metrics endpoint binds to
+metricsBindAddress: ":8080"
+
+# -- Address the health probe endpoint binds to
+healthProbeBindAddress: ":8081"
+
 service:
   # -- Metrics port (Prometheus)
   metricsPort: 8080

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/kardinal-promoter/kardinal-promoter
 
 go 1.25.0
 
+toolchain go1.25.9
+
 require (
 	github.com/google/cel-go v0.28.0
 	github.com/rs/zerolog v1.35.0

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -1,0 +1,230 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+
+//go:build integration
+
+// Package integration contains integration tests for the kardinal-promoter controller.
+// These tests run reconcilers in-process using a fake client, verifying that
+// Bundle and Pipeline objects transition to the expected status within 5 seconds.
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	bundlereconciler "github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/bundle"
+	pipelinereconciler "github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/pipeline"
+)
+
+// buildScheme returns a Scheme with both client-go and kardinal types registered.
+func buildScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s), "clientgoscheme.AddToScheme must not fail")
+	require.NoError(t, kardinalv1alpha1.AddToScheme(s), "kardinalv1alpha1.AddToScheme must not fail")
+	return s
+}
+
+// TestControllerIntegration verifies that:
+// - Bundle.status.phase == "Available" after reconciliation
+// - Pipeline.status.conditions[0].type == "Ready"
+// - Pipeline.status.conditions[0].status == "False"
+//
+// This test runs the reconcilers in-process using a fake client.
+// No real Kubernetes cluster is required.
+func TestControllerIntegration(t *testing.T) {
+	const (
+		namespace    = "default"
+		pipelineName = "nginx-demo"
+		bundleName   = "nginx-demo-v1-29-0"
+		timeout      = 5 * time.Second
+		pollInterval = 50 * time.Millisecond
+	)
+
+	scheme := buildScheme(t)
+
+	// Create a Pipeline object
+	pipeline := &kardinalv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipelineName,
+			Namespace: namespace,
+		},
+		Spec: kardinalv1alpha1.PipelineSpec{
+			Git: kardinalv1alpha1.PipelineGit{
+				URL:    "https://github.com/example/nginx-demo",
+				Branch: "main",
+			},
+			Environments: []kardinalv1alpha1.EnvironmentSpec{
+				{
+					Name: "dev",
+				},
+				{
+					Name:      "prod",
+					DependsOn: []string{"dev"},
+					Approval:  "pr-review",
+				},
+			},
+		},
+	}
+
+	// Create a Bundle object
+	bundle := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bundleName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"kardinal.io/pipeline": pipelineName,
+			},
+		},
+		Spec: kardinalv1alpha1.BundleSpec{
+			Type:     "image",
+			Pipeline: pipelineName,
+			Images: []kardinalv1alpha1.ImageRef{
+				{
+					Repository: "ghcr.io/example/nginx-demo",
+					Tag:        "1.29.0",
+					Digest:     "sha256:replace-with-actual-digest",
+				},
+			},
+		},
+	}
+
+	// Build fake client with both objects pre-created
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pipeline, bundle).
+		WithStatusSubresource(pipeline, bundle).
+		Build()
+
+	ctx := context.Background()
+
+	t.Run("BundleReconciler sets phase to Available", func(t *testing.T) {
+		r := &bundlereconciler.Reconciler{Client: fakeClient}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      bundleName,
+				Namespace: namespace,
+			},
+		}
+
+		// Reconcile should succeed and be idempotent
+		result, err := r.Reconcile(ctx, req)
+		require.NoError(t, err, "BundleReconciler.Reconcile must not return error")
+		assert.Equal(t, ctrl.Result{}, result, "expected empty Result")
+
+		// Verify within 5 seconds
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			var got kardinalv1alpha1.Bundle
+			if err := fakeClient.Get(ctx, client.ObjectKey{Name: bundleName, Namespace: namespace}, &got); err != nil {
+				t.Logf("get bundle: %v", err)
+				time.Sleep(pollInterval)
+				continue
+			}
+			if got.Status.Phase == "Available" {
+				return // success
+			}
+			time.Sleep(pollInterval)
+		}
+		// Re-read for assertion message
+		var got kardinalv1alpha1.Bundle
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: bundleName, Namespace: namespace}, &got))
+		assert.Equal(t, "Available", got.Status.Phase, "Bundle.status.phase must be 'Available' within 5 seconds")
+	})
+
+	t.Run("BundleReconciler is idempotent", func(t *testing.T) {
+		r := &bundlereconciler.Reconciler{Client: fakeClient}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      bundleName,
+				Namespace: namespace,
+			},
+		}
+
+		// Reconcile a second time — should be a no-op
+		result, err := r.Reconcile(ctx, req)
+		require.NoError(t, err, "second BundleReconciler.Reconcile must not return error")
+		assert.Equal(t, ctrl.Result{}, result, "expected empty Result on second reconcile")
+
+		var got kardinalv1alpha1.Bundle
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: bundleName, Namespace: namespace}, &got))
+		assert.Equal(t, "Available", got.Status.Phase, "Bundle phase must still be 'Available' after second reconcile")
+	})
+
+	t.Run("PipelineReconciler sets Ready condition to False", func(t *testing.T) {
+		r := &pipelinereconciler.Reconciler{Client: fakeClient}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      pipelineName,
+				Namespace: namespace,
+			},
+		}
+
+		// Reconcile should succeed
+		result, err := r.Reconcile(ctx, req)
+		require.NoError(t, err, "PipelineReconciler.Reconcile must not return error")
+		assert.Equal(t, ctrl.Result{}, result, "expected empty Result")
+
+		// Verify within 5 seconds
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			var got kardinalv1alpha1.Pipeline
+			if err := fakeClient.Get(ctx, client.ObjectKey{Name: pipelineName, Namespace: namespace}, &got); err != nil {
+				t.Logf("get pipeline: %v", err)
+				time.Sleep(pollInterval)
+				continue
+			}
+			if len(got.Status.Conditions) > 0 {
+				cond := got.Status.Conditions[0]
+				if cond.Type == "Ready" && cond.Status == metav1.ConditionFalse {
+					return // success
+				}
+			}
+			time.Sleep(pollInterval)
+		}
+		// Re-read for assertion message
+		var got kardinalv1alpha1.Pipeline
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: pipelineName, Namespace: namespace}, &got))
+		require.NotEmpty(t, got.Status.Conditions, "Pipeline must have at least one condition")
+		assert.Equal(t, "Ready", got.Status.Conditions[0].Type, "Pipeline.status.conditions[0].type must be 'Ready'")
+		assert.Equal(t, metav1.ConditionFalse, got.Status.Conditions[0].Status, "Pipeline.status.conditions[0].status must be 'False'")
+	})
+
+	t.Run("PipelineReconciler is idempotent", func(t *testing.T) {
+		r := &pipelinereconciler.Reconciler{Client: fakeClient}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      pipelineName,
+				Namespace: namespace,
+			},
+		}
+
+		// Reconcile a second time — should be a no-op
+		result, err := r.Reconcile(ctx, req)
+		require.NoError(t, err, "second PipelineReconciler.Reconcile must not return error")
+		assert.Equal(t, ctrl.Result{}, result, "expected empty Result on second reconcile")
+
+		var got kardinalv1alpha1.Pipeline
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: pipelineName, Namespace: namespace}, &got))
+		require.NotEmpty(t, got.Status.Conditions, "Pipeline must still have conditions after second reconcile")
+		assert.Equal(t, "Ready", got.Status.Conditions[0].Type, "condition type must still be 'Ready'")
+		assert.Equal(t, metav1.ConditionFalse, got.Status.Conditions[0].Status, "condition status must still be 'False'")
+	})
+}


### PR DESCRIPTION
# PR: Item 007 — Helm Chart Controller Deployment + RBAC + Integration Test

## Item Reference

- **Item**: `docs/aide/items/007-helm-chart-controller-deploy.md`
- **Spec**: Stage 2 — Bundle and Pipeline Reconcilers (No-Op Baseline)
- **Design doc**: `docs/design/design-v2.1.md` — Deployment architecture section

## What this implements

Updates the Helm chart skeleton from Stage 0 to include the complete controller Deployment with all required args, adds `make install`/`uninstall` targets that use `helm upgrade --install`, and adds an in-process integration test that verifies `Bundle.status.phase == "Available"` and `Pipeline.status.conditions[0].status == "False"` using a fake client (no cluster required). CI now runs the integration tests on every PR.

## Files Changed

- `chart/kardinal-promoter/templates/deployment.yaml` — added `--leader-elect`, `--metrics-bind-address`, `--health-probe-bind-address` args
- `chart/kardinal-promoter/values.yaml` — added `leaderElect`, `metricsBindAddress`, `healthProbeBindAddress`
- `Makefile` — updated `install` to run `helm upgrade --install`; added `uninstall`, `test-integration` targets
- `test/integration/controller_test.go` — integration tests for BundleReconciler and PipelineReconciler (fake client, `//go:build integration`)
- `.github/workflows/ci.yml` — added `integration tests` CI job

## Acceptance Criteria

- [x] `helm lint chart/kardinal-promoter` passes
- [x] Chart templates render without errors: `helm template kardinal chart/kardinal-promoter`
- [x] Controller Deployment, ServiceAccount, ClusterRole, ClusterRoleBinding, Service all present
- [x] `make install` updated — runs `helm upgrade --install kardinal chart/kardinal-promoter --namespace kardinal-system --create-namespace` (verified renders correctly; no live cluster in CI)
- [x] Integration test: apply Bundle and Pipeline, verify status within 5 seconds — PASS
- [x] `go test ./test/integration/... -tags integration -race` passes
- [x] `go vet ./...` clean
- [x] Copyright header on all new files
- [x] No banned filenames

## Test Output

```
$ go test ./... -race -count=1 -timeout 120s
ok  github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1       2.785s
ok  github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/bundle  2.773s
ok  github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/pipeline 3.254s
ok  github.com/kardinal-promoter/kardinal-promoter/test/e2e           2.785s
ok  github.com/kardinal-promoter/kardinal-promoter/test/helm          3.442s

$ go vet ./...
VET: PASS

$ go build ./...
BUILD: PASS
```

## Phantom Completion Check

No tasks.md for item 007 (item uses acceptance criteria checklist). All acceptance criteria have matching code:
- Deployment args: `chart/kardinal-promoter/templates/deployment.yaml` lines 39-43
- values leaderElect: `chart/kardinal-promoter/values.yaml` line 53
- install target: `Makefile` lines 62-66
- uninstall target: `Makefile` lines 69-71
- integration test: `test/integration/controller_test.go` — 4 test cases all PASS

## Journey Validation Evidence

**Journey 1 (Quickstart) — install step**

```
$ helm template kardinal chart/kardinal-promoter | grep -E "kind: (Deployment|ClusterRole|ServiceAccount)"
kind: ServiceAccount
kind: ClusterRole
kind: ClusterRoleBinding
  kind: ClusterRole
  - kind: ServiceAccount
kind: Deployment

$ go test ./test/integration/... -tags integration -race -v 2>&1 | tail -15
=== RUN   TestControllerIntegration
=== RUN   TestControllerIntegration/BundleReconciler_sets_phase_to_Available
=== RUN   TestControllerIntegration/BundleReconciler_is_idempotent
=== RUN   TestControllerIntegration/PipelineReconciler_sets_Ready_condition_to_False
=== RUN   TestControllerIntegration/PipelineReconciler_is_idempotent
--- PASS: TestControllerIntegration (0.55s)
    --- PASS: TestControllerIntegration/BundleReconciler_sets_phase_to_Available (0.01s)
    --- PASS: TestControllerIntegration/BundleReconciler_is_idempotent (0.00s)
    --- PASS: TestControllerIntegration/PipelineReconciler_sets_Ready_condition_to_False (0.01s)
    --- PASS: TestControllerIntegration/PipelineReconciler_is_idempotent (0.00s)
PASS
ok  	github.com/kardinal-promoter/kardinal-promoter/test/integration	2.414s
```

**Helm template rendered args (from `helm template kardinal chart/kardinal-promoter`):**
```yaml
args:
  - --leader-elect=true
  - --zap-log-level=info
  - --metrics-bind-address=:8080
  - --health-probe-bind-address=:8081
```

## Pre-merge Checklist

- [x] `go test ./... -race` passes
- [x] `go vet ./...` zero findings
- [x] Zero phantom completions (all acceptance criteria have matching implementation)
- [x] Acceptance criteria from ITEM.md verified above
- [x] Journey validation output included above
- [x] All new `.go` files have Apache 2.0 copyright header
- [x] No `util.go`, `helpers.go`, `common.go` created
- [x] No new entries in `go.mod require` block
- [x] Every reconciler exercised has idempotency test (BundleReconciler and PipelineReconciler both have dedicated idempotency subtests)
- [x] No kro module import
- [x] `helm lint chart/kardinal-promoter` passes

## Notes

This PR depends on item 006 (branch `006-controller-manager-and-reconcilers`) for the `bundlereconciler` and `pipelinereconciler` packages. The 006 branch has been merged into this branch. If 006 has not yet been merged to main when this PR is reviewed, this PR should be merged after PR #23.