### PR TITLE
feat(pause): honor Pipeline.spec.paused in Bundle and PromotionStep reconcilers [025]

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -212,7 +212,8 @@ Flags:
 
 ### kardinal pause
 
-Pause all promotion activity for a Pipeline by injecting a PolicyGate with `expression: "false"`.
+Pause all promotion activity for a Pipeline by setting `spec.paused: true`.
+In-flight PromotionSteps are held at their current state; new promotions will not start.
 
 ```bash
 kardinal pause <pipeline>
@@ -220,15 +221,12 @@ kardinal pause <pipeline>
 
 Output:
 ```
-Pipeline my-app paused.
-  PolicyGate "freeze-1712567890" created with expression: "false"
-  All in-flight promotions will be blocked at the next gate evaluation.
-  Run "kardinal resume my-app" to remove the freeze.
+Pipeline my-app paused. No new promotions will start.
 ```
 
 ### kardinal resume
 
-Resume a paused Pipeline by deleting the freeze PolicyGate.
+Resume a paused Pipeline by setting `spec.paused: false`.
 
 ```bash
 kardinal resume <pipeline>

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -153,3 +153,25 @@ For example, in a pipeline `dev -> staging -> [prod-us, prod-eu]`, if `prod-us` 
 | Kargo | Re-promote prior Freight to the Stage (AnalysisTemplate verification) |
 | GitOps Promoter | Manual: create a revert PR |
 | Argo Rollouts | Automatic in-cluster rollback on AnalysisRun failure (no cross-env awareness) |
+
+---
+
+## Pause and Resume
+
+During an incident, you may want to stop all in-flight promotions without rolling back.
+
+```bash
+# Pause: hold all promotions at their current state
+kardinal pause my-app
+
+# Resume: allow promotions to continue
+kardinal resume my-app
+```
+
+When a Pipeline is paused (`spec.paused: true`):
+- PromotionSteps already in progress are held at their current state (Promoting, WaitingForMerge, etc.)
+- Open PRs remain open — no new commits are pushed
+- No new Bundles will advance from Available to Promoting
+- All states are preserved in etcd — resume picks up exactly where pause left
+
+After resume, promotions continue automatically from where they paused. No re-trigger is required.

--- a/pkg/reconciler/bundle/reconciler.go
+++ b/pkg/reconciler/bundle/reconciler.go
@@ -183,6 +183,15 @@ func (r *Reconciler) handleAvailable(ctx context.Context, log zerolog.Logger,
 		return ctrl.Result{}, fmt.Errorf("get pipeline %s: %w", b.Spec.Pipeline, err)
 	}
 
+	// If the Pipeline is paused, do not start a new promotion.
+	// Requeue after a short interval to re-check the pause state.
+	if pipeline.Spec.Paused {
+		log.Info().
+			Str("pipeline", pipeline.Name).
+			Msg("pipeline is paused — holding bundle at Available until resumed")
+		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+	}
+
 	// Translate Pipeline+Bundle into a Graph
 	graphName, err := r.Translator.Translate(ctx, &pipeline, b)
 	if err != nil {

--- a/pkg/reconciler/bundle/reconciler_test.go
+++ b/pkg/reconciler/bundle/reconciler_test.go
@@ -550,3 +550,128 @@ func TestBundleReconciler_ConfigBundleSupersededByNewConfigBundle(t *testing.T) 
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-config-v2", Namespace: "default"}, &gotNew))
 	assert.Equal(t, "Available", gotNew.Status.Phase)
 }
