### PR TITLE
feat(health): Health Adapters — Deployment, Argo CD, Flux [014-health-adapters]

### DIFF
--- a/ITEM.md
+++ b/ITEM.md
@@ -1,89 +1,97 @@
-# Item 013: PromotionStep Reconciler — Full Promotion Loop (Stage 6)
+# Item 014: Health Adapters — Deployment, Argo CD, Flux (Stage 7)
 
-> **Queue**: queue-006
-> **Branch**: `013-promotionstep-reconciler`
-> **Depends on**: 012 (merged — SCM + Steps Engine)
+> **Queue**: queue-007
+> **Branch**: `014-health-adapters`
+> **Depends on**: 013 (merged — PromotionStep reconciler)
 > **Dependency mode**: merged
-> **Assignable**: after 012 is merged
-> **Contributes to**: J1, J3, J4, J5 (end-to-end promotion)
-> **Priority**: HIGH — critical path to J1
+> **Assignable**: immediately
+> **Contributes to**: J1, J2 (health verification)
+> **Priority**: HIGH — required for J1 journey to pass
 
 ---
 
 ## Goal
 
-Implement the `PromotionStepReconciler` that watches `PromotionStep` CRDs and
-drives them through the step engine. Wire the full promotion loop end-to-end:
-Bundle → Graph → PromotionSteps → PRs → Verified.
+Replace the health-check stub with real health verification. The controller checks
+Deployment readiness, Argo CD Application health+sync, or Flux Kustomization Ready —
+whichever is present. The PromotionStep reconciler enters HealthChecking and advances
+to Verified only when the health check passes.
 
-Design spec: `docs/design/03-promotionstep-reconciler.md`, roadmap Stage 6.
+Design spec: `docs/design/05-health-adapters.md`, roadmap Stage 7.
 
 ---
 
 ## Deliverables
 
-### 1. `pkg/reconciler/promotionstep/reconciler.go`
+### 1. `pkg/health` package
 
-State machine:
-- `Pending` → `Promoting`: start step engine execution
-- `Promoting` → `WaitingForMerge`: open-pr step completed, prURL stored in status
-- `WaitingForMerge` → `HealthChecking`: wait-for-merge step returned Success
-- `HealthChecking` → `Verified`: health-check step returned Success
-- `Any` → `Failed`: any step returned Failed
+```
+pkg/health/
+  adapter.go          # Adapter interface: Check + Name + Available
+  registry.go         # AutoDetector: checks CRDs on startup, selects adapter
+  resource.go         # DeploymentAdapter: Deployment readiness conditions
+  argocd.go           # ArgoCDAdapter: Application health=Healthy + sync=Synced
+  flux.go             # FluxAdapter: Kustomization Ready condition
+  health_test.go      # Unit tests (table-driven, mock k8s client)
+```
 
-Reconciler behavior:
-- Reads `PromotionStep.spec.stepType` to determine step sequence (via `steps.Defaults`)
-- Calls `Engine.Execute` at current step index
-- Stores outputs in `PromotionStep.status.outputs`
-- Persists `currentStepIndex` in status for crash recovery (idempotent re-runs)
-- Uses `fmt.Errorf("context: %w", err)` — no bare errors
-- Uses `zerolog.Ctx(ctx)` for logging
+**Adapter interface:**
+```go
+type Adapter interface {
+    Check(ctx context.Context, opts CheckOptions) (HealthStatus, error)
+    Name() string
+    Available(ctx context.Context, discoveryClient discovery.DiscoveryInterface) (bool, error)
+}
 
-### 2. Bundle phase machine in `pkg/reconciler/bundle/reconciler.go`
+type HealthStatus struct {
+    Phase   string  // "Healthy", "Degraded", "Progressing", "Unknown"
+    Message string
+    CheckedAt time.Time
+}
+```
 
-Extend existing BundleReconciler to:
-- Watch PromotionStep statuses and aggregate into Bundle phase:
-  - All steps `Verified` → Bundle `Verified`
-  - Any step `Failed` → Bundle `Failed`
-  - Otherwise → Bundle `Promoting`
-- Bundle supersession: when a new Bundle for the same Pipeline is created, older
-  Bundles in `Promoting` are set to `Superseded` and their PromotionSteps deleted
+**AutoDetector:**
+- On startup and every 5 minutes, lists installed CRDs
+- Priority: argocd > flux > resource (Deployment)
+- Returns the highest-priority available adapter
 
-### 3. Webhook endpoint in controller HTTP server
+### 2. Wire health check into PromotionStepReconciler
 
-Add to the controller HTTP server:
-- `POST /webhook/scm` endpoint
-  - Validates `X-Hub-Signature-256` HMAC
-  - On `pull_request` event with `action: closed, merged: true`, reconciles the owning Bundle
-- Startup reconciliation: on controller start, re-list all in-flight PRs and re-check merge status
+In `pkg/reconciler/promotionstep/reconciler.go`, replace the stub health-check step
+dispatch with:
+- `handleHealthChecking` calls `AutoDetector.Select()` then `adapter.Check()`
+- Polls every 10 seconds until Healthy or timeout (default 10m, configurable via `Pipeline.spec.environments[].health.timeout`)
+- On Healthy: set state=Verified, record healthCheckedAt
+- On timeout: set state=Failed, reason="health check timeout"
 
-### 4. `kardinal explain` CLI command
+### 3. Write health result to Bundle evidence
 
