### PR TITLE
feat(controller): startup reconciliation via Runnable + webhook health endpoint [018]

### DIFF
--- a/cmd/kardinal-controller/main.go
+++ b/cmd/kardinal-controller/main.go
@@ -19,7 +19,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"net/http"
 	"os"
@@ -101,9 +100,6 @@ func main() {
 	zerolog.SetGlobalLevel(level)
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
 
-	// Inject zerolog into controller-runtime log context
-	ctx := logger.WithContext(context.Background())
-
 	ctrl.SetLogger(czap.New(czap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -124,8 +120,9 @@ func main() {
 	gitClient := scm.NewExecGitClient()
 
 	if err := (&bundlereconciler.Reconciler{
-		Client:     mgr.GetClient(),
-		Translator: newTranslator(mgr.GetConfig(), mgr.GetClient(), splitCSV(policyNamespaces), logger),
+		Client:      mgr.GetClient(),
+		Translator:  newTranslator(mgr.GetConfig(), mgr.GetClient(), splitCSV(policyNamespaces), logger),
+		SCMProvider: scmProvider,
 	}).SetupWithManager(mgr); err != nil {
 		logger.Fatal().Err(err).Msg("unable to set up BundleReconciler")
 	}
@@ -164,22 +161,14 @@ func main() {
 
 	// Start webhook server in a goroutine.
 	go func() {
-		webhookSrv := newWebhookServer(scmProvider, mgr.GetClient(), logger)
+		webhookSrv := newWebhookServerWithConfig(scmProvider, mgr.GetClient(), logger, webhookSecret != "")
 		mux := http.NewServeMux()
 		mux.HandleFunc("/webhook/scm", webhookSrv.Handler())
-		mux.HandleFunc("/webhook/scm/health", func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})
+		mux.HandleFunc("/webhook/scm/health", webhookSrv.HealthHandler())
 		logger.Info().Str("addr", webhookBindAddress).Msg("starting webhook server")
 		if err := http.ListenAndServe(webhookBindAddress, mux); err != nil {
 			logger.Error().Err(err).Msg("webhook server error")
 		}
-	}()
-
-	// Startup reconciliation: sync WaitingForMerge steps that may have been
-	// merged during controller downtime.
-	go func() {
-		startupReconciliation(ctx, scmProvider, mgr.GetClient(), logger)
 	}()
 
 	logger.Info().Msg("starting kardinal-controller")

--- a/cmd/kardinal-controller/webhook.go
+++ b/cmd/kardinal-controller/webhook.go
@@ -17,11 +17,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -36,11 +38,16 @@ const (
 	maxWebhookBody = 1 << 20
 )
 
+// webhookEventsTotal counts the number of webhook events processed since startup.
+// Uses sync/atomic for lock-free increment; full Prometheus metrics are in Stage 19.
+var webhookEventsTotal int64
+
 // webhookServer is an HTTP server that handles incoming SCM webhook events.
 type webhookServer struct {
-	scm    scm.SCMProvider
-	client client.Client
-	log    zerolog.Logger
+	scm               scm.SCMProvider
+	client            client.Client
+	log               zerolog.Logger
+	webhookConfigured bool
 }
 
 // newWebhookServer constructs a webhookServer with the given SCM provider and k8s client.
@@ -49,6 +56,17 @@ func newWebhookServer(scmProvider scm.SCMProvider, k8s client.Client, log zerolo
 		scm:    scmProvider,
 		client: k8s,
 		log:    log,
+	}
+}
+
+// newWebhookServerWithConfig constructs a webhookServer and records whether a webhook
+// secret is configured (for the /webhook/scm/health response).
+func newWebhookServerWithConfig(scmProvider scm.SCMProvider, k8s client.Client, log zerolog.Logger, webhookConfigured bool) *webhookServer {
+	return &webhookServer{
+		scm:               scmProvider,
+		client:            k8s,
+		log:               log,
+		webhookConfigured: webhookConfigured,
 	}
 }
 
@@ -76,6 +94,9 @@ func (s *webhookServer) Handler() http.HandlerFunc {
 			return
 		}
 
+		// Count every successfully parsed event.
+		atomic.AddInt64(&webhookEventsTotal, 1)
+
 		s.log.Info().
 			Str("event_type", event.EventType).
 			Str("action", event.Action).
@@ -99,6 +120,24 @@ func (s *webhookServer) Handler() http.HandlerFunc {
 		}
 
 		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// HealthHandler returns an http.HandlerFunc for GET /webhook/scm/health.
+// Responds with 200 OK and a JSON body indicating webhook configuration status
+// and the number of webhook events processed since startup.
+func (s *webhookServer) HealthHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]interface{}{
+			"status":            "ok",
+			"webhookConfigured": s.webhookConfigured,
+			"eventsProcessed":   atomic.LoadInt64(&webhookEventsTotal),
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			s.log.Error().Err(err).Msg("failed to encode health response")
+		}
 	}
 }
 