+
+// TestBundleReconciler_PausedPipeline verifies that a paused Pipeline blocks
+// an Available Bundle from advancing to Promoting.
+func TestBundleReconciler_PausedPipeline(t *testing.T) {
+	pipeline := &kardinalv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: kardinalv1alpha1.PipelineSpec{
+			Paused: true,
+			Environments: []kardinalv1alpha1.EnvironmentSpec{
+				{Name: "test"},
+			},
+		},
+	}
+	b := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1", Namespace: "default"},
+		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status:     kardinalv1alpha1.BundleStatus{Phase: "Available"},
+	}
+	translator := &mockTranslator{graphName: "graph-1"}
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(pipeline, b).
+		WithStatusSubresource(b).
+		Build()
+
+	r := &bundle.Reconciler{Client: c, Translator: translator}
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	// Translator must NOT be called — pipeline is paused.
+	assert.False(t, translator.called, "translator must not be called when pipeline is paused")
+	// Must requeue to re-check pause state.
+	assert.Greater(t, result.RequeueAfter, time.Duration(0), "must requeue to poll pause state")
+
+	// Bundle must remain Available (not advance to Promoting).
+	var got kardinalv1alpha1.Bundle
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &got))
+	assert.Equal(t, "Available", got.Status.Phase, "bundle must stay Available when pipeline is paused")
+}
+
+// TestBundleReconciler_ResumedPipeline verifies that a non-paused Pipeline allows
+// an Available Bundle to advance to Promoting.
+func TestBundleReconciler_ResumedPipeline(t *testing.T) {
+	pipeline := &kardinalv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: kardinalv1alpha1.PipelineSpec{
+			Paused: false,
+			Environments: []kardinalv1alpha1.EnvironmentSpec{
+				{Name: "test"},
+			},
+		},
+	}
+	b := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1", Namespace: "default"},
+		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status:     kardinalv1alpha1.BundleStatus{Phase: "Available"},
+	}
+	translator := &mockTranslator{graphName: "graph-1"}
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(pipeline, b).
+		WithStatusSubresource(b).
+		Build()
+
+	r := &bundle.Reconciler{Client: c, Translator: translator}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	// Translator MUST be called when pipeline is not paused.
+	assert.True(t, translator.called, "translator must be called when pipeline is not paused")
+
+	// Bundle must advance to Promoting.
+	var got kardinalv1alpha1.Bundle
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &got))
+	assert.Equal(t, "Promoting", got.Status.Phase, "bundle must advance to Promoting when pipeline is not paused")
+}
+
+// TestBundleReconciler_PausedIdempotent verifies that reconciling a paused pipeline
+// multiple times does not change state (idempotent).
+func TestBundleReconciler_PausedIdempotent(t *testing.T) {
+	pipeline := &kardinalv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: kardinalv1alpha1.PipelineSpec{
+			Paused:       true,
+			Environments: []kardinalv1alpha1.EnvironmentSpec{{Name: "test"}},
+		},
+	}
+	b := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1", Namespace: "default"},
+		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status:     kardinalv1alpha1.BundleStatus{Phase: "Available"},
+	}
+	translator := &mockTranslator{graphName: "graph-1"}
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(pipeline, b).
+		WithStatusSubresource(b).
+		Build()
+
+	r := &bundle.Reconciler{Client: c, Translator: translator}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}}
+
+	// Reconcile twice.
+	_, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	_, err = r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	// Bundle must still be Available after two reconciles.
+	var got kardinalv1alpha1.Bundle
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &got))
+	assert.Equal(t, "Available", got.Status.Phase, "bundle must stay Available after idempotent reconcile of paused pipeline")
+	// Translator must never have been called.
+	assert.False(t, translator.called, "translator must not be called for paused pipeline (idempotent)")
+}

--- a/pkg/reconciler/promotionstep/reconciler.go
+++ b/pkg/reconciler/promotionstep/reconciler.go
@@ -125,6 +125,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	// Pause check: if the Pipeline is paused, hold all non-terminal states.
+	// This allows in-flight PRs to remain open without advancing further.
+	if ps.Status.State != StateVerified && ps.Status.State != StateFailed {
+		pipeline, pipelineErr := r.loadPipeline(ctx, &ps)
+		if pipelineErr == nil && pipeline.Spec.Paused {
+			log.Info().
+				Str("pipeline", ps.Spec.PipelineName).
+				Str("state", ps.Status.State).
+				Msg("pipeline is paused — holding PromotionStep")
+			return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		}
+	}
+
 	switch ps.Status.State {
 	case StatePending, StatePendingExplicit:
 		return r.handlePending(ctx, log, &ps)

--- a/pkg/reconciler/promotionstep/reconciler_test.go
+++ b/pkg/reconciler/promotionstep/reconciler_test.go
@@ -505,3 +505,90 @@ func TestStepIndex_OutputsAccumulated(t *testing.T) {
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "step-out", Namespace: "default"}, &final))
 	assert.Equal(t, "Verified", final.Status.State)
 }
