### PR TITLE
feat(cli): CLI foundation — cobra + version + get commands [011-cli-foundation]

### DIFF
--- a/cmd/kardinal/cmd/format.go
+++ b/cmd/kardinal/cmd/format.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmd implements the cobra subcommand tree for the kardinal CLI.
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+// HumanAge returns a human-readable age string for the given creation time.
+func HumanAge(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+// FormatPipelineTable writes a tabwriter-formatted table of pipelines to w.
+func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "PIPELINE\tPHASE\tENVIRONMENTS\tPAUSED\tAGE")
+	for _, p := range pipelines {
+		phase := p.Status.Phase
+		if phase == "" {
+			phase = "Unknown"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%v\t%s\n",
+			p.Name,
+			phase,
+			len(p.Spec.Environments),
+			p.Spec.Paused,
+			HumanAge(p.CreationTimestamp.Time),
+		)
+	}
+	tw.Flush()
+}
+
+// FormatBundleTable writes a tabwriter-formatted table of bundles to w.
+func FormatBundleTable(w io.Writer, bundles []v1alpha1.Bundle) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "BUNDLE\tTYPE\tPHASE\tAGE")
+	for _, b := range bundles {
+		phase := b.Status.Phase
+		if phase == "" {
+			phase = "Unknown"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			b.Name,
+			b.Spec.Type,
+			phase,
+			HumanAge(b.CreationTimestamp.Time),
+		)
+	}
+	tw.Flush()
+}
+
+// FormatStepsTable writes a tabwriter-formatted table of promotion steps to w.
+func FormatStepsTable(w io.Writer, steps []v1alpha1.PromotionStep) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "ENVIRONMENT\tSTEP-TYPE\tSTATE\tMESSAGE")
+	for _, s := range steps {
+		state := s.Status.State
+		if state == "" {
+			state = "Pending"
+		}
+		msg := s.Status.Message
+		if msg == "" {
+			msg = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			s.Spec.Environment,
+			s.Spec.StepType,
+			state,
+			msg,
+		)
+	}
+	tw.Flush()
+}

--- a/cmd/kardinal/cmd/format.go
+++ b/cmd/kardinal/cmd/format.go
@@ -39,48 +39,64 @@ func HumanAge(t time.Time) string {
 }
 
 // FormatPipelineTable writes a tabwriter-formatted table of pipelines to w.
-func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline) {
+func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(tw, "PIPELINE\tPHASE\tENVIRONMENTS\tPAUSED\tAGE")
+	if _, err := fmt.Fprintln(tw, "PIPELINE\tPHASE\tENVIRONMENTS\tPAUSED\tAGE"); err != nil {
+		return fmt.Errorf("write pipeline table header: %w", err)
+	}
 	for _, p := range pipelines {
 		phase := p.Status.Phase
 		if phase == "" {
 			phase = "Unknown"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%v\t%s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\t%v\t%s\n",
 			p.Name,
 			phase,
 			len(p.Spec.Environments),
 			p.Spec.Paused,
 			HumanAge(p.CreationTimestamp.Time),
-		)
+		); err != nil {
+			return fmt.Errorf("write pipeline row: %w", err)
+		}
 	}
-	tw.Flush()
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("flush pipeline table: %w", err)
+	}
+	return nil
 }
 
 // FormatBundleTable writes a tabwriter-formatted table of bundles to w.
-func FormatBundleTable(w io.Writer, bundles []v1alpha1.Bundle) {
+func FormatBundleTable(w io.Writer, bundles []v1alpha1.Bundle) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(tw, "BUNDLE\tTYPE\tPHASE\tAGE")
+	if _, err := fmt.Fprintln(tw, "BUNDLE\tTYPE\tPHASE\tAGE"); err != nil {
+		return fmt.Errorf("write bundle table header: %w", err)
+	}
 	for _, b := range bundles {
 		phase := b.Status.Phase
 		if phase == "" {
 			phase = "Unknown"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
 			b.Name,
 			b.Spec.Type,
 			phase,
 			HumanAge(b.CreationTimestamp.Time),
-		)
+		); err != nil {
+			return fmt.Errorf("write bundle row: %w", err)
+		}
 	}
-	tw.Flush()
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("flush bundle table: %w", err)
+	}
+	return nil
 }
 
 // FormatStepsTable writes a tabwriter-formatted table of promotion steps to w.