@@ -151,61 +190,6 @@ func (s *webhookServer) reconcileMergedPR(ctx context.Context, event scm.Webhook
 			Msg("advanced promotionstep to HealthChecking via webhook")
 	}
 	return nil
-}
-
-// startupReconciliation checks all WaitingForMerge PromotionSteps and re-syncs PR status.
-// Called once on controller startup to recover state from controller downtime.
-func startupReconciliation(ctx context.Context, scmProvider scm.SCMProvider, k8s client.Client, log zerolog.Logger) {
-	var psList v1alpha1.PromotionStepList
-	if err := k8s.List(ctx, &psList); err != nil {
-		log.Error().Err(err).Msg("startup reconciliation: failed to list promotionsteps")
-		return
-	}
-
-	for i := range psList.Items {
-		ps := &psList.Items[i]
-		if ps.Status.State != "WaitingForMerge" {
-			continue
-		}
-		prNumStr := ps.Status.Outputs["prNumber"]
-		if prNumStr == "" {
-			prNumStr = extractPRNumberFromURL(ps.Status.PRURL)
-		}
-		if prNumStr == "" {
-			continue
-		}
-		prNum, err := strconv.Atoi(prNumStr)
-		if err != nil {
-			continue
-		}
-		repo := extractRepoFromURL(ps.Status.PRURL)
-		if repo == "" {
-			continue
-		}
-
-		merged, open, err := scmProvider.GetPRStatus(ctx, repo, prNum)
-		if err != nil {
-			log.Warn().Err(err).Str("promotionstep", ps.Name).Msg("startup reconciliation: failed to get PR status")
-			continue
-		}
-		if merged {
-			patch := client.MergeFrom(ps.DeepCopy())
-			ps.Status.State = "HealthChecking"
-			ps.Status.Message = "PR merged during controller downtime (startup reconciliation)"
-			if patchErr := k8s.Status().Patch(ctx, ps, patch); patchErr != nil {
-				log.Error().Err(patchErr).Str("promotionstep", ps.Name).Msg("startup reconciliation: patch failed")
-			} else {
-				log.Info().Str("promotionstep", ps.Name).Msg("startup reconciliation: advanced to HealthChecking")
-			}
-		} else if !open {
-			patch := client.MergeFrom(ps.DeepCopy())
-			ps.Status.State = "Failed"
-			ps.Status.Message = "PR closed without merge (detected during startup reconciliation)"
-			if patchErr := k8s.Status().Patch(ctx, ps, patch); patchErr != nil {
-				log.Error().Err(patchErr).Str("promotionstep", ps.Name).Msg("startup reconciliation: patch failed")
-			}
-		}
-	}
 }
 
 // extractPRNumberFromURL parses the PR number from a GitHub PR URL.

--- a/cmd/kardinal-controller/webhook_test.go
+++ b/cmd/kardinal-controller/webhook_test.go
@@ -176,3 +176,42 @@ func TestWebhook_IgnoresNonMergeEvents(t *testing.T) {
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "step-wfm", Namespace: "default"}, &updated))
 	assert.Equal(t, "WaitingForMerge", updated.Status.State)
 }
+
+// TestWebhookHealth_ReturnsOK verifies that GET /webhook/scm/health returns 200
+// with a JSON body containing status, webhookConfigured, and eventsProcessed fields.
+func TestWebhookHealth_ReturnsOK(t *testing.T) {
+	s := webhookScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	server := newWebhookServerWithConfig(&mockSCMProvider{}, c, zerolog.Nop(), true)
+	handler := server.HealthHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/webhook/scm/health", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	body := w.Body.String()
+	assert.Contains(t, body, `"status"`)
+	assert.Contains(t, body, `"webhookConfigured"`)
+	assert.Contains(t, body, `"eventsProcessed"`)
+}
+
+// TestWebhookHealth_ReflectsWebhookUnconfigured verifies that the health endpoint
+// returns webhookConfigured=false when no secret is set.
+func TestWebhookHealth_ReflectsWebhookUnconfigured(t *testing.T) {
+	s := webhookScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	server := newWebhookServerWithConfig(&mockSCMProvider{}, c, zerolog.Nop(), false)
+	handler := server.HealthHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/webhook/scm/health", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"webhookConfigured":false`)
+}