+
+// TestPausedPipeline_BlocksPromotionStep verifies that a paused Pipeline causes the
+// PromotionStep reconciler to hold (not advance state) and requeue.
+func TestPausedPipeline_BlocksPromotionStep(t *testing.T) {
+	scheme := buildScheme(t)
+
+	pausedPipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Paused: true,
+			Git:    v1alpha1.PipelineGit{URL: "https://github.com/test/repo", Branch: "main"},
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test", Approval: "auto"},
+			},
+		},
+	}
+	step := makeStep("step-paused", "nginx-demo", "bundle-1", "test")
+	step.Status.State = "Promoting"
+	bundle := makeBundle("bundle-1", "nginx-demo")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(
+		&v1alpha1.PromotionStep{}, &v1alpha1.Bundle{},
+	).WithObjects(step, pausedPipeline, bundle).Build()
+
+	r := &promotionstep.Reconciler{
+		Client:    c,
+		SCM:       &mockSCM{},
+		GitClient: &mockGit{},
+		WorkDirFn: func(_, _ string) string { return t.TempDir() },
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "step-paused", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	// Must requeue to re-check the pause state.
+	assert.Greater(t, result.RequeueAfter, time.Duration(0), "must requeue when pipeline is paused")
+
+	// Step must NOT have advanced from Promoting.
+	var updated v1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "step-paused", Namespace: "default"}, &updated))
+	assert.Equal(t, "Promoting", updated.Status.State,
+		"step must stay at Promoting when pipeline is paused; got %s", updated.Status.State)
+}
+
+// TestPausedPipeline_IdempotentOnMultipleReconciles verifies that reconciling a paused
+// pipeline multiple times does not change the PromotionStep state (idempotent).
+func TestPausedPipeline_IdempotentOnMultipleReconciles(t *testing.T) {
+	scheme := buildScheme(t)
+
+	pausedPipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Paused: true,
+			Git:    v1alpha1.PipelineGit{URL: "https://github.com/test/repo", Branch: "main"},
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test", Approval: "auto"},
+			},
+		},
+	}
+	step := makeStep("step-paused-idem", "nginx-demo", "bundle-1", "test")
+	step.Status.State = "Promoting"
+	bundle := makeBundle("bundle-1", "nginx-demo")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(
+		&v1alpha1.PromotionStep{}, &v1alpha1.Bundle{},
+	).WithObjects(step, pausedPipeline, bundle).Build()
+
+	r := &promotionstep.Reconciler{
+		Client:    c,
+		SCM:       &mockSCM{},
+		GitClient: &mockGit{},
+		WorkDirFn: func(_, _ string) string { return t.TempDir() },
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "step-paused-idem", Namespace: "default"}}
+	for i := 0; i < 3; i++ {
+		_, err := r.Reconcile(context.Background(), req)
+		require.NoError(t, err, "reconcile %d should not error", i)
+	}
+
+	var updated v1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &updated))
+	assert.Equal(t, "Promoting", updated.Status.State,
+		"step must stay at Promoting after 3 reconciles of paused pipeline")
+}


### PR DESCRIPTION
## Summary

**Item**: 025-pause-resume | **Issue**: #83

Implements the missing reconciler logic for `kardinal pause` / `kardinal resume`.

## What changed

- **BundleReconciler**: `handleAvailable` now checks `pipeline.Spec.Paused` before creating the Graph. If paused, the Bundle stays at `Available` and requeues after 15s.
- **PromotionStepReconciler**: Added a pause gate before the state switch. Non-terminal steps requeue after 15s when the Pipeline is paused.
- **docs/cli-reference.md**: Updated pause/resume description to match actual `Pipeline.Spec.Paused` implementation (was incorrectly describing freeze-gate approach).
- **docs/rollback.md**: Added pause/resume section.

## Tests

New tests:
- `TestBundleReconciler_PausedPipeline` — translator not called, bundle stays Available
- `TestBundleReconciler_ResumedPipeline` — translator called, bundle advances to Promoting
- `TestBundleReconciler_PausedIdempotent` — two reconciles of paused pipeline → same result
- `TestPausedPipeline_BlocksPromotionStep` — promoting step held at Promoting when paused
- `TestPausedPipeline_IdempotentOnMultipleReconciles` — 3 reconciles → state unchanged

All existing tests pass.

## Acceptance criteria

- [x] T001 Paused pipeline: Bundle stays at Available (not Promoting)
- [x] T002 Paused pipeline: PromotionStep held at current state
- [x] T003 Idempotency: reconciling twice with paused pipeline → same result
- [x] T004 Docs updated to reflect actual implementation
- [x] T005 All tests pass (go test -race)