### PR TITLE
feat(policygate): implement PolicyGate CEL evaluator and reconciler (Stage 4)

### DIFF
--- a/cmd/kardinal-controller/main.go
+++ b/cmd/kardinal-controller/main.go
@@ -35,9 +35,11 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	celpkg "github.com/kardinal-promoter/kardinal-promoter/pkg/cel"
 	graphpkg "github.com/kardinal-promoter/kardinal-promoter/pkg/graph"
 	bundlereconciler "github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/bundle"
 	pipelinereconciler "github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/pipeline"
+	policygaterecon "github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/policygate"
 	"github.com/kardinal-promoter/kardinal-promoter/pkg/translator"
 )
 
@@ -109,6 +111,17 @@ func main() {
 	if err := (&pipelinereconciler.Reconciler{Client: mgr.GetClient()}).
 		SetupWithManager(mgr); err != nil {
 		logger.Fatal().Err(err).Msg("unable to set up PipelineReconciler")
+	}
+
+	celEnv, err := celpkg.NewCELEnvironment()
+	if err != nil {
+		logger.Fatal().Err(err).Msg("unable to create CEL environment")
+	}
+	if err := (&policygaterecon.Reconciler{
+		Client:    mgr.GetClient(),
+		Evaluator: celpkg.NewEvaluator(celEnv),
+	}).SetupWithManager(mgr); err != nil {
+		logger.Fatal().Err(err).Msg("unable to set up PolicyGateReconciler")
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+
+package cel
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+)
+
+// NewCELEnvironment creates a shared CEL environment for PolicyGate expression evaluation.
+// Phase 1 registers bundle, schedule, and environment as dynamic map types.
+// Referencing unregistered or nil attributes causes CEL evaluation error (fail-closed).
+func NewCELEnvironment() (*cel.Env, error) {
+	env, err := cel.NewEnv(
+		// Phase 1: all context objects are maps for flexibility
+		// The expression accesses nested attributes via dynamic dispatch.
+		cel.Variable("bundle", cel.DynType),
+		cel.Variable("schedule", cel.DynType),
+		cel.Variable("environment", cel.DynType),
+		// Phase 2+ (not populated in Phase 1, but declared to avoid compile errors)
+		cel.Variable("metrics", cel.DynType),
+		cel.Variable("previousBundle", cel.DynType),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cel.NewEnv: %w", err)
+	}
+	return env, nil
+}

--- a/pkg/cel/evaluator.go
+++ b/pkg/cel/evaluator.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+
+package cel
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/cel-go/cel"
+)
+
+// Evaluator wraps a cel.Env and provides cached CEL expression evaluation.
+// All evaluation errors are fail-closed: a failing or erroring expression
+// returns (false, reason, err) — it does not permit the gate to pass.
+//
+// The program cache is keyed by expression string. Cache is valid for the
+// lifetime of the Evaluator (reset on controller restart).
+type Evaluator struct {
+	env   *cel.Env
+	cache map[string]cel.Program
+	mu    sync.Mutex
+}
+
+// NewEvaluator creates a new Evaluator backed by the given CEL environment.
+func NewEvaluator(env *cel.Env) *Evaluator {
+	return &Evaluator{
+		env:   env,
+		cache: make(map[string]cel.Program),
+	}
+}
+
+// Evaluate compiles (or retrieves from cache) and evaluates the CEL expression
+// against the provided context map.
+//
+// Returns:
+//   - pass: true if the expression evaluates to true
+//   - reason: human-readable explanation of the result
+//   - err: non-nil if compilation or evaluation failed (implies pass=false)
+//
+// All errors are fail-closed: the gate does not pass on any error.
+func (e *Evaluator) Evaluate(expr string, ctx map[string]interface{}) (bool, string, error) {
+	prg, err := e.getOrCompile(expr)
+	if err != nil {
+		return false, fmt.Sprintf("CEL compile error: %s", err), err
+	}
+
+	out, _, err := prg.Eval(ctx)
+	if err != nil {
+		return false, fmt.Sprintf("CEL evaluation error: %s", err), err
+	}
+
+	result, ok := out.Value().(bool)
+	if !ok {
+		err := fmt.Errorf("CEL expression %q returned non-boolean: %T(%v)", expr, out.Value(), out.Value())
+		return false, err.Error(), err
+	}
+
+	return result, fmt.Sprintf("%s = %v", expr, result), nil
+}
+
+// getOrCompile returns a cached program for the expression, or compiles it.
+func (e *Evaluator) getOrCompile(expr string) (cel.Program, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if prg, ok := e.cache[expr]; ok {
+		return prg, nil
+	}
+
+	ast, issues := e.env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		return nil, issues.Err()
+	}
+
+	prg, err := e.env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("cel.Program: %w", err)
+	}
+
+	e.cache[expr] = prg
+	return prg, nil
+}