-func FormatStepsTable(w io.Writer, steps []v1alpha1.PromotionStep) {
+func FormatStepsTable(w io.Writer, steps []v1alpha1.PromotionStep) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(tw, "ENVIRONMENT\tSTEP-TYPE\tSTATE\tMESSAGE")
+	if _, err := fmt.Fprintln(tw, "ENVIRONMENT\tSTEP-TYPE\tSTATE\tMESSAGE"); err != nil {
+		return fmt.Errorf("write steps table header: %w", err)
+	}
 	for _, s := range steps {
 		state := s.Status.State
 		if state == "" {
@@ -90,12 +106,17 @@ func FormatStepsTable(w io.Writer, steps []v1alpha1.PromotionStep) {
 		if msg == "" {
 			msg = "-"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
 			s.Spec.Environment,
 			s.Spec.StepType,
 			state,
 			msg,
-		)
+		); err != nil {
+			return fmt.Errorf("write step row: %w", err)
+		}
 	}
-	tw.Flush()
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("flush steps table: %w", err)
+	}
+	return nil
 }

--- a/cmd/kardinal/cmd/format_test.go
+++ b/cmd/kardinal/cmd/format_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	"github.com/kardinal-promoter/kardinal-promoter/cmd/kardinal/cmd"
+)
+
+func TestFormatPipelineTable(t *testing.T) {
+	now := time.Now()
+	pipelines := []v1alpha1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "nginx-demo",
+				CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Minute)),
+			},
+			Spec: v1alpha1.PipelineSpec{
+				Environments: []v1alpha1.EnvironmentSpec{
+					{Name: "dev"},
+					{Name: "uat"},
+					{Name: "prod"},
+				},
+				Paused: false,
+			},
+			Status: v1alpha1.PipelineStatus{
+				Phase: "Ready",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	cmd.FormatPipelineTable(&buf, pipelines)
+	out := buf.String()
+
+	assert.Contains(t, out, "PIPELINE")
+	assert.Contains(t, out, "PHASE")
+	assert.Contains(t, out, "ENVIRONMENTS")
+	assert.Contains(t, out, "PAUSED")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "nginx-demo")
+	assert.Contains(t, out, "Ready")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "false")
+}
+
+func TestFormatBundleTable(t *testing.T) {
+	now := time.Now()
+	bundles := []v1alpha1.Bundle{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "nginx-demo-v1-29-0",
+				CreationTimestamp: metav1.NewTime(now.Add(-45 * time.Second)),
+			},
+			Spec: v1alpha1.BundleSpec{
+				Type:     "image",
+				Pipeline: "nginx-demo",
+			},
+			Status: v1alpha1.BundleStatus{
+				Phase: "Promoting",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	cmd.FormatBundleTable(&buf, bundles)
+	out := buf.String()
+
+	assert.Contains(t, out, "BUNDLE")
+	assert.Contains(t, out, "TYPE")
+	assert.Contains(t, out, "PHASE")
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "nginx-demo-v1-29-0")
+	assert.Contains(t, out, "image")
+	assert.Contains(t, out, "Promoting")
+}
+
+func TestFormatStepsTable(t *testing.T) {
+	now := time.Now()
+	steps := []v1alpha1.PromotionStep{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "nginx-demo-v1-29-0-test",
+				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Minute)),
+			},
+			Spec: v1alpha1.PromotionStepSpec{
+				Environment: "test",
+				StepType:    "kustomize-set-image",
+			},
+			Status: v1alpha1.PromotionStepStatus{
+				State:   "Pending",
+				Message: "",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "nginx-demo-v1-29-0-prod-gate",
+				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Minute)),
+			},
+			Spec: v1alpha1.PromotionStepSpec{
+				Environment: "prod",
+				StepType:    "PolicyGate",
+			},
+			Status: v1alpha1.PromotionStepStatus{
+				State:   "Pending",
+				Message: "no-weekend-deploys",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	cmd.FormatStepsTable(&buf, steps)
+	out := buf.String()
+
+	assert.Contains(t, out, "ENVIRONMENT")
+	assert.Contains(t, out, "STEP-TYPE")
+	assert.Contains(t, out, "STATE")
+	assert.Contains(t, out, "MESSAGE")
+	assert.Contains(t, out, "test")
+	assert.Contains(t, out, "kustomize-set-image")
+	assert.Contains(t, out, "Pending")
+	assert.Contains(t, out, "no-weekend-deploys")
+}
+
+func TestHumanAge(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		contains string
+	}{
+		{"seconds", 45 * time.Second, "s"},
+		{"minutes", 3 * time.Minute, "m"},
+		{"hours", 2 * time.Hour, "h"},
+		{"days", 25 * time.Hour, "d"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cmd.HumanAge(time.Now().Add(-tc.duration))
+			require.True(t, strings.Contains(result, tc.contains),
+				"expected %q to contain %q, got %q", tc.name, tc.contains, result)
+		})
+	}
+}

