### PR TITLE
fix(cli): FormatPipelineTable per-environment status columns (#115)

### DIFF
--- a/CLAIM
+++ b/CLAIM
@@ -1,3 +1,3 @@
 AGENT_ID=STANDALONE-ENG
-ITEM_ID=028-custom-steps
+ITEM_ID=029-pipeline-table-columns
 MODE=standalone

--- a/ITEM.md
+++ b/ITEM.md
@@ -1,61 +1,47 @@
-# Item 028: Custom Promotion Steps via HTTP Webhook
+# Item 029: Fix FormatPipelineTable Per-Environment Status Columns
 
-> **Stage**: Stage 16 (Custom Promotion Steps via Webhook)
-> **Queue**: queue-013
-> **Priority**: high
-> **Size**: m
-> **Depends on**: 013 (PromotionStep reconciler)
+> **Stage**: Workshop 1 Parity (CLI fix)
+> **Queue**: queue-014
+> **Priority**: critical
+> **Size**: s
+> **Depends on**: 011 (CLI foundation), 013 (PromotionStep reconciler)
 > **dependency_mode**: merged
+> **GitHub issue**: #115
 
 ## Context
 
-Stage 16 allows teams to add custom logic to the promotion sequence via HTTP webhooks.
-Any step `uses:` value not matching a built-in step name is dispatched as an HTTP POST
-to `spec.steps[].webhook.url`.
+`kardinal get pipelines` currently outputs a generic PHASE column:
+```
+PIPELINE         PHASE       ENVIRONMENTS   PAUSED   AGE
+nginx-demo       Promoting   3              false    2m
+```
 
-The webhook contract:
-- POST JSON: `{bundle, environment, inputs, outputs_so_far}`
-- Response JSON: `{result: "pass|fail", outputs: {key: value}, message: string}`
-
-Custom steps must be idempotent: the reconciler may call them multiple times if a
-crash occurs between the call and the status patch.
+The Workshop 1 definition-of-done requires per-environment columns:
+```
+PIPELINE    BUNDLE    TEST       UAT     PROD     AGE
+nginx-demo  v1.29.0  Verified   ...     ...      2m
+```
 
 ## Acceptance Criteria
 
-- Custom step dispatch in `PromotionStepReconciler`:
-  - Any `uses` value not matching a built-in step is treated as custom
-  - Dispatches HTTP POST to `spec.steps[].webhook.url`
-  - Body: `{bundle, environment, inputs, outputs_so_far}`
-  - Response: `{result: "pass|fail", outputs: {}, message: string}`
-  - Timeout: `spec.steps[].webhook.timeoutSeconds` (default 300)
-  - Retry: 3 attempts with 30-second backoff on 5xx errors
-- Webhook authentication: `spec.steps[].webhook.secretRef` — K8s Secret with `Authorization` header
-- Step output accumulator: custom step outputs merged into `PromotionStep.status.outputs`
-- Example server: `examples/custom-step/` with a sample Go HTTP server and Pipeline referencing it
-- Documentation: `docs/custom-steps.md`
-- Tests:
-  - Custom step returning pass: next step receives outputs
-  - Custom step returning fail: PromotionStep → Failed
-  - Webhook timeout: marked Failed with `DeadlineExceeded`
-  - Auth header from Secret: included in request
+- `kardinal get pipelines` output format:
+  - Column 1: PIPELINE (pipeline name)
+  - Column 2: BUNDLE (active bundle version tag, or `-` if none)
+  - Columns 3..N: one column per environment in Pipeline.spec.environments order, showing state (Pending/Promoting/Verified/Failed/Paused or `-`)
+  - Last column: AGE
+- Works with any number of environments (dynamic columns based on pipeline spec)
+- When multiple pipelines exist, all rows aligned to same columns (use the union of all environment names)
+- When bundle tag is unknown: show `-`
+- `kardinal get pipelines --namespace all-ns` (if supported) must also use the new format
 
-## Files to Create/Modify
+## Files to Modify
 
-- `pkg/steps/custom.go` — custom HTTP step implementation (moved to parent pkg)
-- `pkg/steps/steps/custom_test.go` — unit tests with mock HTTP server
-- `pkg/steps/registry.go` — extend Lookup to dispatch unknown steps to custom
-- `api/v1alpha1/pipeline_types.go` — add `WebhookConfig` + `StepSpec` types
-- `examples/custom-step/server.go` — example custom step server
-- `examples/custom-step/pipeline.yaml` — example Pipeline with custom step
-- `docs/custom-steps.md` — documentation
+- `cmd/kardinal/cmd/get.go` — FormatPipelineTable function
+- `cmd/kardinal/cmd/get_test.go` — update/add tests for new format
 
 ## Tasks
 
-- [x] T001 Add `WebhookConfig` to `StepSpec` in pipeline_types.go
-- [x] T002 Write failing tests for custom HTTP step (pass, fail, timeout, auth)
-- [x] T003 Implement `pkg/steps/custom.go` with HTTP dispatch
-- [x] T004 Extend step registry to dispatch unknown step names to custom
-- [x] T005 Write integration test: custom step pass → next step receives outputs
-- [x] T006 Create examples/custom-step/ server and pipeline
-- [x] T007 Create docs/custom-steps.md
-- [x] T008 Verify go test -race passes
+- [x] T001 Read current FormatPipelineTable implementation
+- [x] T002 Write failing test for new column format
+- [x] T003 Implement new per-environment column format
+- [x] T004 Verify go test -race passes

--- a/cmd/kardinal/cmd/format.go
+++ b/cmd/kardinal/cmd/format.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -39,26 +40,97 @@ func HumanAge(t time.Time) string {
 }
 
 // FormatPipelineTable writes a tabwriter-formatted table of pipelines to w.
-func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline) error {
+// steps is the list of PromotionSteps in the same namespace; it is used to
+// derive per-environment status and the active bundle version for each pipeline.
+// If steps is nil or empty the environment columns will show "-".
+func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1alpha1.PromotionStep) error {
+	// Build a lookup: pipeline → environment → (state, bundleName)
+	type envState struct {
+		state      string
+		bundleName string
+	}
+	// pipelineEnvMap[pipelineName][envName] = envState
+	pipelineEnvMap := make(map[string]map[string]envState)
+	for _, s := range steps {
+		pipe := s.Spec.PipelineName
+		env := s.Spec.Environment
+		if pipe == "" || env == "" {
+			continue
+		}
+		if _, ok := pipelineEnvMap[pipe]; !ok {
+			pipelineEnvMap[pipe] = make(map[string]envState)
+		}
+		state := s.Status.State
+		if state == "" {
+			state = "Pending"
+		}
+		pipelineEnvMap[pipe][env] = envState{
+			state:      state,
+			bundleName: s.Spec.BundleName,
+		}
+	}
+
+	// Collect all environment names in spec order across all pipelines so that
+	// when multiple pipelines are printed their columns align.
+	// We preserve spec-order per pipeline and use the union across all.
+	envOrder := make([]string, 0)
+	envSeen := make(map[string]bool)
+	for _, p := range pipelines {
+		for _, e := range p.Spec.Environments {
+			if !envSeen[e.Name] {
+				envSeen[e.Name] = true
+				envOrder = append(envOrder, e.Name)
+			}
+		}
+	}
+
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "PIPELINE\tPHASE\tENVIRONMENTS\tPAUSED\tAGE"); err != nil {
+
+	// Build header: PIPELINE BUNDLE <ENV1> <ENV2> ... AGE
+	header := "PIPELINE\tBUNDLE"
+	for _, env := range envOrder {
+		header += "\t" + strings.ToUpper(env)
+	}
+	header += "\tAGE"
+	if _, err := fmt.Fprintln(tw, header); err != nil {
 		return fmt.Errorf("write pipeline table header: %w", err)
 	}
+
 	for _, p := range pipelines {
-		phase := p.Status.Phase
-		if phase == "" {
-			phase = "Unknown"
+		// Determine active bundle version.
+		// Use the bundle name from any PromotionStep for this pipeline, preferring
+		// the most-advanced (Verified) environment's bundle name.
+		bundleDisplay := "-"
+		if envMap, ok := pipelineEnvMap[p.Name]; ok {
+			// Prefer Verified env bundle, else take any non-empty bundle name.
+			for _, est := range envMap {
+				if est.bundleName != "" && bundleDisplay == "-" {
+					bundleDisplay = est.bundleName
+				}
+				if est.state == "Verified" && est.bundleName != "" {
+					bundleDisplay = est.bundleName
+				}
+			}
 		}
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\t%v\t%s\n",
-			p.Name,
-			phase,
-			len(p.Spec.Environments),
-			p.Spec.Paused,
-			HumanAge(p.CreationTimestamp.Time),
-		); err != nil {
+
+		// Build the row.
+		row := fmt.Sprintf("%s\t%s", p.Name, bundleDisplay)
+		for _, env := range envOrder {
+			state := "-"
+			if envMap, ok := pipelineEnvMap[p.Name]; ok {
+				if est, ok := envMap[env]; ok {
+					state = est.state
+				}
+			}
+			row += "\t" + state
+		}
+		row += "\t" + HumanAge(p.CreationTimestamp.Time)
+
+		if _, err := fmt.Fprintln(tw, row); err != nil {
 			return fmt.Errorf("write pipeline row: %w", err)
 		}
 	}
+
 	if err := tw.Flush(); err != nil {
 		return fmt.Errorf("flush pipeline table: %w", err)
 	}

--- a/cmd/kardinal/cmd/format_test.go
+++ b/cmd/kardinal/cmd/format_test.go
@@ -37,31 +37,168 @@ func TestFormatPipelineTable(t *testing.T) {
 			},
 			Spec: v1alpha1.PipelineSpec{
 				Environments: []v1alpha1.EnvironmentSpec{
-					{Name: "dev"},
+					{Name: "test"},
 					{Name: "uat"},
 					{Name: "prod"},
 				},
-				Paused: false,
 			},
-			Status: v1alpha1.PipelineStatus{
-				Phase: "Ready",
+		},
+	}
+	steps := []v1alpha1.PromotionStep{
+		{
+			Spec: v1alpha1.PromotionStepSpec{
+				PipelineName: "nginx-demo",
+				Environment:  "test",
+				BundleName:   "nginx-demo-v1-29-0",
+				StepType:     "health-check",
+			},
+			Status: v1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+		{
+			Spec: v1alpha1.PromotionStepSpec{
+				PipelineName: "nginx-demo",
+				Environment:  "uat",
+				BundleName:   "nginx-demo-v1-29-0",
+				StepType:     "health-check",
+			},
+			Status: v1alpha1.PromotionStepStatus{State: "Promoting"},
+		},
+		{
+			Spec: v1alpha1.PromotionStepSpec{
+				PipelineName: "nginx-demo",
+				Environment:  "prod",
+				BundleName:   "nginx-demo-v1-29-0",
+				StepType:     "health-check",
+			},
+			Status: v1alpha1.PromotionStepStatus{State: "Pending"},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cmd.FormatPipelineTable(&buf, pipelines, steps))
+	out := buf.String()
+
+	// Header must have per-environment columns.
+	assert.Contains(t, out, "PIPELINE")
+	assert.Contains(t, out, "BUNDLE")
+	assert.Contains(t, out, "TEST")
+	assert.Contains(t, out, "UAT")
+	assert.Contains(t, out, "PROD")
+	assert.Contains(t, out, "AGE")
+
+	// Must NOT have old columns.
+	assert.NotContains(t, out, "PHASE")
+	assert.NotContains(t, out, "ENVIRONMENTS")
+	assert.NotContains(t, out, "PAUSED")
+
+	// Row data.
+	assert.Contains(t, out, "nginx-demo")
+	assert.Contains(t, out, "nginx-demo-v1-29-0")
+	assert.Contains(t, out, "Verified")
+	assert.Contains(t, out, "Promoting")
+	assert.Contains(t, out, "Pending")
+}
+
+// TestFormatPipelineTable_NoSteps verifies that an empty step list shows "-" for all env columns.
+func TestFormatPipelineTable_NoSteps(t *testing.T) {
+	now := time.Now()
+	pipelines := []v1alpha1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "my-pipeline",
+				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
+			},
+			Spec: v1alpha1.PipelineSpec{
+				Environments: []v1alpha1.EnvironmentSpec{
+					{Name: "dev"},
+					{Name: "prod"},
+				},
 			},
 		},
 	}
 
 	var buf bytes.Buffer