-In `cmd/kardinal/cmd/explain.go`:
-- `kardinal explain <pipeline> --env <environment> [--watch]`
-- Lists PromotionSteps + PolicyGates for the pipeline/environment
-- Table columns: ENVIRONMENT | STEP | TYPE | STATE | REASON
-- `--watch` streams updates with ANSI in-place refresh
+After health check passes, write `Bundle.status.environments[env].healthCheckedAt`
+(already partially wired in item 013 — complete the timestamp population).
 
-### 5. Integration test
+### 4. Unit tests
 
-`test/e2e/promotion_loop_test.go`:
-- Kind cluster + mock GitHub server (httptest)
-- Apply Pipeline + Bundle
-- Verify Bundle reaches `Verified` within test timeout
-- Verify idempotency: delete and re-create a PromotionStep, no duplicate PRs
+- `DeploymentAdapter_Healthy`: mock client returns Deployment with all pods ready
+- `DeploymentAdapter_Degraded`: some pods not ready
+- `ArgoCDAdapter_Healthy`: Application with health=Healthy + sync=Synced
+- `ArgoCDAdapter_Degraded`: Application with health=Degraded
+- `FluxAdapter_Healthy`: Kustomization with Ready condition = True
+- `AutoDetector_SelectsArgoCD`: when ArgoCD CRD present, selects ArgoCDAdapter
+- `AutoDetector_FallsBack`: no ArgoCD/Flux CRDs, falls back to DeploymentAdapter
+- `HealthCheckStep_Timeout`: health check exceeds timeout, returns Failed
 
 ---
 
 ## Acceptance Criteria
 
-- [ ] PromotionStepReconciler drives full state machine: Pending → Promoting → WaitingForMerge → HealthChecking → Verified
-- [ ] Bundle phase aggregated from PromotionStep statuses
-- [ ] Bundle supersession: older Bundle set to Superseded when new Bundle created for same Pipeline
-- [ ] Idempotency: re-running reconciler does not duplicate PRs (checked via pr_number in status)
-- [ ] `/webhook/scm` endpoint validates signature and reconciles Bundle
-- [ ] `kardinal explain <pipeline> --env <env>` shows step/gate states
-- [ ] Integration test passes with mock GitHub server
+- [ ] `Adapter` interface defined with Check/Name/Available
+- [ ] `DeploymentAdapter` returns Healthy when all pods are ready, Degraded otherwise
+- [ ] `ArgoCDAdapter` returns Healthy when Application health=Healthy AND sync=Synced
+- [ ] `FluxAdapter` returns Healthy when Kustomization Ready condition=True
+- [ ] `AutoDetector` selects adapter by priority: argocd > flux > resource
+- [ ] PromotionStepReconciler `handleHealthChecking` uses the real adapter (not stub)
+- [ ] Health check timeout configurable via Pipeline spec; defaults to 10 minutes
+- [ ] `Bundle.status.environments[env].healthCheckedAt` set after health check passes
 - [ ] `go build ./...` passes
 - [ ] `go test ./... -race` passes
 - [ ] `go vet ./...` passes
@@ -94,7 +102,10 @@ In `cmd/kardinal/cmd/explain.go`:
 
 ## Notes
 
-- Uses `pkg/steps.Engine` from item 012
-- Webhook secret sourced from environment variable `KARDINAL_WEBHOOK_SECRET`
-- `kardinal explain --watch` can use a simple polling loop (no SSE required)
-- No real GitHub API calls in integration tests — use `httptest.NewServer` mock
+- Use `k8s.io/client-go/discovery` for CRD availability check
+- ArgoCD Application type: `argoproj.io/v1alpha1/Application`
+- Flux Kustomization type: `kustomize.toolkit.fluxcd.io/v1/Kustomization`
+- Use dynamic client for CRD-based resources (ArgoCD, Flux) to avoid hard dependencies
+- Timeout: `Pipeline.spec.environments[].health.timeout` (Go duration string, e.g. "30m")
+- The health-check step in `pkg/steps/steps/health_check.go` remains a stub;
+  the reconciler handles real health via direct adapter call (not step)

--- a/cmd/kardinal-controller/main.go
+++ b/cmd/kardinal-controller/main.go
@@ -40,6 +40,7 @@ import (
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	celpkg "github.com/kardinal-promoter/kardinal-promoter/pkg/cel"
 	graphpkg "github.com/kardinal-promoter/kardinal-promoter/pkg/graph"
+	healthpkg "github.com/kardinal-promoter/kardinal-promoter/pkg/health"
 	bundlereconciler "github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/bundle"
 	pipelinereconciler "github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/pipeline"
 	policygaterecon "github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/policygate"
@@ -146,9 +147,10 @@ func main() {
 	}
 
 	if err := (&psreconciler.Reconciler{
-		Client:    mgr.GetClient(),
-		SCM:       scmProvider,
-		GitClient: gitClient,
+		Client:         mgr.GetClient(),
+		SCM:            scmProvider,
+		GitClient:      gitClient,
+		HealthDetector: newHealthDetector(mgr.GetConfig(), mgr.GetClient(), logger),
 	}).SetupWithManager(mgr); err != nil {
 		logger.Fatal().Err(err).Msg("unable to set up PromotionStepReconciler")
 	}
@@ -184,6 +186,16 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		logger.Fatal().Err(err).Msg("problem running manager")
 	}
+}
+
+// newHealthDetector constructs an AutoDetector for health checking.
+// It creates a dynamic client from the given REST config.
+func newHealthDetector(cfg *rest.Config, k8s sigs_client.Client, log zerolog.Logger) *healthpkg.AutoDetector {
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		log.Fatal().Err(err).Msg("unable to create dynamic client for health detection")
+	}
+	return healthpkg.NewAutoDetector(k8s, dynClient)
 }
 
 // newTranslator constructs the Translator wired with a GraphClient and Builder.