--- a/cmd/kardinal/cmd/format_test.go
+++ b/cmd/kardinal/cmd/format_test.go
@@ -50,7 +50,7 @@ func TestFormatPipelineTable(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	cmd.FormatPipelineTable(&buf, pipelines)
+	require.NoError(t, cmd.FormatPipelineTable(&buf, pipelines))
 	out := buf.String()
 
 	assert.Contains(t, out, "PIPELINE")
@@ -83,7 +83,7 @@ func TestFormatBundleTable(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	cmd.FormatBundleTable(&buf, bundles)
+	require.NoError(t, cmd.FormatBundleTable(&buf, bundles))
 	out := buf.String()
 
 	assert.Contains(t, out, "BUNDLE")
@@ -129,7 +129,7 @@ func TestFormatStepsTable(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	cmd.FormatStepsTable(&buf, steps)
+	require.NoError(t, cmd.FormatStepsTable(&buf, steps))
 	out := buf.String()
 
 	assert.Contains(t, out, "ENVIRONMENT")

--- a/cmd/kardinal/cmd/get.go
+++ b/cmd/kardinal/cmd/get.go
@@ -11,21 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package main is the entry point for the kardinal CLI binary.
-// The CLI creates and reads kardinal-promoter CRDs via the Kubernetes API.
-package main
+package cmd
 
-import (
-	"fmt"
-	"os"
+import "github.com/spf13/cobra"
 
-	"github.com/kardinal-promoter/kardinal-promoter/cmd/kardinal/cmd"
-)
-
-func main() {
-	root := cmd.NewRootCmd()
-	if err := root.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+func newGetCmd() *cobra.Command {
+	get := &cobra.Command{
+		Use:   "get",
+		Short: "Display one or more kardinal resources",
 	}
+	get.AddCommand(newGetPipelinesCmd())
+	get.AddCommand(newGetBundlesCmd())
+	get.AddCommand(newGetStepsCmd())
+	return get
 }

--- a/cmd/kardinal/cmd/get_bundles.go
+++ b/cmd/kardinal/cmd/get_bundles.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+func newGetBundlesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "bundles [pipeline]",
+		Aliases: []string{"bundle"},
+		Short:   "List Bundles, optionally filtered by pipeline name",
+		Args:    cobra.MaximumNArgs(1),
+		RunE:    runGetBundles,
+	}
+}
+
+func runGetBundles(cmd *cobra.Command, args []string) error {
+	client, ns, err := buildClient()
+	if err != nil {
+		return fmt.Errorf("get bundles: %w", err)
+	}
+
+	opts := []sigs_client.ListOption{sigs_client.InNamespace(ns)}
+	if len(args) == 1 {
+		opts = append(opts, sigs_client.MatchingFields{"spec.pipeline": args[0]})
+	}
+
+	var bundles v1alpha1.BundleList
+	if err := client.List(context.Background(), &bundles, opts...); err != nil {
+		// Fall back to unfiltered list and filter in-process if field indexer
+		// is not available (e.g. no cache).
+		var all v1alpha1.BundleList
+		if err2 := client.List(context.Background(), &all, sigs_client.InNamespace(ns)); err2 != nil {
+			return fmt.Errorf("list bundles: %w", err)
+		}
+		if len(args) == 1 {
+			pipeline := args[0]
+			for _, b := range all.Items {
+				if b.Spec.Pipeline == pipeline {
+					bundles.Items = append(bundles.Items, b)
+				}
+			}
+		} else {
+			bundles = all
+		}
+	}
+
+	FormatBundleTable(cmd.OutOrStdout(), bundles.Items)
+	return nil
+}

--- a/cmd/kardinal/cmd/get_bundles.go
+++ b/cmd/kardinal/cmd/get_bundles.go
@@ -64,6 +64,5 @@ func runGetBundles(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	FormatBundleTable(cmd.OutOrStdout(), bundles.Items)
-	return nil
+	return FormatBundleTable(cmd.OutOrStdout(), bundles.Items)
 }

--- a/cmd/kardinal/cmd/get_pipelines.go
+++ b/cmd/kardinal/cmd/get_pipelines.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+func newGetPipelinesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "pipelines [name]",
+		Aliases: []string{"pipeline"},
+		Short:   "List Pipelines",
+		Args:    cobra.MaximumNArgs(1),
+		RunE:    runGetPipelines,
+	}
+}
+
+func runGetPipelines(cmd *cobra.Command, args []string) error {
+	client, ns, err := buildClient()
+	if err != nil {
+		return fmt.Errorf("get pipelines: %w", err)
+	}
+
+	var pipelines v1alpha1.PipelineList
+	opts := []sigs_client.ListOption{sigs_client.InNamespace(ns)}
+
+	if err := client.List(context.Background(), &pipelines, opts...); err != nil {
+		return fmt.Errorf("list pipelines: %w", err)
+	}
+
+	// If a specific name was given, filter.
+	items := pipelines.Items
+	if len(args) == 1 {
+		name := args[0]
+		filtered := items[:0]
+		for _, p := range items {
+			if p.Name == name {
+				filtered = append(filtered, p)
+			}
+		}
+		items = filtered
+	}
+
+	FormatPipelineTable(cmd.OutOrStdout(), items)
+	return nil
+}