-	require.NoError(t, cmd.FormatPipelineTable(&buf, pipelines))
+	require.NoError(t, cmd.FormatPipelineTable(&buf, pipelines, nil))
 	out := buf.String()
 
-	assert.Contains(t, out, "PIPELINE")
-	assert.Contains(t, out, "PHASE")
-	assert.Contains(t, out, "ENVIRONMENTS")
-	assert.Contains(t, out, "PAUSED")
-	assert.Contains(t, out, "AGE")
-	assert.Contains(t, out, "nginx-demo")
-	assert.Contains(t, out, "Ready")
-	assert.Contains(t, out, "3")
-	assert.Contains(t, out, "false")
+	assert.Contains(t, out, "DEV")
+	assert.Contains(t, out, "PROD")
+	assert.Contains(t, out, "my-pipeline")
+	// Without steps both env columns and bundle should show "-".
+	// Count occurrences of "-" — at least 3 (bundle + 2 envs).
+	assert.GreaterOrEqual(t, strings.Count(out, "-"), 3)
+}
+
+// TestFormatPipelineTable_MultiPipeline verifies that multiple pipelines with different
+// environments produce a union-column table with "-" for absent environments.
+func TestFormatPipelineTable_MultiPipeline(t *testing.T) {
+	now := time.Now()
+	pipelines := []v1alpha1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "app-a",
+				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+			},
+			Spec: v1alpha1.PipelineSpec{
+				Environments: []v1alpha1.EnvironmentSpec{
+					{Name: "test"},
+					{Name: "prod"},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "app-b",
+				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
+			},
+			Spec: v1alpha1.PipelineSpec{
+				Environments: []v1alpha1.EnvironmentSpec{
+					{Name: "test"},
+					{Name: "staging"},
+					{Name: "prod"},
+				},
+			},
+		},
+	}
+	steps := []v1alpha1.PromotionStep{
+		{
+			Spec: v1alpha1.PromotionStepSpec{
+				PipelineName: "app-a",
+				Environment:  "test",
+				BundleName:   "app-a-v1-0-0",
+				StepType:     "health-check",
+			},
+			Status: v1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+		{
+			Spec: v1alpha1.PromotionStepSpec{
+				PipelineName: "app-b",
+				Environment:  "staging",
+				BundleName:   "app-b-v2-0-0",
+				StepType:     "health-check",
+			},
+			Status: v1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cmd.FormatPipelineTable(&buf, pipelines, steps))
+	out := buf.String()
+
+	// Union columns: TEST, PROD from app-a, STAGING from app-b.
+	assert.Contains(t, out, "TEST")
+	assert.Contains(t, out, "STAGING")
+	assert.Contains(t, out, "PROD")
+
+	// app-a has no staging column — its staging cell should be "-".
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.GreaterOrEqual(t, len(lines), 3, "need header + 2 data rows")
+	// Find the app-a row.
+	for _, line := range lines[1:] { // skip header
+		if strings.HasPrefix(strings.TrimSpace(line), "app-a") {
+			assert.Contains(t, line, "-", "app-a row must have '-' for missing staging column")
+		}
+	}
 }
 
 func TestFormatBundleTable(t *testing.T) {

--- a/cmd/kardinal/cmd/get_pipelines.go
+++ b/cmd/kardinal/cmd/get_pipelines.go
@@ -39,11 +39,19 @@ func runGetPipelines(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get pipelines: %w", err)
 	}
 
-	var pipelines v1alpha1.PipelineList
+	ctx := context.Background()
 	opts := []sigs_client.ListOption{sigs_client.InNamespace(ns)}
 
-	if err := client.List(context.Background(), &pipelines, opts...); err != nil {
+	var pipelines v1alpha1.PipelineList
+	if err := client.List(ctx, &pipelines, opts...); err != nil {
 		return fmt.Errorf("list pipelines: %w", err)
+	}
+
+	// Fetch PromotionSteps in the same namespace for per-environment status columns.
+	var promotionSteps v1alpha1.PromotionStepList
+	if err := client.List(ctx, &promotionSteps, opts...); err != nil {
+		// Non-fatal: fall back to empty step list (env columns will show "-").
+		promotionSteps.Items = nil
 	}
 
 	// If a specific name was given, filter.
@@ -59,5 +67,5 @@ func runGetPipelines(cmd *cobra.Command, args []string) error {
 		items = filtered
 	}
 
-	return FormatPipelineTable(cmd.OutOrStdout(), items)
+	return FormatPipelineTable(cmd.OutOrStdout(), items, promotionSteps.Items)
 }


### PR DESCRIPTION
Fixes #115.

Replaces PHASE/ENVIRONMENTS/PAUSED columns with per-environment status: PIPELINE BUNDLE <ENV...> AGE.

Per-environment state derived from PromotionStep.status.state. Bundle version from BundleName of most-advanced step. Union columns across multiple pipelines.

Tests: 3 new tests in format_test.go + full test suite pass.