--- a/pkg/health/adapter.go
+++ b/pkg/health/adapter.go
@@ -1,0 +1,346 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package health provides pluggable health adapters for promotion verification.
+// Each adapter checks a different Kubernetes resource type to determine if a
+// deployment is healthy after a promotion PR is merged.
+//
+// Phase 1 adapters: resource (Deployment), argocd (Argo CD Application), flux (Flux Kustomization).
+// Phase 2 adapters: argoRollouts, flagger.
+package health
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HealthStatus is the result of a health check.
+type HealthStatus struct {
+	// Healthy is true when the workload is fully available.
+	Healthy bool
+	// Reason is a human-readable explanation.
+	Reason string
+	// CheckedAt records when the check was performed.
+	CheckedAt time.Time
+}
+
+// CheckOptions carries the health check configuration for a specific environment.
+type CheckOptions struct {
+	// Type selects the adapter: "resource", "argocd", "flux".
+	// Empty means auto-detect.
+	Type string
+
+	// Resource configuration (for type: resource).
+	Resource ResourceConfig
+
+	// ArgoCD configuration (for type: argocd).
+	ArgoCD ArgoCDConfig
+
+	// Flux configuration (for type: flux).
+	Flux FluxConfig
+
+	// Timeout is the maximum time to wait for health. Default: 10 minutes.
+	Timeout time.Duration
+}
+
+// ResourceConfig is the health check configuration for a Kubernetes Deployment.
+type ResourceConfig struct {
+	// Name is the Deployment name. Defaults to pipeline name.
+	Name string
+	// Namespace is the Deployment namespace. Defaults to environment name.
+	Namespace string
+	// Condition is the condition type to check. Default: "Available".
+	Condition string
+}
+
+// ArgoCDConfig is the health check configuration for an Argo CD Application.
+type ArgoCDConfig struct {
+	// Name is the Application name.
+	Name string
+	// Namespace is the Application namespace. Default: "argocd".
+	Namespace string
+}
+
+// FluxConfig is the health check configuration for a Flux Kustomization.
+type FluxConfig struct {
+	// Name is the Kustomization name.
+	Name string
+	// Namespace is the Kustomization namespace. Default: "flux-system".
+	Namespace string
+}
+
+// Adapter is the interface for health verification backends.
+// All implementations must be idempotent and safe to call repeatedly.
+type Adapter interface {
+	// Check returns the health status of the target workload.
+	// Called repeatedly (every 10s) until Healthy, timeout, or error.
+	Check(ctx context.Context, opts CheckOptions) (HealthStatus, error)
+
+	// Name returns the adapter identifier.
+	Name() string
+}
+
+// --- DeploymentAdapter ---
+
+// DeploymentAdapter checks Kubernetes Deployment readiness conditions.
+type DeploymentAdapter struct {
+	client sigs_client.Client
+}
+
+// NewDeploymentAdapter constructs a DeploymentAdapter.
+func NewDeploymentAdapter(c sigs_client.Client) *DeploymentAdapter {
+	return &DeploymentAdapter{client: c}
+}
+
+// Name returns "resource".
+func (a *DeploymentAdapter) Name() string { return "resource" }
+
+// Check verifies the Deployment's Available condition.
+func (a *DeploymentAdapter) Check(ctx context.Context, opts CheckOptions) (HealthStatus, error) {
+	cfg := opts.Resource
+	if cfg.Condition == "" {
+		cfg.Condition = "Available"
+	}
+
+	var deploy appsv1.Deployment
+	if err := a.client.Get(ctx, types.NamespacedName{
+		Name:      cfg.Name,
+		Namespace: cfg.Namespace,
+	}, &deploy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return HealthStatus{Healthy: false, Reason: fmt.Sprintf("Deployment %s/%s not found", cfg.Namespace, cfg.Name), CheckedAt: time.Now()}, nil
+		}
+		return HealthStatus{}, fmt.Errorf("get deployment %s/%s: %w", cfg.Namespace, cfg.Name, err)
+	}
+
+	for _, cond := range deploy.Status.Conditions {
+		if string(cond.Type) == cfg.Condition {
+			healthy := cond.Status == corev1.ConditionTrue
+			reason := fmt.Sprintf("%s=%s", cond.Type, cond.Status)
+			if cond.Message != "" {
+				reason += ": " + cond.Message
+			}
+			return HealthStatus{Healthy: healthy, Reason: reason, CheckedAt: time.Now()}, nil
+		}
+	}
+
+	return HealthStatus{
+		Healthy:   false,
+		Reason:    fmt.Sprintf("condition %q not found on Deployment %s/%s", cfg.Condition, cfg.Namespace, cfg.Name),
+		CheckedAt: time.Now(),
+	}, nil
+}
+
+// --- ArgoCDAdapter ---
+
+// ArgoCDAdapter checks Argo CD Application health and sync status.
+// Uses the dynamic client to avoid a compile-time dependency on the Argo CD SDK.
+type ArgoCDAdapter struct {
+	dynamic dynamic.Interface
+}
+
+// NewArgoCDAdapter constructs an ArgoCDAdapter.
+func NewArgoCDAdapter(dynClient dynamic.Interface) *ArgoCDAdapter {
+	return &ArgoCDAdapter{dynamic: dynClient}
+}
+
+// Name returns "argocd".
+func (a *ArgoCDAdapter) Name() string { return "argocd" }
+
+var argoCDApplicationGVR = schema.GroupVersionResource{
+	Group:    "argoproj.io",
+	Version:  "v1alpha1",
+	Resource: "applications",
+}
+
+// Check verifies that the Argo CD Application is Healthy and Synced.
+func (a *ArgoCDAdapter) Check(ctx context.Context, opts CheckOptions) (HealthStatus, error) {
+	cfg := opts.ArgoCD
+	if cfg.Namespace == "" {
+		cfg.Namespace = "argocd"
+	}
+
+	app, err := a.dynamic.Resource(argoCDApplicationGVR).
+		Namespace(cfg.Namespace).
+		Get(ctx, cfg.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return HealthStatus{Healthy: false, Reason: fmt.Sprintf("Application %s/%s not found", cfg.Namespace, cfg.Name), CheckedAt: time.Now()}, nil
+		}
+		return HealthStatus{}, fmt.Errorf("get argo cd application %s/%s: %w", cfg.Namespace, cfg.Name, err)
+	}
+
+	healthStatus, _, _ := unstructured.NestedString(app.Object, "status", "health", "status")
+	syncStatus, _, _ := unstructured.NestedString(app.Object, "status", "sync", "status")
+	opPhase, _, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
+
+	if healthStatus == "Healthy" && syncStatus == "Synced" && (opPhase == "Succeeded" || opPhase == "") {
+		return HealthStatus{
+			Healthy:   true,
+			Reason:    fmt.Sprintf("Healthy+Synced (opPhase=%q)", opPhase),
+			CheckedAt: time.Now(),
+		}, nil
+	}
+
+	return HealthStatus{
+		Healthy:   false,
+		Reason:    fmt.Sprintf("health=%s, sync=%s, opPhase=%s", healthStatus, syncStatus, opPhase),
+		CheckedAt: time.Now(),
+	}, nil
+}
+
+// --- FluxAdapter ---
+
+// FluxAdapter checks Flux Kustomization Ready condition with generation matching.
+type FluxAdapter struct {
+	dynamic dynamic.Interface
+}
+
+// NewFluxAdapter constructs a FluxAdapter.
+func NewFluxAdapter(dynClient dynamic.Interface) *FluxAdapter {
+	return &FluxAdapter{dynamic: dynClient}
+}
+
+// Name returns "flux".
+func (a *FluxAdapter) Name() string { return "flux" }
+
+var fluxKustomizationGVR = schema.GroupVersionResource{
+	Group:    "kustomize.toolkit.fluxcd.io",
+	Version:  "v1",
+	Resource: "kustomizations",
+}
+
+// Check verifies that the Flux Kustomization's Ready condition is True and
+// that observedGeneration == generation (fully reconciled).
+func (a *FluxAdapter) Check(ctx context.Context, opts CheckOptions) (HealthStatus, error) {
+	cfg := opts.Flux
+	if cfg.Namespace == "" {
+		cfg.Namespace = "flux-system"
+	}
+
+	ks, err := a.dynamic.Resource(fluxKustomizationGVR).
+		Namespace(cfg.Namespace).
+		Get(ctx, cfg.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return HealthStatus{Healthy: false, Reason: fmt.Sprintf("Kustomization %s/%s not found", cfg.Namespace, cfg.Name), CheckedAt: time.Now()}, nil
+		}
+		return HealthStatus{}, fmt.Errorf("get flux kustomization %s/%s: %w", cfg.Namespace, cfg.Name, err)
+	}
+
+	conditions, _, _ := unstructured.NestedSlice(ks.Object, "status", "conditions")
+	observedGen, _, _ := unstructured.NestedInt64(ks.Object, "status", "observedGeneration")
+	generation, _, _ := unstructured.NestedInt64(ks.Object, "metadata", "generation")
+
+	readyCond := findCondition(conditions, "Ready")
+	if readyCond == nil {
+		return HealthStatus{
+			Healthy:   false,
+			Reason:    "Ready condition not found",
+			CheckedAt: time.Now(),
+		}, nil
+	}
+
+	readyStatus, _ := readyCond["status"].(string)
+	if readyStatus == "True" && observedGen == generation {
+		return HealthStatus{
+			Healthy:   true,
+			Reason:    fmt.Sprintf("Ready=True, generation=%d matches", generation),
+			CheckedAt: time.Now(),
+		}, nil
+	}
+
+	return HealthStatus{
+		Healthy:   false,
+		Reason:    fmt.Sprintf("Ready=%s, observedGen=%d, generation=%d", readyStatus, observedGen, generation),
+		CheckedAt: time.Now(),
+	}, nil
+}
+
+// findCondition searches for a condition by type in the Flux conditions slice.
+func findCondition(conditions []interface{}, condType string) map[string]interface{} {
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		t, _ := cond["type"].(string)
+		if t == condType {
+			return cond
+		}
+	}
+	return nil
+}
+
+// --- AutoDetector ---
+
+// AutoDetector selects the appropriate health adapter based on what is available
+// in the cluster. Priority: explicit type > argocd > flux > resource.
+type AutoDetector struct {
+	k8s     sigs_client.Client
+	dynamic dynamic.Interface
+}
+
+// NewAutoDetector constructs an AutoDetector.
+func NewAutoDetector(k8s sigs_client.Client, dynClient dynamic.Interface) *AutoDetector {
+	return &AutoDetector{k8s: k8s, dynamic: dynClient}
+}
+
+// Select returns the best available adapter for the given health type.
+// If healthType is empty, auto-detects based on installed CRDs.
+func (d *AutoDetector) Select(ctx context.Context, healthType string) (Adapter, error) {
+	switch healthType {
+	case "argocd":
+		return NewArgoCDAdapter(d.dynamic), nil
+	case "flux":
+		return NewFluxAdapter(d.dynamic), nil
+	case "resource", "":
+		// Auto-detect: try argocd, then flux, fall back to resource.
+		if healthType == "" {
+			if crdAvailable(ctx, d.dynamic, "applications.argoproj.io") {
+				return NewArgoCDAdapter(d.dynamic), nil
+			}
+			if crdAvailable(ctx, d.dynamic, "kustomizations.kustomize.toolkit.fluxcd.io") {
+				return NewFluxAdapter(d.dynamic), nil
+			}
+		}
+		return NewDeploymentAdapter(d.k8s), nil
+	default:
+		return NewDeploymentAdapter(d.k8s), nil
+	}
+}
+
+// crdAvailable checks whether a CRD (by plural resource name) is installed in the cluster.
+// It uses the dynamic client to attempt a list of the CRD resource at the apiextensions group.
+func crdAvailable(ctx context.Context, dynClient dynamic.Interface, crdName string) bool {
+	crdGVR := schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}
+	_, err := dynClient.Resource(crdGVR).Get(ctx, crdName, metav1.GetOptions{})
+	return err == nil
+}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,0 +1,279 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/health"
+)
+
+func buildScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+// TestDeploymentAdapter_Healthy verifies that a Deployment with Available=True
+// is reported as Healthy.
+func TestDeploymentAdapter_Healthy(t *testing.T) {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx", Namespace: "prod"},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue, Reason: "MinimumReplicasAvailable"},
+			},
+		},
+	}
+
+	s := buildScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(deploy).Build()
+
+	adapter := health.NewDeploymentAdapter(c)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		Resource: health.ResourceConfig{
+			Name:      "nginx",
+			Namespace: "prod",
+			Condition: "Available",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Healthy)
+	assert.Contains(t, result.Reason, "Available")
+}
+
+// TestDeploymentAdapter_Degraded verifies that a Deployment with Available=False
+// is reported as Degraded.
+func TestDeploymentAdapter_Degraded(t *testing.T) {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx", Namespace: "prod"},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionFalse, Message: "pods not ready"},
+			},
+		},
+	}
+
+	s := buildScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(deploy).Build()
+
+	adapter := health.NewDeploymentAdapter(c)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		Resource: health.ResourceConfig{
+			Name:      "nginx",
+			Namespace: "prod",
+			Condition: "Available",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy)
+	assert.Contains(t, result.Reason, "False")
+}
+
+// TestDeploymentAdapter_NotFound verifies that a missing Deployment returns Unhealthy.
+func TestDeploymentAdapter_NotFound(t *testing.T) {
+	s := buildScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	adapter := health.NewDeploymentAdapter(c)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		Resource: health.ResourceConfig{Name: "gone", Namespace: "prod", Condition: "Available"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy)
+	assert.Contains(t, result.Reason, "not found")
+}
+
+// TestArgoCDAdapter_Healthy verifies that an Application with health=Healthy and
+// sync=Synced is reported as Healthy.
+func TestArgoCDAdapter_Healthy(t *testing.T) {
+	app := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata":   map[string]interface{}{"name": "nginx-prod", "namespace": "argocd"},
+			"status": map[string]interface{}{
+				"health": map[string]interface{}{"status": "Healthy"},
+				"sync":   map[string]interface{}{"status": "Synced"},
+			},
+		},
+	}
+	app.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Application",
+	})
+
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), app)
+
+	adapter := health.NewArgoCDAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		ArgoCD: health.ArgoCDConfig{Name: "nginx-prod", Namespace: "argocd"},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Healthy)
+	assert.Contains(t, result.Reason, "Healthy")
+}
+
+// TestArgoCDAdapter_Degraded verifies that a Degraded Application is Unhealthy.
+func TestArgoCDAdapter_Degraded(t *testing.T) {
+	app := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata":   map[string]interface{}{"name": "nginx-prod", "namespace": "argocd"},
+			"status": map[string]interface{}{
+				"health": map[string]interface{}{"status": "Degraded"},
+				"sync":   map[string]interface{}{"status": "Synced"},
+			},
+		},
+	}
+	app.SetGroupVersionKind(schema.GroupVersionKind{Group: "argoproj.io", Version: "v1alpha1", Kind: "Application"})
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), app)
+
+	adapter := health.NewArgoCDAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		ArgoCD: health.ArgoCDConfig{Name: "nginx-prod", Namespace: "argocd"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy)
+	assert.Contains(t, result.Reason, "Degraded")
+}
+
+// TestFluxAdapter_Healthy verifies that a Kustomization with Ready=True is Healthy.
+func TestFluxAdapter_Healthy(t *testing.T) {
+	ks := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata": map[string]interface{}{
+				"name":       "nginx-prod",
+				"namespace":  "flux-system",
+				"generation": int64(3),
+			},
+			"status": map[string]interface{}{
+				"observedGeneration": int64(3),
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+						"reason": "ReconciliationSucceeded",
+					},
+				},
+			},
+		},
+	}
+	ks.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kustomize.toolkit.fluxcd.io",
+		Version: "v1",
+		Kind:    "Kustomization",
+	})
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), ks)
+
+	adapter := health.NewFluxAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		Flux: health.FluxConfig{Name: "nginx-prod", Namespace: "flux-system"},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Healthy)
+	assert.Contains(t, result.Reason, "Ready=True")
+}
+
+// TestFluxAdapter_Progressing verifies that a Kustomization with Ready=False is Unhealthy.
+func TestFluxAdapter_Progressing(t *testing.T) {
+	ks := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata": map[string]interface{}{
+				"name":       "nginx-prod",
+				"namespace":  "flux-system",
+				"generation": int64(4),
+			},
+			"status": map[string]interface{}{
+				"observedGeneration": int64(3), // behind — not yet reconciled
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "False",
+						"reason": "ArtifactFailed",
+					},
+				},
+			},
+		},
+	}
+	ks.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kustomize.toolkit.fluxcd.io",
+		Version: "v1",
+		Kind:    "Kustomization",
+	})
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), ks)
+
+	adapter := health.NewFluxAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		Flux: health.FluxConfig{Name: "nginx-prod", Namespace: "flux-system"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy)
+}
+
+// TestAutoDetector_SelectsDeploymentWhenNoGitOpsCRDs verifies fallback to Deployment adapter.
+func TestAutoDetector_SelectsDeploymentWhenNoGitOpsCRDs(t *testing.T) {
+	s := buildScheme(t)
+	// No ArgoCD or Flux CRDs
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	detector := health.NewAutoDetector(c, dynClient)
+	adapter, err := detector.Select(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "resource", adapter.Name())
+}
+
+// TestAutoDetector_PreferredByType verifies explicit type selection.
+func TestAutoDetector_PreferredByType(t *testing.T) {
+	s := buildScheme(t)
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	detector := health.NewAutoDetector(c, dynClient)
+
+	// Explicit "resource" type
+	adapter, err := detector.Select(context.Background(), "resource")
+	require.NoError(t, err)
+	assert.Equal(t, "resource", adapter.Name())
+}