--- a/cmd/kardinal/cmd/get_pipelines.go
+++ b/cmd/kardinal/cmd/get_pipelines.go
@@ -59,6 +59,5 @@ func runGetPipelines(cmd *cobra.Command, args []string) error {
 		items = filtered
 	}
 
-	FormatPipelineTable(cmd.OutOrStdout(), items)
-	return nil
+	return FormatPipelineTable(cmd.OutOrStdout(), items)
 }

--- a/cmd/kardinal/cmd/get_steps.go
+++ b/cmd/kardinal/cmd/get_steps.go
@@ -49,6 +49,5 @@ func runGetSteps(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("list promotion steps: %w", err)
 	}
 
-	FormatStepsTable(cmd.OutOrStdout(), steps.Items)
-	return nil
+	return FormatStepsTable(cmd.OutOrStdout(), steps.Items)
 }

--- a/cmd/kardinal/cmd/get_steps.go
+++ b/cmd/kardinal/cmd/get_steps.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+func newGetStepsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "steps <pipeline>",
+		Aliases: []string{"step"},
+		Short:   "List PromotionSteps for a pipeline",
+		Args:    cobra.ExactArgs(1),
+		RunE:    runGetSteps,
+	}
+}
+
+func runGetSteps(cmd *cobra.Command, args []string) error {
+	client, ns, err := buildClient()
+	if err != nil {
+		return fmt.Errorf("get steps: %w", err)
+	}
+
+	pipeline := args[0]
+
+	var steps v1alpha1.PromotionStepList
+	if err := client.List(context.Background(), &steps,
+		sigs_client.InNamespace(ns),
+		sigs_client.MatchingLabels{"kardinal.io/pipeline": pipeline},
+	); err != nil {
+		return fmt.Errorf("list promotion steps: %w", err)
+	}
+
+	FormatStepsTable(cmd.OutOrStdout(), steps.Items)
+	return nil
+}

--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -1,0 +1,121 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+var (
+	rootScheme = runtime.NewScheme()
+
+	globalNamespace  string
+	globalKubeconfig string
+	globalContext    string
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(rootScheme))
+	utilruntime.Must(v1alpha1.AddToScheme(rootScheme))
+}
+
+// NewRootCmd constructs and returns the root cobra command.
+func NewRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "kardinal",
+		Short: "kardinal manages promotion pipelines on Kubernetes",
+		Long: `kardinal is the CLI for kardinal-promoter.
+It communicates with the Kubernetes API server to read and write CRDs.`,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	// Persistent flags available to all subcommands.
+	root.PersistentFlags().StringVarP(&globalNamespace, "namespace", "n", "",
+		"Kubernetes namespace (default: current context namespace)")
+	root.PersistentFlags().StringVar(&globalKubeconfig, "kubeconfig", defaultKubeconfig(),
+		"Path to kubeconfig file")
+	root.PersistentFlags().StringVar(&globalContext, "context", "",
+		"Kubeconfig context override")
+
+	root.AddCommand(newVersionCmd())
+	root.AddCommand(newGetCmd())
+
+	return root
+}
+
+// buildClient constructs a controller-runtime client from the persistent flags.
+func buildClient() (sigs_client.Client, string, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if globalKubeconfig != "" {
+		loadingRules.ExplicitPath = globalKubeconfig
+	}
+
+	overrides := &clientcmd.ConfigOverrides{}
+	if globalContext != "" {
+		overrides.CurrentContext = globalContext
+	}
+
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules, overrides,
+	).ClientConfig()
+	if err != nil {
+		// Fall back to in-cluster config.
+		cfg, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, "", fmt.Errorf("build kubeconfig: %w", err)
+		}
+	}
+
+	c, err := sigs_client.New(cfg, sigs_client.Options{Scheme: rootScheme})
+	if err != nil {
+		return nil, "", fmt.Errorf("create k8s client: %w", err)
+	}
+
+	// Resolve namespace.
+	ns := globalNamespace
+	if ns == "" {
+		ns, _, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			loadingRules, overrides,
+		).Namespace()
+		if err != nil || ns == "" {
+			ns = "default"
+		}
+	}
+
+	return c, ns, nil
+}
+
+// defaultKubeconfig returns $KUBECONFIG if set, otherwise ~/.kube/config.
+func defaultKubeconfig() string {
+	if kc := os.Getenv("KUBECONFIG"); kc != "" {
+		return kc
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".kube", "config")
+	}
+	return ""
+}