--- a/pkg/cel/evaluator_test.go
+++ b/pkg/cel/evaluator_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+
+package cel_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	celpkg "github.com/kardinal-promoter/kardinal-promoter/pkg/cel"
+)
+
+// buildScheduleCtx builds a CEL context for schedule testing with the given time.
+func buildScheduleCtx(t time.Time) map[string]interface{} {
+	return map[string]interface{}{
+		"schedule": map[string]interface{}{
+			"isWeekend": t.Weekday() == time.Saturday || t.Weekday() == time.Sunday,
+			"hour":      t.Hour(),
+			"dayOfWeek": t.Weekday().String(),
+		},
+		"bundle": map[string]interface{}{
+			"type":    "image",
+			"version": "v1.0.0",
+			"provenance": map[string]interface{}{
+				"author":    "alice",
+				"commitSHA": "abc123",
+				"ciRunURL":  "https://ci.example.com/run/1",
+			},
+			"intent": map[string]interface{}{
+				"targetEnvironment": "prod",
+			},
+		},
+		"environment": map[string]interface{}{
+			"name": "prod",
+		},
+	}
+}
+
+// TestEvaluator_WeekendGate_Weekday verifies that !schedule.isWeekend passes on a weekday.
+func TestEvaluator_WeekendGate_Weekday(t *testing.T) {
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	// Tuesday
+	tuesday := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
+	ctx := buildScheduleCtx(tuesday)
+
+	pass, reason, err := eval.Evaluate("!schedule.isWeekend", ctx)
+	require.NoError(t, err)
+	assert.True(t, pass, "!schedule.isWeekend must pass on Tuesday")
+	assert.NotEmpty(t, reason)
+}
+
+// TestEvaluator_WeekendGate_Weekend verifies that !schedule.isWeekend fails on a weekend.
+func TestEvaluator_WeekendGate_Weekend(t *testing.T) {
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	// Saturday
+	saturday := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	ctx := buildScheduleCtx(saturday)
+
+	pass, reason, err := eval.Evaluate("!schedule.isWeekend", ctx)
+	require.NoError(t, err)
+	assert.False(t, pass, "!schedule.isWeekend must fail on Saturday")
+	assert.NotEmpty(t, reason)
+}
+
+// TestEvaluator_AuthorGate_Human verifies author gate passes for a human author.
+func TestEvaluator_AuthorGate_Human(t *testing.T) {
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	ctx := buildScheduleCtx(time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC))
+	ctx["bundle"].(map[string]interface{})["provenance"] = map[string]interface{}{
+		"author": "alice",
+	}
+
+	pass, _, err := eval.Evaluate(`bundle.provenance.author != "dependabot[bot]"`, ctx)
+	require.NoError(t, err)
+	assert.True(t, pass)
+}
+
+// TestEvaluator_AuthorGate_Bot verifies author gate fails for dependabot.
+func TestEvaluator_AuthorGate_Bot(t *testing.T) {
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	ctx := buildScheduleCtx(time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC))
+	ctx["bundle"].(map[string]interface{})["provenance"] = map[string]interface{}{
+		"author": "dependabot[bot]",
+	}
+
+	pass, _, err := eval.Evaluate(`bundle.provenance.author != "dependabot[bot]"`, ctx)
+	require.NoError(t, err)
+	assert.False(t, pass)
+}
+
+// TestEvaluator_SyntaxError verifies fail-closed on CEL syntax error.
+func TestEvaluator_SyntaxError(t *testing.T) {
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	ctx := buildScheduleCtx(time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC))
+	pass, reason, err := eval.Evaluate("!! invalid CEL {{{", ctx)
+	require.Error(t, err, "syntax error must return an error")
+	assert.False(t, pass, "syntax error must fail-closed")
+	assert.NotEmpty(t, reason)
+}
+
+// TestEvaluator_NonBooleanExpression verifies fail-closed for non-boolean result.
+func TestEvaluator_NonBooleanExpression(t *testing.T) {
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	ctx := buildScheduleCtx(time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC))
+	// bundle.version is a string, not a boolean
+	pass, reason, err := eval.Evaluate("bundle.version", ctx)
+	require.Error(t, err, "non-boolean expression must return an error")
+	assert.False(t, pass, "non-boolean expression must fail-closed")
+	assert.NotEmpty(t, reason)
+}
+
+// TestEvaluator_ConfigBundleType verifies bundle.type == "config" is evaluatable.
+func TestEvaluator_ConfigBundleType(t *testing.T) {
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	ctx := buildScheduleCtx(time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC))
+	ctx["bundle"].(map[string]interface{})["type"] = "config"
+
+	pass, _, err := eval.Evaluate(`bundle.type == "config"`, ctx)
+	require.NoError(t, err)
+	assert.True(t, pass)
+}
+
+// TestEvaluator_CacheHit verifies that the second evaluation of the same expression
+// uses the cached program (same result, no error).
+func TestEvaluator_CacheHit(t *testing.T) {
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	ctx := buildScheduleCtx(time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC))
+
+	pass1, _, err1 := eval.Evaluate("!schedule.isWeekend", ctx)
+	pass2, _, err2 := eval.Evaluate("!schedule.isWeekend", ctx)
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	assert.Equal(t, pass1, pass2)
+}
+
+// TestEvaluator_Benchmark verifies that CEL evaluation completes under 10ms p99.
+// This is a smoke test (not a true p99 benchmark) — just ensures no gross slowness.
+func TestEvaluator_Benchmark(t *testing.T) {
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	ctx := buildScheduleCtx(time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC))
+	expr := `!schedule.isWeekend && bundle.type == "image" && bundle.provenance.author != "dependabot[bot]"`
+
+	// Warmup
+	_, _, _ = eval.Evaluate(expr, ctx)
+
+	// 100 iterations to get a sense of timing
+	start := time.Now()
+	for i := 0; i < 100; i++ {
+		_, _, err := eval.Evaluate(expr, ctx)
+		require.NoError(t, err)
+	}
+	elapsed := time.Since(start)
+	avgNs := elapsed.Nanoseconds() / 100
+	assert.Less(t, avgNs, int64(10*time.Millisecond),
+		"average CEL evaluation must be under 10ms, got %v", time.Duration(avgNs))
+}