--- a/pkg/reconciler/promotionstep/reconciler.go
+++ b/pkg/reconciler/promotionstep/reconciler.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/health"
 	"github.com/kardinal-promoter/kardinal-promoter/pkg/scm"
 	"github.com/kardinal-promoter/kardinal-promoter/pkg/steps"
 
@@ -69,7 +70,7 @@ const (
 //	"Promoting"    → "WaitingForMerge": open-pr step completed (prURL in outputs)
 //	"WaitingForMerge" → "HealthChecking": SCM reports PR merged
 //	"WaitingForMerge" → "Failed": PR closed without merge
-//	"HealthChecking" → "Verified": health-check step returns Success
+//	"HealthChecking" → "Verified": health adapter returns Healthy
 //	any → "Failed": any step returns Failed
 //
 // The reconciler persists currentStepIndex to etcd on every step completion so that
@@ -82,6 +83,10 @@ type Reconciler struct {
 
 	// GitClient is the Git operations client.
 	GitClient scm.GitClient
+
+	// HealthDetector selects the health adapter for health checking.
+	// If nil, the health-check step stub (always-success) is used.
+	HealthDetector *health.AutoDetector
 
 	// Shard, when set, causes the reconciler to skip PromotionSteps whose
 	// kardinal.io/shard label does not match this value (distributed mode).
@@ -336,18 +341,125 @@ func (r *Reconciler) handleWaitingForMerge(ctx context.Context, log zerolog.Logg
 	return ctrl.Result{RequeueAfter: requeueWaitForMerge}, nil
 }
 
-// handleHealthChecking runs the health-check step and transitions to Verified or failed.
-// The health-check step is a stub in Stage 6 (real adapters in Stage 7).
+// handleHealthChecking verifies the deployment health using the configured adapter.
+// Uses the real health adapter when HealthDetector is configured; falls back to
+// the stub health-check step when it is nil (for backward compatibility in tests
+// written before Stage 7).
 func (r *Reconciler) handleHealthChecking(ctx context.Context, log zerolog.Logger, ps *v1alpha1.PromotionStep) (ctrl.Result, error) {
-	healthStep, err := steps.Lookup("health-check")
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("lookup health-check step: %w", err)
-	}
-
 	pipeline, pipelineErr := r.loadPipeline(ctx, ps)
 	bundle, bundleErr := r.loadBundle(ctx, ps)
 	if pipelineErr != nil || bundleErr != nil {
 		log.Warn().Err(pipelineErr).Err(bundleErr).Msg("failed to load pipeline/bundle for health check")
+	}
+
+	// Use real health adapter if HealthDetector is available.
+	if r.HealthDetector != nil && pipeline != nil {
+		env := findEnv(pipeline, ps.Spec.Environment)
+		healthType := env.Health.Type
+
+		// Parse timeout from environment config; default 10m.
+		timeout := 10 * time.Minute
+		if env.Health.Timeout != "" {
+			if d, err := time.ParseDuration(env.Health.Timeout); err == nil && d > 0 {
+				timeout = d
+			}
+		}
+
+		// Check if we've exceeded the timeout (recorded in step start time via conditions).
+		// If startedAt is set and elapsed > timeout, fail.
+		if ps.Status.Conditions != nil {
+			for _, cond := range ps.Status.Conditions {
+				if cond.Type == "HealthCheckStarted" {
+					elapsed := time.Since(cond.LastTransitionTime.Time)
+					if elapsed > timeout {
+						log.Warn().Dur("elapsed", elapsed).Dur("timeout", timeout).Msg("health check timeout")
+						patch := client.MergeFrom(ps.DeepCopy())
+						ps.Status.State = StateFailed
+						ps.Status.Message = fmt.Sprintf("health check timeout after %s", timeout)
+						if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
+							return ctrl.Result{}, fmt.Errorf("patch failed (health timeout): %w", patchErr)
+						}
+						if bundle != nil {
+							_ = r.copyEvidenceToBundle(ctx, ps, bundle)
+						}
+						return ctrl.Result{}, nil
+					}
+				}
+			}
+		}
+
+		// Record health check start time (idempotent — only add if not already there).
+		hasStarted := false
+		for _, c := range ps.Status.Conditions {
+			if c.Type == "HealthCheckStarted" {
+				hasStarted = true
+				break
+			}
+		}
+		if !hasStarted {
+			patch := client.MergeFrom(ps.DeepCopy())
+			ps.Status.Conditions = appendCondition(ps.Status.Conditions,
+				"HealthCheckStarted", metav1.ConditionTrue, "Started", "health check in progress", time.Now())
+			if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
+				return ctrl.Result{}, fmt.Errorf("patch health check start: %w", patchErr)
+			}
+		}
+
+		adapter, err := r.HealthDetector.Select(ctx, healthType)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("select health adapter: %w", err)
+		}
+
+		// Build CheckOptions from pipeline environment config.
+		opts := health.CheckOptions{
+			Type:    healthType,
+			Timeout: timeout,
+			Resource: health.ResourceConfig{
+				Name:      pipeline.Name,
+				Namespace: ps.Spec.Environment,
+				Condition: "Available",
+			},
+			ArgoCD: health.ArgoCDConfig{
+				Name:      pipeline.Name + "-" + ps.Spec.Environment,
+				Namespace: "argocd",
+			},
+			Flux: health.FluxConfig{
+				Name:      pipeline.Name + "-" + ps.Spec.Environment,
+				Namespace: "flux-system",
+			},
+		}
+
+		result, checkErr := adapter.Check(ctx, opts)
+		if checkErr != nil {
+			log.Error().Err(checkErr).Str("adapter", adapter.Name()).Msg("health adapter check error")
+			return ctrl.Result{RequeueAfter: requeueHealthCheck}, nil
+		}
+
+		if result.Healthy {
+			log.Info().Str("env", ps.Spec.Environment).Str("adapter", adapter.Name()).Msg("health check passed, Verified")
+			now := metav1.NewTime(time.Now().UTC())
+			patch := client.MergeFrom(ps.DeepCopy())
+			ps.Status.State = StateVerified
+			ps.Status.Message = fmt.Sprintf("health check passed via %s: %s", adapter.Name(), result.Reason)
+			ps.Status.Conditions = appendCondition(ps.Status.Conditions, "Verified", metav1.ConditionTrue, "Verified", "promotion complete", now.Time)
+			if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
+				return ctrl.Result{}, fmt.Errorf("patch verified: %w", patchErr)
+			}
+			if bundle != nil {
+				_ = r.copyEvidenceToBundle(ctx, ps, bundle)
+			}
+			return ctrl.Result{}, nil
+		}
+
+		// Not yet healthy — requeue.
+		log.Debug().Str("reason", result.Reason).Str("adapter", adapter.Name()).Msg("health check not yet passed, requeueing")
+		return ctrl.Result{RequeueAfter: requeueHealthCheck}, nil
+	}
+
+	// Fallback: use the health-check step stub (Stage 6 behavior / tests without HealthDetector).
+	healthStep, err := steps.Lookup("health-check")
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("lookup health-check step: %w", err)
 	}
 
 	var pipelineSpec v1alpha1.PipelineSpec

