### PR TITLE
feat(cli): add kardinal promote command

### DIFF
--- a/cmd/kardinal/cmd/promote.go
+++ b/cmd/kardinal/cmd/promote.go
@@ -1,0 +1,114 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+func newPromoteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "promote <pipeline> --env <environment>",
+		Short: "Trigger promotion of a pipeline to a specific environment",
+		Long: `Trigger promotion by creating a Bundle that targets a specific environment.
+
+The Bundle flows through all upstream environments first, then targets the
+specified environment. PolicyGates and approval mode apply as configured.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			env, _ := cmd.Flags().GetString("env")
+			if env == "" {
+				return fmt.Errorf("--env is required")
+			}
+			c, ns, err := buildClient()
+			if err != nil {
+				return fmt.Errorf("promote: %w", err)
+			}
+			return promoteFn(cmd.OutOrStdout(), c, ns, args[0], env)
+		},
+	}
+
+	cmd.Flags().StringP("env", "e", "", "Target environment name (required)")
+	_ = cmd.MarkFlagRequired("env")
+
+	return cmd
+}
+
+// promoteFn is the testable implementation of the promote command.
+// It validates the pipeline and environment exist, then creates a Bundle targeting
+// the specified environment via spec.intent.targetEnvironment.
+func promoteFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client, ns, pipeline, env string) error {
+	ctx := context.Background()
+
+	// Look up the Pipeline
+	var pl v1alpha1.Pipeline
+	if err := c.Get(ctx, types.NamespacedName{Name: pipeline, Namespace: ns}, &pl); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("pipeline not found: %s", pipeline)
+		}
+		return fmt.Errorf("get pipeline %s: %w", pipeline, err)
+	}
+
+	// Validate that the environment exists in the pipeline
+	found := false
+	for _, e := range pl.Spec.Environments {
+		if e.Name == env {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("environment %q not found in pipeline %s", env, pipeline)
+	}
+
+	// Create a Bundle with intent targeting the specified environment
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: pipeline + "-",
+			Namespace:    ns,
+		},
+		Spec: v1alpha1.BundleSpec{
+			Type:     "image",
+			Pipeline: pipeline,
+			Intent: &v1alpha1.BundleIntent{
+				TargetEnvironment: env,
+			},
+		},
+	}
+
+	if err := c.Create(ctx, bundle); err != nil {
+		return fmt.Errorf("create promote bundle for pipeline %s env %s: %w", pipeline, env, err)
+	}
+
+	if _, err := fmt.Fprintf(w,
+		"Promoting %s to %s: bundle %s created\n"+
+			"Track with: kardinal get bundles %s\n",
+		pipeline, env, bundle.Name, pipeline,
+	); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/kardinal/cmd/promote_test.go
+++ b/cmd/kardinal/cmd/promote_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+// TestPromote_CreatesBundleForEnvironment verifies that promoteFn creates a Bundle
+// targeting the specified environment.
+func TestPromote_CreatesBundleForEnvironment(t *testing.T) {
+	s := cliTestScheme(t)
+	pipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Git: v1alpha1.PipelineGit{URL: "https://github.com/test/repo"},
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test"},
+				{Name: "uat"},
+				{Name: "prod"},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline).Build()
+
+	var buf bytes.Buffer
+	err := promoteFn(&buf, c, "default", "nginx-demo", "prod")
+	require.NoError(t, err)
+
+	// Verify Bundle was created
+	var bundles v1alpha1.BundleList
+	require.NoError(t, c.List(context.Background(), &bundles))
+	require.Len(t, bundles.Items, 1)
+	assert.Equal(t, "nginx-demo", bundles.Items[0].Spec.Pipeline)
+	require.NotNil(t, bundles.Items[0].Spec.Intent, "Intent should not be nil")
+	assert.Equal(t, "prod", bundles.Items[0].Spec.Intent.TargetEnvironment)
+
+	out := buf.String()
+	assert.Contains(t, out, "nginx-demo")
+	assert.Contains(t, out, "prod")
+}
+
+// TestPromote_PipelineNotFound returns an error when the pipeline does not exist.
+func TestPromote_PipelineNotFound(t *testing.T) {
+	s := cliTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	var buf bytes.Buffer
+	err := promoteFn(&buf, c, "default", "no-such-pipeline", "prod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no-such-pipeline")
+}
+
+// TestPromote_EnvironmentNotInPipeline returns an error when the env is not in the pipeline.
+func TestPromote_EnvironmentNotInPipeline(t *testing.T) {
+	s := cliTestScheme(t)
+	pipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Git: v1alpha1.PipelineGit{URL: "https://github.com/test/repo"},
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test"},
+				{Name: "prod"},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline).Build()
+
+	var buf bytes.Buffer
+	err := promoteFn(&buf, c, "default", "nginx-demo", "nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent")
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -65,6 +65,7 @@ It communicates with the Kubernetes API server to read and write CRDs.`,
 	root.AddCommand(newGetCmd())
 	root.AddCommand(newExplainCmd())
 	root.AddCommand(newCreateCmd())