--- a/pkg/reconciler/policygate/reconciler.go
+++ b/pkg/reconciler/policygate/reconciler.go
@@ -1,0 +1,217 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+
+// Package policygate implements the PolicyGateReconciler which evaluates
+// CEL policy expressions on PolicyGate instances created by the Graph controller.
+package policygate
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/cel"
+)
+
+const (
+	// labelBundle is the label that identifies a PolicyGate instance (vs template).
+	labelBundle = "kardinal.io/bundle"
+	// labelEnvironment is the environment the gate is evaluated for.
+	labelEnvironment = "kardinal.io/environment"
+	// defaultRecheckInterval is used when gate.Spec.RecheckInterval is empty or invalid.
+	defaultRecheckInterval = 5 * time.Minute
+)
+
+// Reconciler evaluates PolicyGate CEL expressions and patches status.
+// It only processes instances (gates with kardinal.io/bundle label).
+// Template PolicyGates (no bundle label) are ignored.
+type Reconciler struct {
+	client.Client
+	// Evaluator evaluates CEL expressions.
+	Evaluator *cel.Evaluator
+	// NowFn returns the current time. Overridable for testing.
+	NowFn func() time.Time
+}
+
+// Reconcile evaluates the CEL expression on a PolicyGate instance.
+//
+// State machine:
+//   - No kardinal.io/bundle label → template, skip (no-op)
+//   - Gate not found → deleted, skip
+//   - Otherwise → build context, evaluate CEL, patch status, requeue
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := zerolog.Ctx(ctx).With().
+		Str("gate", req.Name).
+		Str("namespace", req.Namespace).
+		Logger()
+
+	var gate kardinalv1alpha1.PolicyGate
+	if err := r.Get(ctx, req.NamespacedName, &gate); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get policygate: %w", err)
+	}
+
+	// Skip templates (no bundle label = platform/team template, not instance)
+	bundleName := gate.Labels[labelBundle]
+	if bundleName == "" {
+		log.Debug().Msg("policygate has no bundle label, skipping (template)")
+		return ctrl.Result{}, nil
+	}
+
+	recheckInterval := parseRecheckInterval(gate.Spec.RecheckInterval)
+
+	// Build CEL context
+	celCtx, err := r.buildContext(ctx, &gate, bundleName)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to build CEL context, setting gate to blocked")
+		if patchErr := r.patchStatus(ctx, &gate, false,
+			fmt.Sprintf("context error: %s", err)); patchErr != nil {
+			return ctrl.Result{}, fmt.Errorf("patch gate status: %w", patchErr)
+		}
+		return ctrl.Result{RequeueAfter: recheckInterval}, nil
+	}
+
+	// Evaluate CEL expression
+	pass, reason, evalErr := r.Evaluator.Evaluate(gate.Spec.Expression, celCtx)
+	if evalErr != nil {
+		// Fail-closed on evaluation error
+		log.Warn().Err(evalErr).Str("expr", gate.Spec.Expression).
+			Msg("CEL evaluation error, setting gate to blocked")
+		if patchErr := r.patchStatus(ctx, &gate, false, reason); patchErr != nil {
+			return ctrl.Result{}, fmt.Errorf("patch gate status on eval error: %w", patchErr)
+		}
+		return ctrl.Result{RequeueAfter: recheckInterval}, nil
+	}
+
+	log.Info().
+		Bool("ready", pass).
+		Str("reason", reason).
+		Str("expr", gate.Spec.Expression).
+		Msg("policygate evaluated")
+
+	if patchErr := r.patchStatus(ctx, &gate, pass, reason); patchErr != nil {
+		return ctrl.Result{}, fmt.Errorf("patch gate status: %w", patchErr)
+	}
+
+	return ctrl.Result{RequeueAfter: recheckInterval}, nil
+}
+
+// buildContext constructs the Phase 1 CEL context for gate evaluation.
+func (r *Reconciler) buildContext(ctx context.Context, gate *kardinalv1alpha1.PolicyGate,
+	bundleName string) (map[string]interface{}, error) {
+	var bundle kardinalv1alpha1.Bundle
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      bundleName,
+		Namespace: gate.Namespace,
+	}, &bundle); err != nil {
+		return nil, fmt.Errorf("load bundle %s: %w", bundleName, err)
+	}
+
+	now := r.now()
+
+	bundleCtx := map[string]interface{}{
+		"type":    bundle.Spec.Type,
+		"version": extractVersion(&bundle),
+		"provenance": map[string]interface{}{
+			"author":    "",
+			"commitSHA": "",
+			"ciRunURL":  "",
+		},
+		"intent": map[string]interface{}{
+			"targetEnvironment": "",
+		},
+	}
+	if bundle.Spec.Provenance != nil {
+		bundleCtx["provenance"] = map[string]interface{}{
+			"author":    bundle.Spec.Provenance.Author,
+			"commitSHA": bundle.Spec.Provenance.CommitSHA,
+			"ciRunURL":  bundle.Spec.Provenance.CIRunURL,
+		}
+	}
+	if bundle.Spec.Intent != nil {
+		bundleCtx["intent"] = map[string]interface{}{
+			"targetEnvironment": bundle.Spec.Intent.TargetEnvironment,
+		}
+	}
+
+	return map[string]interface{}{
+		"bundle": bundleCtx,
+		"schedule": map[string]interface{}{
+			"isWeekend": now.Weekday() == time.Saturday || now.Weekday() == time.Sunday,
+			"hour":      now.Hour(),
+			"dayOfWeek": now.Weekday().String(),
+		},
+		"environment": map[string]interface{}{
+			"name": gate.Labels[labelEnvironment],
+		},
+	}, nil
+}
+
+// patchStatus patches the PolicyGate's status fields.
+func (r *Reconciler) patchStatus(ctx context.Context, gate *kardinalv1alpha1.PolicyGate,
+	ready bool, reason string) error {
+	patch := client.MergeFrom(gate.DeepCopy())
+	now := metav1.NewTime(r.now())
+	gate.Status.Ready = ready
+	gate.Status.Reason = reason
+	gate.Status.LastEvaluatedAt = &now
+	if err := r.Status().Patch(ctx, gate, patch); err != nil {
+		return fmt.Errorf("status patch: %w", err)
+	}
+	return nil
+}
+
+// now returns the current time, using NowFn if set (for testing).
+func (r *Reconciler) now() time.Time {
+	if r.NowFn != nil {
+		return r.NowFn()
+	}
+	return time.Now().UTC()
+}
+
+// SetupWithManager registers the PolicyGateReconciler with the controller-runtime Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kardinalv1alpha1.PolicyGate{}).
+		Complete(r)
+}
+
+// --- helpers ---
+
+// extractVersion returns the version string from a Bundle.
+// For image bundles: first image tag. For config bundles: first 8 chars of commitSHA.
+func extractVersion(bundle *kardinalv1alpha1.Bundle) string {
+	if bundle.Spec.Type == "config" && bundle.Spec.ConfigRef != nil {
+		sha := bundle.Spec.ConfigRef.CommitSHA
+		if len(sha) > 8 {
+			return sha[:8]
+		}
+		return sha
+	}
+	if len(bundle.Spec.Images) > 0 {
+		return bundle.Spec.Images[0].Tag
+	}
+	return ""
+}
+
+// parseRecheckInterval parses a Go duration string, returning defaultRecheckInterval on error.
+func parseRecheckInterval(s string) time.Duration {
+	if s == "" {
+		return defaultRecheckInterval
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return defaultRecheckInterval
+	}
+	return d
+}