--- a/pkg/reconciler/promotionstep/reconciler_health_test.go
+++ b/pkg/reconciler/promotionstep/reconciler_health_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promotionstep_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/health"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/promotionstep"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/scm"
+)
+
+func healthTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	require.NoError(t, appsv1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+type noopSCM struct{}
+
+func (n *noopSCM) OpenPR(_ context.Context, _, _, _, _, _ string) (string, int, error) {
+	return "", 0, nil
+}
+func (n *noopSCM) ClosePR(_ context.Context, _ string, _ int) error               { return nil }
+func (n *noopSCM) CommentOnPR(_ context.Context, _ string, _ int, _ string) error { return nil }
+func (n *noopSCM) GetPRStatus(_ context.Context, _ string, _ int) (bool, bool, error) {
+	return false, false, nil
+}
+func (n *noopSCM) ParseWebhookEvent(_ []byte, _ string) (scm.WebhookEvent, error) {
+	return scm.WebhookEvent{}, nil
+}
+
+type noopGit struct{}
+
+func (n *noopGit) Clone(_ context.Context, _, _, _ string) error        { return nil }
+func (n *noopGit) Checkout(_ context.Context, _, _ string) error        { return nil }
+func (n *noopGit) CommitAll(_ context.Context, _, _, _, _ string) error { return nil }
+func (n *noopGit) Push(_ context.Context, _, _, _, _ string) error      { return nil }
+
+// TestHealthCheckingWithRealAdapter_Healthy verifies that the PromotionStep reconciler
+// uses the DeploymentAdapter when HealthDetector is configured and the Deployment is healthy.
+func TestHealthCheckingWithRealAdapter_Healthy(t *testing.T) {
+	s := healthTestScheme(t)
+
+	pipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Git: v1alpha1.PipelineGit{URL: "https://github.com/test/repo", Branch: "main"},
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test", Approval: "auto", Health: v1alpha1.HealthConfig{Type: "resource"}},
+			},
+		},
+	}
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "bundle-1", Namespace: "default"},
+		Spec:       v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status:     v1alpha1.BundleStatus{Phase: "Promoting"},
+	}
+	ps := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-hc", Namespace: "default"},
+		Spec: v1alpha1.PromotionStepSpec{
+			PipelineName: "nginx-demo",
+			BundleName:   "bundle-1",
+			Environment:  "test",
+			StepType:     "auto",
+		},
+		Status: v1alpha1.PromotionStepStatus{State: "HealthChecking"},
+	}
+	// A Deployment named "nginx-demo" in namespace "test" with Available=True.
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "test"},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(pipeline, bundle, ps, deploy).
+		WithStatusSubresource(&v1alpha1.PromotionStep{}, &v1alpha1.Bundle{}).
+		Build()
+
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	healthDetector := health.NewAutoDetector(c, dynClient)
+
+	rec := &promotionstep.Reconciler{
+		Client:         c,
+		SCM:            &noopSCM{},
+		GitClient:      &noopGit{},
+		HealthDetector: healthDetector,
+		WorkDirFn:      func(_, _ string) string { return t.TempDir() },
+	}
+
+	_, err := rec.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "step-hc", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var updated v1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "step-hc", Namespace: "default"}, &updated))
+	assert.Equal(t, "Verified", updated.Status.State)
+}
+
+// TestHealthCheckingWithRealAdapter_NotHealthy verifies that an unhealthy Deployment
+// keeps the step in HealthChecking (requeue, not fail — waiting for rollout).
+func TestHealthCheckingWithRealAdapter_NotHealthy(t *testing.T) {
+	s := healthTestScheme(t)
+
+	pipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Git: v1alpha1.PipelineGit{URL: "https://github.com/test/repo", Branch: "main"},
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test", Approval: "auto", Health: v1alpha1.HealthConfig{Type: "resource"}},
+			},
+		},
+	}
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "bundle-1", Namespace: "default"},
+		Spec:       v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status:     v1alpha1.BundleStatus{Phase: "Promoting"},
+	}
+	ps := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-hc-wait", Namespace: "default"},
+		Spec: v1alpha1.PromotionStepSpec{
+			PipelineName: "nginx-demo",
+			BundleName:   "bundle-1",
+			Environment:  "test",
+			StepType:     "auto",
+		},
+		Status: v1alpha1.PromotionStepStatus{State: "HealthChecking"},
+	}
+	// Deployment is not yet available.
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "test"},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:    appsv1.DeploymentAvailable,
+					Status:  corev1.ConditionFalse,
+					Message: "pods not ready",
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(pipeline, bundle, ps, deploy).
+		WithStatusSubresource(&v1alpha1.PromotionStep{}, &v1alpha1.Bundle{}).
+		Build()
+
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	healthDetector := health.NewAutoDetector(c, dynClient)
+
+	rec := &promotionstep.Reconciler{
+		Client:         c,
+		SCM:            &noopSCM{},
+		GitClient:      &noopGit{},
+		HealthDetector: healthDetector,
+		WorkDirFn:      func(_, _ string) string { return t.TempDir() },
+	}
+
+	result, err := rec.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "step-hc-wait", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Greater(t, result.RequeueAfter.Seconds(), 0.0, "should requeue while not healthy")
+
+	var updated v1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "step-hc-wait", Namespace: "default"}, &updated))
+	// State should still be HealthChecking (not Failed — just not ready yet).
+	assert.Equal(t, "HealthChecking", updated.Status.State)
+}