--- a/cmd/kardinal/cmd/version.go
+++ b/cmd/kardinal/cmd/version.go
@@ -53,8 +53,12 @@ func runVersion(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "CLI:        %s\n", cliVer)
-	fmt.Fprintf(cmd.OutOrStdout(), "Controller: %s\n", controllerVer)
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "CLI:        %s\n", cliVer); err != nil {
+		return fmt.Errorf("write version: %w", err)
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Controller: %s\n", controllerVer); err != nil {
+		return fmt.Errorf("write version: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/kardinal/cmd/version.go
+++ b/cmd/kardinal/cmd/version.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// CLIVersion is the static CLI version string, overridable at build time via ldflags.
+var CLIVersion = "v0.1.0-dev"
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the CLI and controller versions",
+		RunE:  runVersion,
+	}
+}
+
+func runVersion(cmd *cobra.Command, _ []string) error {
+	cliVer := buildInfoVersion()
+	controllerVer := "unknown"
+
+	// Best-effort: try to read from the kardinal-version ConfigMap.
+	client, _, err := buildClient()
+	if err == nil {
+		var cm corev1.ConfigMap
+		if err := client.Get(context.Background(),
+			types.NamespacedName{
+				Namespace: "kardinal-system",
+				Name:      "kardinal-version",
+			}, &cm); err == nil {
+			if v, ok := cm.Data["version"]; ok && v != "" {
+				controllerVer = v
+			}
+		}
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "CLI:        %s\n", cliVer)
+	fmt.Fprintf(cmd.OutOrStdout(), "Controller: %s\n", controllerVer)
+	return nil
+}
+
+// buildInfoVersion returns the version from embedded build info, falling back
+// to the static CLIVersion constant.
+func buildInfoVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			return info.Main.Version
+		}
+	}
+	return CLIVersion
+}


### PR DESCRIPTION
## Summary

Implements [011-cli-foundation](https://github.com/pnz1990/kardinal-promoter/issues/32): cobra CLI foundation for the `kardinal` binary.

## Changes

- **`cmd/kardinal/main.go`** — wires cobra root command (replaces stub)
- **`cmd/kardinal/cmd/root.go`** — root command with `--namespace`, `--kubeconfig`, `--context` persistent flags; `buildClient()` helper
- **`cmd/kardinal/cmd/version.go`** — `kardinal version` reads build info and `kardinal-system/kardinal-version` ConfigMap
- **`cmd/kardinal/cmd/get.go`** — `get` parent command
- **`cmd/kardinal/cmd/get_pipelines.go`** — `kardinal get pipelines [name]` → tabwriter table
- **`cmd/kardinal/cmd/get_bundles.go`** — `kardinal get bundles [pipeline]` → tabwriter table
- **`cmd/kardinal/cmd/get_steps.go`** — `kardinal get steps <pipeline>` → tabwriter table (filtered by `kardinal.io/pipeline` label)
- **`cmd/kardinal/cmd/format.go`** — exported `FormatPipelineTable`, `FormatBundleTable`, `FormatStepsTable`, `HumanAge`
- **`cmd/kardinal/cmd/format_test.go`** — table-driven tests for all formatting functions

## Acceptance Criteria

- [x] `kardinal version` prints CLI and controller versions
- [x] `kardinal get pipelines` shows table with correct columns
- [x] `kardinal get bundles` shows table with correct columns
- [x] `kardinal get steps` shows PromotionStep states
- [x] All commands use `--namespace` flag (default: current context)
- [x] `go build ./cmd/kardinal/...` produces a binary
- [x] `go test ./cmd/kardinal/...` passes
- [x] `go vet ./...` passes
- [x] Copyright headers on all new files
- [x] No banned filenames

Closes #32