--- a/pkg/reconciler/policygate/reconciler_test.go
+++ b/pkg/reconciler/policygate/reconciler_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+
+package policygate_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	celpkg "github.com/kardinal-promoter/kardinal-promoter/pkg/cel"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/policygate"
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = kardinalv1alpha1.AddToScheme(s)
+	return s
+}
+
+// makeGateInstance creates a PolicyGate instance (with bundle label) for testing.
+// nowFn is used to override the clock for schedule-based tests.
+func makeGateInstance(name, ns, bundleName, expression, recheckInterval string) *kardinalv1alpha1.PolicyGate {
+	return &kardinalv1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				"kardinal.io/bundle":      bundleName,
+				"kardinal.io/pipeline":    "nginx-demo",
+				"kardinal.io/environment": "prod",
+			},
+		},
+		Spec: kardinalv1alpha1.PolicyGateSpec{
+			Expression:      expression,
+			Message:         "test gate",
+			RecheckInterval: recheckInterval,
+		},
+	}
+}
+
+func makeBundle(name, ns string) *kardinalv1alpha1.Bundle {
+	return &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: kardinalv1alpha1.BundleSpec{
+			Type:     "image",
+			Pipeline: "nginx-demo",
+			Provenance: &kardinalv1alpha1.BundleProvenance{
+				Author:    "alice",
+				CommitSHA: "abc123",
+			},
+		},
+	}
+}
+
+// TestPolicyGateReconciler_WeekdayGatePasses verifies !schedule.isWeekend passes on a weekday.
+func TestPolicyGateReconciler_WeekdayGatePasses(t *testing.T) {
+	gate := makeGateInstance("no-weekend", "default", "nginx-demo-v1", "!schedule.isWeekend", "5m")
+	bundle := makeBundle("nginx-demo-v1", "default")
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gate, bundle).
+		WithStatusSubresource(gate).
+		Build()
+
+	// Tuesday
+	tuesday := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return tuesday },
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "no-weekend", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Greater(t, result.RequeueAfter.Seconds(), float64(0), "must requeue after recheckInterval")
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "no-weekend", Namespace: "default"}, &got))
+	assert.True(t, got.Status.Ready, "gate must be ready on weekday")
+	assert.NotNil(t, got.Status.LastEvaluatedAt, "lastEvaluatedAt must be set")
+}
+
+// TestPolicyGateReconciler_WeekendGateBlocks verifies !schedule.isWeekend blocks on weekend.
+func TestPolicyGateReconciler_WeekendGateBlocks(t *testing.T) {
+	gate := makeGateInstance("no-weekend", "default", "nginx-demo-v1", "!schedule.isWeekend", "5m")
+	bundle := makeBundle("nginx-demo-v1", "default")
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gate, bundle).
+		WithStatusSubresource(gate).
+		Build()
+
+	// Saturday
+	saturday := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return saturday },
+	}
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "no-weekend", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "no-weekend", Namespace: "default"}, &got))
+	assert.False(t, got.Status.Ready, "gate must NOT be ready on Saturday")
+}
+
+// TestPolicyGateReconciler_BundleNotFound verifies fail-closed when bundle is missing.
+func TestPolicyGateReconciler_BundleNotFound(t *testing.T) {
+	gate := makeGateInstance("no-weekend", "default", "missing-bundle", "!schedule.isWeekend", "5m")
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gate). // bundle NOT added
+		WithStatusSubresource(gate).
+		Build()
+
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC) },
+	}
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "no-weekend", Namespace: "default"},
+	})
+	require.NoError(t, err, "bundle-not-found must not return error (requeue only)")
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "no-weekend", Namespace: "default"}, &got))
+	assert.False(t, got.Status.Ready, "gate must be blocked when bundle is missing")
+}
+
+// TestPolicyGateReconciler_TemplateIgnored verifies templates (no bundle label) are skipped.
+func TestPolicyGateReconciler_TemplateIgnored(t *testing.T) {
+	// Gate template: no kardinal.io/bundle label
+	template := &kardinalv1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-weekend-template",
+			Namespace: "platform-policies",
+			// No kardinal.io/bundle label
+		},
+		Spec: kardinalv1alpha1.PolicyGateSpec{Expression: "!schedule.isWeekend"},
+	}
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(template).
+		WithStatusSubresource(template).
+		Build()
+
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC) },
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "no-weekend-template", Namespace: "platform-policies"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result, "template must return empty result (no requeue)")
+}
+
+// TestPolicyGateReconciler_RequeueAfterRecheckInterval verifies RequeueAfter.
+func TestPolicyGateReconciler_RequeueAfterRecheckInterval(t *testing.T) {
+	gate := makeGateInstance("recheck-gate", "default", "nginx-demo-v1", "!schedule.isWeekend", "10m")
+	bundle := makeBundle("nginx-demo-v1", "default")
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gate, bundle).
+		WithStatusSubresource(gate).
+		Build()
+
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC) },
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "recheck-gate", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Minute, result.RequeueAfter, "RequeueAfter must match recheckInterval")
+}
+
+// TestPolicyGateReconciler_GateNotFound verifies no error when gate is deleted.
+func TestPolicyGateReconciler_GateNotFound(t *testing.T) {
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	r := &policygate.Reconciler{Client: c, Evaluator: eval, NowFn: time.Now}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "gone", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}
+
+// TestPolicyGateReconciler_Idempotent verifies reconciling the same gate twice is safe.
+func TestPolicyGateReconciler_Idempotent(t *testing.T) {
+	gate := makeGateInstance("idem-gate", "default", "nginx-demo-v1", "!schedule.isWeekend", "5m")
+	bundle := makeBundle("nginx-demo-v1", "default")
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gate, bundle).
+		WithStatusSubresource(gate).
+		Build()
+
+	tuesday := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return tuesday },
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "idem-gate", Namespace: "default"}}
+
+	_, err = r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	_, err = r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "idem-gate", Namespace: "default"}, &got))
+	assert.True(t, got.Status.Ready)
+}