+	root.AddCommand(newPromoteCmd())
 	root.AddCommand(newRollbackCmd())
 	root.AddCommand(newPauseCmd())
 	root.AddCommand(newResumeCmd())

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -146,7 +146,7 @@ Bundle my-app-v1-29-0-1712567890 created.
 
 ### kardinal promote
 
-Manually trigger promotion of the latest available Bundle to a specific environment. Normally promotion is automatic, but this command is useful for debugging or for environments that require manual triggering.
+Manually trigger promotion by creating a Bundle targeting a specific environment. The Bundle flows through all upstream environments before reaching the target environment. PolicyGates and approval mode apply as configured.
 
 ```bash
 kardinal promote <pipeline> --env <environment>
@@ -159,10 +159,8 @@ kardinal promote my-app --env prod
 
 Output:
 ```
-Promoting my-app to prod: v1.28.0 -> v1.29.0
-  Metric gate passed (staging success-rate: 99.7%)
-  PR #144 opened: https://github.com/myorg/gitops-repo/pull/144
-  Merge PR #144 to complete promotion (gate: pr-review)
+Promoting my-app to prod: bundle my-app-x7k2p created
+Track with: kardinal get bundles my-app
 ```
 
 ### kardinal explain


### PR DESCRIPTION
## Summary

Adds `kardinal promote <pipeline> --env <env>` subcommand.

**Item**: 033-promote-command
**Spec**: .specify/specs/033-promote-command/spec.md
**Closes**: #156, #119

## Acceptance Criteria

- [x] FR-001: `kardinal promote <pipeline> --env <env>` subcommand exists in cobra CLI
- [x] FR-002: Command creates a Bundle with `spec.intent.targetEnvironment = <env>`
- [x] FR-003: Output: "Promoting <pipeline> to <env>: bundle <name> created"
- [x] FR-004: Exit code 1 on pipeline not found with descriptive error
- [x] FR-005: Exit code 1 on environment not in pipeline
- [x] FR-006: docs/cli-reference.md updated with correct output format

## Test Output

```
--- PASS: TestPromote_CreatesBundleForEnvironment (0.04s)
--- PASS: TestPromote_PipelineNotFound (0.00s)
--- PASS: TestPromote_EnvironmentNotInPipeline (0.00s)
PASS
ok  github.com/kardinal-promoter/kardinal-promoter/cmd/kardinal/cmd
```

## Journey Validation

Journey 5 (CLI) promote step:
```
$ kardinal promote my-app --env prod
Promoting my-app to prod: bundle my-app-x7k2p created
Track with: kardinal get bundles my-app
```

## Build/Test/Lint

- go build ./...: PASS
- go test ./... -race: PASS
- go vet ./...: PASS