### PR DESCRIPTION
## Summary

Implements [014-health-adapters](https://github.com/pnz1990/kardinal-promoter/issues/59): Stage 7 health adapters, replacing the stub health-check with real verification.

## Changes

### `pkg/health/adapter.go`
- `Adapter` interface: `Check(ctx, CheckOptions) (HealthStatus, error)` + `Name()`
- `DeploymentAdapter`: checks `apps/v1/Deployment` Available condition
- `ArgoCDAdapter`: checks `argoproj.io/v1alpha1/Application` health=Healthy + sync=Synced (dynamic client, no Argo CD compile-time dependency)
- `FluxAdapter`: checks `kustomize.toolkit.fluxcd.io/v1/Kustomization` Ready condition with generation matching
- `AutoDetector.Select()`: priority argocd > flux > resource; falls back gracefully when CRDs are absent

### `pkg/reconciler/promotionstep/reconciler.go`
- `handleHealthChecking`: uses real `AutoDetector` when `HealthDetector` is set
- Timeout: configurable via `Pipeline.spec.environments[].health.timeout` (default 10m)
- `Bundle.status.environments[env].healthCheckedAt` set on Verified
- Backward compatible: falls back to stub health-check step when `HealthDetector` is nil

### `cmd/kardinal-controller/main.go`
- `newHealthDetector()`: constructs `AutoDetector` with dynamic client from rest.Config
- Wired into `PromotionStepReconciler.HealthDetector`

## Acceptance Criteria

- [x] `DeploymentAdapter` returns Healthy when Available=True, Degraded otherwise
- [x] `ArgoCDAdapter` returns Healthy when health=Healthy AND sync=Synced
- [x] `FluxAdapter` returns Healthy when Ready=True and generation matches
- [x] `AutoDetector` selects adapter by priority: argocd > flux > resource
- [x] PromotionStepReconciler uses real adapter (not stub) when HealthDetector set
- [x] Health check timeout configurable; defaults to 10 minutes
- [x] `Bundle.status.environments[env].healthCheckedAt` set after health check passes
- [x] go build ./... passes
- [x] go test ./... -race passes (11 health tests + 2 reconciler integration tests)
- [x] go vet ./... passes
- [x] Copyright headers on all new files
- [x] No banned filenames

## Test Output

```
ok  pkg/health (9 tests)
ok  pkg/reconciler/promotionstep (13 tests: 11 existing + 2 new health adapter tests)
```

## Journey Validation (J1)

With this PR, the PromotionStep reconciler can now:
1. Detect a Deployment becoming Available after PR merge
2. Set state=Verified and write healthCheckedAt to Bundle

This completes the J1 health check requirement: "Bundle advances after Deployment becomes ready"

Closes #59