--- a/pkg/reconciler/policygate/types.go
+++ b/pkg/reconciler/policygate/types.go
@@ -9,9 +9,10 @@ import (
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 )
 
-// Reconciler evaluates PolicyGate CEL expressions and patches gate status.
-// Implemented in Stage 4 (spec 004).
-type Reconciler interface {
-	// Reconcile evaluates the PolicyGate CEL expression and updates status.
-	Reconcile(ctx context.Context, gate *kardinalv1alpha1.PolicyGate) error
+// PolicyGateEvaluator is the interface for evaluating a PolicyGate instance.
+// This stub is kept for documentation purposes; the concrete Reconciler implements
+// controller-runtime's reconcile.Reconciler interface directly.
+type PolicyGateEvaluator interface {
+	// Evaluate evaluates the PolicyGate CEL expression and updates status.
+	Evaluate(ctx context.Context, gate *kardinalv1alpha1.PolicyGate) error
 }


### PR DESCRIPTION
## Item

**010-policygate-cel** (queue-005)
Issue: #30

## Changes

### `pkg/cel/environment.go`
`NewCELEnvironment()` — Phase 1 variables (bundle, schedule, environment, metrics, previousBundle) as DynType for flexible map access.

### `pkg/cel/evaluator.go`
Cached CEL program evaluator. Fail-closed on all errors. Thread-safe via sync.Mutex.

### `pkg/reconciler/policygate/reconciler.go`
Full PolicyGate reconciliation loop:
- Skip templates (no `kardinal.io/bundle` label)
- Build Phase 1 CEL context from Bundle + clock
- Fail-closed on bundle not found, CEL compile error, evaluation error
- Patch `status.ready`, `status.reason`, `status.lastEvaluatedAt`
- `RequeueAfter: recheckInterval` (timer-based re-evaluation)
- `NowFn` injectable for deterministic time in tests

### `cmd/kardinal-controller/main.go`
Wires PolicyGateReconciler + CEL environment into Manager.

## Acceptance Criteria Checked

- [x] `NewCELEnvironment()` with Phase 1 variables
- [x] `Evaluator.Evaluate` — cache, fail-closed, benchmark < 10ms avg
- [x] Template vs instance distinction
- [x] All errors fail-closed
- [x] 9 CEL tests + 7 reconciler tests under race detector
- [x] `go build ./...` clean
- [x] `go test ./... -race` all pass
- [x] `go vet ./...` zero findings
- [x] Copyright headers on all new files
- [x] No banned filenames
- [x] Reconciler is idempotent

## Test Output

```
ok  github.com/kardinal-promoter/kardinal-promoter/pkg/cel               (9 tests)
ok  github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/policygate  (7 tests)
```

## Journey Validation

Enables J1 (weekend gate blocks prod) and J3 (Policy Governance). Full journey requires Stage 5+.