--- a/pkg/reconciler/bundle/reconciler.go
+++ b/pkg/reconciler/bundle/reconciler.go
@@ -21,6 +21,8 @@ package bundle
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/rs/zerolog"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/scm"
 )
 
 // BundleTranslator is the interface the BundleReconciler uses to translate a
@@ -43,6 +46,9 @@ type Reconciler struct {
 	// Translator creates the kro Graph for a Bundle+Pipeline pair.
 	// May be nil in test environments where translation is not needed.
 	Translator BundleTranslator
+	// SCMProvider is used for startup reconciliation to re-check in-flight PR status.
+	// May be nil if startup reconciliation is not needed.
+	SCMProvider scm.SCMProvider
 }
 
 // Reconcile is called whenever a Bundle is created, updated, or deleted.
@@ -199,8 +205,129 @@ func (r *Reconciler) handleAvailable(ctx context.Context, log zerolog.Logger,
 	return ctrl.Result{}, nil
 }
 
+// Start implements manager.Runnable. It is called by controller-runtime after the
+// informer cache is synced, making it safe to List resources. It runs startup
+// reconciliation once: re-checks all WaitingForMerge PromotionSteps to recover
+// state from PRs merged during controller downtime.
+func (r *Reconciler) Start(ctx context.Context) error {
+	if r.SCMProvider == nil {
+		return nil
+	}
+	log := zerolog.Ctx(ctx).With().Str("component", "startup-reconciliation").Logger()
+
+	var psList kardinalv1alpha1.PromotionStepList
+	if err := r.List(ctx, &psList); err != nil {
+		log.Error().Err(err).Msg("startup reconciliation: failed to list promotionsteps")
+		return nil // non-fatal: don't block manager startup
+	}
+
+	var inFlight int
+	for i := range psList.Items {
+		ps := &psList.Items[i]
+		if ps.Status.State != "WaitingForMerge" {
+			continue
+		}
+		inFlight++
+	}
+	log.Info().Int("in_flight_prs", inFlight).Msg("startup reconciliation: re-checking in-flight PRs")
+
+	for i := range psList.Items {
+		ps := &psList.Items[i]
+		if ps.Status.State != "WaitingForMerge" {
+			continue
+		}
+
+		prNumStr := ps.Status.Outputs["prNumber"]
+		if prNumStr == "" {
+			prNumStr = extractPRNumberFromURL(ps.Status.PRURL)
+		}
+		if prNumStr == "" {
+			continue
+		}
+		prNum, err := strconv.Atoi(prNumStr)
+		if err != nil {
+			continue
+		}
+		repo := extractRepoFromURL(ps.Status.PRURL)
+		if repo == "" {
+			continue
+		}
+
+		merged, open, err := r.SCMProvider.GetPRStatus(ctx, repo, prNum)
+		if err != nil {
+			log.Warn().Err(err).
+				Str("promotionstep", ps.Name).
+				Msg("startup reconciliation: failed to get PR status")
+			continue
+		}
+
+		patch := client.MergeFrom(ps.DeepCopy())
+		if merged {
+			ps.Status.State = "HealthChecking"
+			ps.Status.Message = "PR merged during controller downtime (startup reconciliation)"
+			if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
+				log.Error().Err(patchErr).
+					Str("promotionstep", ps.Name).
+					Msg("startup reconciliation: patch to HealthChecking failed")
+			} else {
+				log.Info().
+					Str("promotionstep", ps.Name).
+					Int("pr", prNum).
+					Msg("startup reconciliation: advanced to HealthChecking")
+			}
+		} else if !open {
+			ps.Status.State = "Failed"
+			ps.Status.Message = "PR closed without merge (detected during startup reconciliation)"
+			if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
+				log.Error().Err(patchErr).
+					Str("promotionstep", ps.Name).
+					Msg("startup reconciliation: patch to Failed failed")
+			} else {
+				log.Info().
+					Str("promotionstep", ps.Name).
+					Int("pr", prNum).
+					Msg("startup reconciliation: marked Failed (PR closed without merge)")
+			}
+		}
+	}
+	return nil
+}
+
+// extractPRNumberFromURL parses the PR number from a GitHub PR URL.
+func extractPRNumberFromURL(prURL string) string {
+	if prURL == "" {
+		return ""
+	}
+	parts := strings.Split(strings.TrimRight(prURL, "/"), "/")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return ""
+}
+
+// extractRepoFromURL extracts "owner/repo" from a GitHub PR URL.
+func extractRepoFromURL(prURL string) string {
+	s := strings.TrimPrefix(prURL, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	idx := strings.Index(s, "/")
+	if idx < 0 {
+		return ""
+	}
+	s = s[idx+1:]
+	parts := strings.SplitN(s, "/", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
+}
+
 // SetupWithManager registers the BundleReconciler with the controller-runtime Manager.
+// It also registers the reconciler as a Runnable so that Start() is called after
+// cache sync to perform startup reconciliation.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.Add(r); err != nil {
+		return fmt.Errorf("add reconciler as runnable: %w", err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kardinalv1alpha1.Bundle{}).
 		Complete(r)

--- a/pkg/reconciler/bundle/reconciler_test.go
+++ b/pkg/reconciler/bundle/reconciler_test.go
@@ -17,6 +17,7 @@ import (
 
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	"github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/bundle"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/scm"
 )
 
 func newScheme() *runtime.Scheme {
@@ -36,6 +37,32 @@ func (m *mockTranslator) Translate(_ context.Context,
 	_ *kardinalv1alpha1.Pipeline, _ *kardinalv1alpha1.Bundle) (string, error) {
 	m.called = true
 	return m.graphName, m.err
+}
+
+// mockSCMProvider is a test double for scm.SCMProvider.
+type mockSCMProvider struct {
+	merged bool
+	open   bool
+	err    error
+	calls  int
+}
+
+func (m *mockSCMProvider) OpenPR(_ context.Context, _, _, _, _, _ string) (string, int, error) {
+	return "", 0, nil
+}
+func (m *mockSCMProvider) ClosePR(_ context.Context, _ string, _ int) error { return nil }
+func (m *mockSCMProvider) CommentOnPR(_ context.Context, _ string, _ int, _ string) error {
+	return nil
+}
+func (m *mockSCMProvider) GetPRStatus(_ context.Context, _ string, _ int) (bool, bool, error) {
+	m.calls++
+	return m.merged, m.open, m.err
+}
+func (m *mockSCMProvider) ParseWebhookEvent(_ []byte, _ string) (scm.WebhookEvent, error) {
+	return scm.WebhookEvent{}, nil
+}
+func (m *mockSCMProvider) AddLabelsToPR(_ context.Context, _ string, _ int, _ []string) error {
+	return nil
 }
 
 // TestBundleReconciler_SetsAvailablePhase verifies that a Bundle with an empty
@@ -349,4 +376,100 @@ func TestBundleReconciler_Supersession_IdempotentForSuperseded(t *testing.T) {
 	var gotOld kardinalv1alpha1.Bundle
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v0", Namespace: "default"}, &gotOld))
 	assert.Equal(t, "Superseded", gotOld.Status.Phase)
+}
+
+// TestStartupReconciliation_RechecksInFlightPRs verifies that Start() re-checks
+// WaitingForMerge PromotionSteps and advances them to HealthChecking when merged.
+func TestStartupReconciliation_RechecksInFlightPRs(t *testing.T) {
+	ps := &kardinalv1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-wfm", Namespace: "default"},
+		Spec: kardinalv1alpha1.PromotionStepSpec{
+			PipelineName: "nginx-demo",
+			BundleName:   "bundle-1",
+			Environment:  "prod",
+			StepType:     "pr-review",
+		},
+		Status: kardinalv1alpha1.PromotionStepStatus{
+			State: "WaitingForMerge",
+			PRURL: "https://github.com/owner/repo/pull/42",
+			Outputs: map[string]string{
+				"prNumber": "42",
+			},
+		},
+	}
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(ps).
+		WithStatusSubresource(ps).
+		Build()
+
+	mockSCM := &mockSCMProvider{merged: true, open: false}
+	r := &bundle.Reconciler{Client: c, SCMProvider: mockSCM}
+
+	err := r.Start(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockSCM.calls, "GetPRStatus must be called once for the WaitingForMerge step")
+
+	var updated kardinalv1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "step-wfm", Namespace: "default"}, &updated))
+	assert.Equal(t, "HealthChecking", updated.Status.State)
+	assert.Contains(t, updated.Status.Message, "startup reconciliation")
+}
+
+// TestStartupReconciliation_SkipsCompletedBundles verifies that PromotionSteps
+// not in WaitingForMerge state are skipped by startup reconciliation.
+func TestStartupReconciliation_SkipsCompletedBundles(t *testing.T) {
+	// Step already succeeded — should NOT be touched.
+	psSucceeded := &kardinalv1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-done", Namespace: "default"},
+		Status: kardinalv1alpha1.PromotionStepStatus{
+			State:   "Succeeded",
+			PRURL:   "https://github.com/owner/repo/pull/10",
+			Outputs: map[string]string{"prNumber": "10"},
+		},
+	}
+	// Step in HealthChecking — should NOT be touched.
+	psHealthChecking := &kardinalv1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-hc", Namespace: "default"},
+		Status: kardinalv1alpha1.PromotionStepStatus{
+			State:   "HealthChecking",
+			PRURL:   "https://github.com/owner/repo/pull/11",
+			Outputs: map[string]string{"prNumber": "11"},
+		},
+	}
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(psSucceeded, psHealthChecking).
+		WithStatusSubresource(psSucceeded, psHealthChecking).
+		Build()
+
+	mockSCM := &mockSCMProvider{merged: true, open: false}
+	r := &bundle.Reconciler{Client: c, SCMProvider: mockSCM}
+
+	err := r.Start(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, mockSCM.calls, "GetPRStatus must NOT be called for non-WaitingForMerge steps")
+
+	// States must be unchanged.
+	var gotDone kardinalv1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "step-done", Namespace: "default"}, &gotDone))
+	assert.Equal(t, "Succeeded", gotDone.Status.State)
+
+	var gotHC kardinalv1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "step-hc", Namespace: "default"}, &gotHC))
+	assert.Equal(t, "HealthChecking", gotHC.Status.State)
+}
+
+// TestStartupReconciliation_NoSCMProvider verifies that Start() is a no-op
+// when SCMProvider is nil.
+func TestStartupReconciliation_NoSCMProvider(t *testing.T) {
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	r := &bundle.Reconciler{Client: c} // SCMProvider is nil
+	err := r.Start(context.Background())
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Item Reference

- **Item**: `docs/aide/items/018-startup-reconciliation.md`
- **Spec**: Stage 10 completion — startup reconciliation + webhook health

## What this implements

Completes Stage 10 startup reconciliation: on controller start, the BundleReconciler
now implements `manager.Runnable` so `Start(ctx)` runs after cache sync, re-checking
all `WaitingForMerge` PromotionSteps via `SCMProvider.GetPRStatus`. Also adds
a JSON `/webhook/scm/health` endpoint with `webhookConfigured` and `eventsProcessed`
fields, and a `sync/atomic` event counter in the webhook server.

## Acceptance Criteria

- [x] On controller start, in-flight `WaitingForMerge` PromotionSteps have their PR status re-checked
- [x] PRs merged during downtime are detected on next startup
- [x] `/webhook/scm/health` returns `200 OK` with webhookConfigured field
- [x] Startup reconciliation logs the number of in-flight PRs checked
- [x] `go build ./...` passes
- [x] `go test ./... -race` passes
- [x] `go vet ./...` passes
- [x] Copyright headers present on all files (edits only, no new files)
- [x] No banned filenames

## Test Output

```
ok  github.com/kardinal-promoter/kardinal-promoter/cmd/kardinal-controller  2.462s
ok  github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/bundle    4.301s
[14 packages total — all pass]
go vet: zero findings
```

## Phantom Completion Check

All tasks implemented: Start(ctx) Runnable, HealthHandler(), webhookEventsTotal atomic counter, 5 new tests. Zero phantom completions.

## Journey Validation

- J1 (Quickstart): startup reconciliation ensures PRs merged during downtime are detected on next controller restart — advancing promotion reliably
- J4 (Rollback): rollback PRs also benefit from startup reconciliation detecting merges during downtime

## Pre-merge Checklist

- [x] `go test ./... -race` passes
- [x] `go vet ./...` zero findings
- [x] Zero phantom completions
- [x] All acceptance criteria pass
- [x] No `util.go`, `helpers.go`, `common.go` created
- [x] No new go.mod entries
- [x] Idempotency: `Start()` is safe to re-run (no-op if no WaitingForMerge steps)
- [x] No kro module import