### PR TITLE
docs(stage3-spec-gate): fix GraphNode PropagateWhen field + intent field names

### DIFF
--- a/docs/design/01-graph-integration.md
+++ b/docs/design/01-graph-integration.md
@@ -53,12 +53,30 @@ type GraphSpec struct {
 }
 
 type GraphNode struct {
-    ID          string            `json:"id"`
-    Template    runtime.RawExtension `json:"template"`
-    ReadyWhen   []string          `json:"readyWhen,omitempty"`
-    IncludeWhen []string          `json:"includeWhen,omitempty"`
-    ForEach     string            `json:"forEach,omitempty"`
+    ID            string               `json:"id"`
+    Template      runtime.RawExtension `json:"template"`
+    ReadyWhen     []string             `json:"readyWhen,omitempty"`
+    PropagateWhen []string             `json:"propagateWhen,omitempty"`
+    IncludeWhen   []string             `json:"includeWhen,omitempty"`
+    ForEach       string               `json:"forEach,omitempty"`
 }
+
+// PropagateWhen usage:
+//
+//   ReadyWhen   = health signal only. Feeds the Graph's aggregated Ready condition
+//                 and the UI. Does NOT block downstream nodes.
+//   PropagateWhen = data-flow gate. When unsatisfied, downstream nodes do not receive
+//                   updated data and are not re-evaluated. This is the field that
+//                   gates PolicyGate blocking. See design-v2.1.md §3.5.
+//
+// For PromotionStep nodes: use PropagateWhen to block downstream when not Verified.
+//   propagateWhen: ["${dev.status.state == \"Verified\"}"]
+//
+// For PolicyGate nodes: use PropagateWhen to block downstream when gate not ready.
+//   propagateWhen: ["${noWeekendDeploys.status.ready == true}"]
+//
+// ReadyWhen on PolicyGate nodes is only the UI health signal (shows pass/fail colour).
+// The actual blocking is done by PropagateWhen on the upstream PolicyGate node.
 
 type GraphStatus struct {
     Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/docs/design/02-pipeline-to-graph-translator.md
+++ b/docs/design/02-pipeline-to-graph-translator.md
@@ -21,7 +21,7 @@ The Pipeline-to-Graph translator is the core logic that reads a Pipeline CRD, a 
   - One node per matching PolicyGate per gated environment (PolicyGate instance template)
   - Correct CEL reference edges between nodes
   - `readyWhen` expressions on each node
-  - Nodes excluded based on `intent.target` and `intent.skip`
+  - Nodes excluded based on `intent.targetEnvironment` and `intent.skipEnvironments`
 
 ## Go Package Structure
 
@@ -54,15 +54,15 @@ Output: a map of `environmentName -> []dependsOnNames`.
 
 Read `spec.intent` from the Bundle CRD.
 
-- `intent.target`: only include environments up to and including the target in the dependency graph. Walk the graph from the first environment to the target, including all environments on any path.
-- `intent.skip`: remove skipped environments from the graph. Before removing, validate skip permissions (see Step 3).
+- `intent.targetEnvironment`: only include environments up to and including the target in the dependency graph. Walk the graph from the first environment to the target, including all environments on any path.
+- `intent.skipEnvironments`: remove skipped environments from the graph. Before removing, validate skip permissions (see Step 3).
 - Default (no intent): include all environments.
 
 Output: a filtered list of environment names to include in the Graph.
 
 ### Step 3: Validate skip permissions
 
-For each environment in `intent.skip`:
+For each environment in `intent.skipEnvironments`:
 
 1. Collect all org-level PolicyGates (`kardinal.io/scope: org`) that match this environment via `kardinal.io/applies-to`.
 2. If any org gate applies, check for a SkipPermission PolicyGate:
@@ -208,8 +208,8 @@ If the Pipeline CRD is updated while a Bundle is mid-flight:
 | Case | Behavior |
 |---|---|
 | Pipeline has 0 environments | Error: Bundle set to Failed with reason "Pipeline has no environments." |
-| intent.target names an environment not in the Pipeline | Error: Bundle set to Failed with reason "Unknown target environment." |
-| intent.skip removes all environments | Error: Bundle set to Failed with reason "All environments skipped." |
+| intent.targetEnvironment names an environment not in the Pipeline | Error: Bundle set to Failed with reason "Unknown target environment." |
+| intent.skipEnvironments removes all environments | Error: Bundle set to Failed with reason "All environments skipped." |
 | PolicyGate applies-to matches no environment in the Pipeline | Gate is ignored (not injected). No error. |
 | Two PolicyGates with the same name in different namespaces | Both are injected. Node IDs include the namespace to prevent collisions. |
 | dependsOn references a skipped environment | Error: Bundle set to Failed with reason "dependsOn references skipped environment." |
@@ -222,9 +222,9 @@ Test cases for `translator.go`:
 1. Linear 3-env pipeline, no gates, default intent: verify 3 PromotionStep nodes with sequential dependencies.
 2. Linear 3-env pipeline with 2 org gates on prod: verify 3 PromotionStep nodes + 2 PolicyGate nodes, gates between staging and prod.
 3. Fan-out pipeline (staging -> [prod-us, prod-eu]): verify parallel nodes with shared dependency on staging.
-4. intent.target = staging: verify only dev and staging nodes, no prod.
-5. intent.skip = [staging] with SkipPermission: verify staging removed, dev -> prod directly.
-6. intent.skip = [staging] without SkipPermission: verify Bundle set to SkipDenied.
+4. intent.targetEnvironment = staging: verify only dev and staging nodes, no prod.
+5. intent.skipEnvironments = [staging] with SkipPermission: verify staging removed, dev -> prod directly.
+6. intent.skipEnvironments = [staging] without SkipPermission: verify Bundle set to SkipDenied.
 7. Pipeline with shard on prod: verify shard label on prod PromotionStep.
 8. Pipeline with custom steps on prod: verify steps field on prod PromotionStep.
 9. Config Bundle: verify different default step sequence (config-merge instead of kustomize-set-image).


### PR DESCRIPTION
[📋 PM] ## Spec Gate Fix — Stage 3 (Graph Generation)

**Status**: BLOCKING — queue-004 must not assign Stage 3 items until this merges and item 008 is complete.

---

## Error 1 — `GraphNode` missing `PropagateWhen` (CRITICAL)

**File**: `docs/design/01-graph-integration.md`

The `GraphNode` struct was missing `PropagateWhen []string`. `design-v2.1.md` §3.5 is unambiguous:

> `propagateWhen` = data-flow gate — DOES block downstream when unsatisfied

PolicyGate blocking works via `propagateWhen` on the gate node. Without this field in the spec, the Stage 3 builder has no field to set — PolicyGates would never block downstream PromotionSteps. All journeys involving policy gates (J3 Policy Governance, J1 weekend gates, J5 CLI explain) would appear to work but gates would be silently bypassed.

**Fix**: Added `PropagateWhen []string` to `GraphNode` with a detailed usage comment showing example expressions for both PromotionStep and PolicyGate nodes.

**Code fix also needed**: `pkg/graph/types.go` (merged in Stage 2) also lacks `PropagateWhen`. This is a source code change — see **item 008** (pre-queue blocking fix) that must be completed before any Stage 3 implementation item.

---

## Error 2 — Translator spec uses wrong `intent` field names (SIGNIFICANT)

**File**: `docs/design/02-pipeline-to-graph-translator.md`

8 occurrences used `intent.target` / `intent.skip` but the merged Bundle CRD type uses:
- `BundleIntent.TargetEnvironment` (json: `targetEnvironment`)
- `BundleIntent.SkipEnvironments` (json: `skipEnvironments`)

A Stage 3 engineer following the spec would reference the wrong Go fields.

**Fix**: All 8 occurrences corrected to `intent.targetEnvironment` and `intent.skipEnvironments`.
