### PR TITLE
feat(health): implement ArgoRollouts health adapter

### DIFF
--- a/docs/health-adapters.md
+++ b/docs/health-adapters.md
@@ -107,7 +107,7 @@ health:
 | Suspended | Fail after timeout |
 | Not found | Retry for 60s, then fail |
 
-## Adapter: argoRollouts (Phase 2)
+## Adapter: argoRollouts
 
 Watches an Argo Rollouts Rollout's phase after promotion.
 

--- a/pkg/health/adapter.go
+++ b/pkg/health/adapter.go
@@ -49,7 +49,7 @@ type HealthStatus struct {
 
 // CheckOptions carries the health check configuration for a specific environment.
 type CheckOptions struct {
-	// Type selects the adapter: "resource", "argocd", "flux".
+	// Type selects the adapter: "resource", "argocd", "flux", "argoRollouts".
 	// Empty means auto-detect.
 	Type string
 
@@ -61,6 +61,9 @@ type CheckOptions struct {
 
 	// Flux configuration (for type: flux).
 	Flux FluxConfig
+
+	// ArgoRollouts configuration (for type: argoRollouts).
+	ArgoRollouts ArgoRolloutsConfig
 
 	// Timeout is the maximum time to wait for health. Default: 10 minutes.
 	Timeout time.Duration
@@ -89,6 +92,14 @@ type FluxConfig struct {
 	// Name is the Kustomization name.
 	Name string
 	// Namespace is the Kustomization namespace. Default: "flux-system".
+	Namespace string
+}
+
+// ArgoRolloutsConfig is the health check configuration for an Argo Rollouts Rollout.
+type ArgoRolloutsConfig struct {
+	// Name is the Rollout name. Defaults to pipeline name.
+	Name string
+	// Namespace is the Rollout namespace. Defaults to environment name.
 	Namespace string
 }
 
@@ -295,6 +306,71 @@ func findCondition(conditions []interface{}, condType string) map[string]interfa
 	return nil
 }
 
+// --- ArgoRolloutsAdapter ---
+
+// ArgoRolloutsAdapter checks Argo Rollouts Rollout health status.
+// A Rollout is healthy when status.phase == "Healthy".
+// Uses the dynamic client to avoid a compile-time dependency on the Argo Rollouts SDK.
+type ArgoRolloutsAdapter struct {
+	dynamic dynamic.Interface
+}
+
+// NewArgoRolloutsAdapter constructs an ArgoRolloutsAdapter.
+func NewArgoRolloutsAdapter(dynClient dynamic.Interface) *ArgoRolloutsAdapter {
+	return &ArgoRolloutsAdapter{dynamic: dynClient}
+}
+
+// Name returns "argoRollouts".
+func (a *ArgoRolloutsAdapter) Name() string { return "argoRollouts" }
+
+var argoRolloutsGVR = schema.GroupVersionResource{
+	Group:    "argoproj.io",
+	Version:  "v1alpha1",
+	Resource: "rollouts",
+}
+
+// Check verifies that the Argo Rollouts Rollout is in the Healthy phase.
+func (a *ArgoRolloutsAdapter) Check(ctx context.Context, opts CheckOptions) (HealthStatus, error) {
+	cfg := opts.ArgoRollouts
+	if cfg.Namespace == "" {
+		cfg.Namespace = "default"
+	}
+	if cfg.Name == "" {
+		return HealthStatus{Healthy: false, Reason: "ArgoRollouts.Name not configured", CheckedAt: time.Now()}, nil
+	}
+
+	rollout, err := a.dynamic.Resource(argoRolloutsGVR).
+		Namespace(cfg.Namespace).
+		Get(ctx, cfg.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return HealthStatus{
+				Healthy:   false,
+				Reason:    fmt.Sprintf("Rollout %s/%s not found", cfg.Namespace, cfg.Name),
+				CheckedAt: time.Now(),
+			}, nil
+		}
+		return HealthStatus{}, fmt.Errorf("get rollout %s/%s: %w", cfg.Namespace, cfg.Name, err)
+	}
+
+	phase, _, _ := unstructured.NestedString(rollout.Object, "status", "phase")
+	message, _, _ := unstructured.NestedString(rollout.Object, "status", "message")
+
+	if phase == "Healthy" {
+		reason := fmt.Sprintf("Rollout phase: Healthy")
+		if message != "" {
+			reason += " — " + message
+		}
+		return HealthStatus{Healthy: true, Reason: reason, CheckedAt: time.Now()}, nil
+	}
+
+	reason := fmt.Sprintf("Rollout phase: %s", phase)
+	if message != "" {
+		reason += " — " + message
+	}
+	return HealthStatus{Healthy: false, Reason: reason, CheckedAt: time.Now()}, nil
+}
+
 // --- AutoDetector ---
 
 // AutoDetector selects the appropriate health adapter based on what is available
@@ -317,6 +393,8 @@ func (d *AutoDetector) Select(ctx context.Context, healthType string) (Adapter, 
 		return NewArgoCDAdapter(d.dynamic), nil
 	case "flux":
 		return NewFluxAdapter(d.dynamic), nil
+	case "argoRollouts":
+		return NewArgoRolloutsAdapter(d.dynamic), nil
 	case "resource", "":
 		// Auto-detect: try argocd, then flux, fall back to resource.
 		if healthType == "" {

--- a/pkg/health/adapter.go
+++ b/pkg/health/adapter.go
@@ -357,7 +357,7 @@ func (a *ArgoRolloutsAdapter) Check(ctx context.Context, opts CheckOptions) (Hea
 	message, _, _ := unstructured.NestedString(rollout.Object, "status", "message")
 
 	if phase == "Healthy" {
-		reason := fmt.Sprintf("Rollout phase: Healthy")
+		reason := "Rollout phase: Healthy"
 		if message != "" {
 			reason += " — " + message
 		}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -277,3 +277,89 @@ func TestAutoDetector_PreferredByType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "resource", adapter.Name())
 }
+
+// TestArgoRolloutsAdapter_Healthy verifies that a Rollout with phase=Healthy
+// is reported as Healthy.
+func TestArgoRolloutsAdapter_Healthy(t *testing.T) {
+	rollout := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Rollout",
+			"metadata":   map[string]interface{}{"name": "my-app", "namespace": "prod"},
+			"status": map[string]interface{}{
+				"phase":   "Healthy",
+				"message": "all replicas up to date",
+			},
+		},
+	}
+	rollout.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Rollout",
+	})
+
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), rollout)
+
+	adapter := health.NewArgoRolloutsAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		ArgoRollouts: health.ArgoRolloutsConfig{Name: "my-app", Namespace: "prod"},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Healthy)
+	assert.Contains(t, result.Reason, "Healthy")
+}
+
+// TestArgoRolloutsAdapter_Degraded verifies that a Degraded Rollout is Unhealthy.
+func TestArgoRolloutsAdapter_Degraded(t *testing.T) {
+	rollout := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Rollout",
+			"metadata":   map[string]interface{}{"name": "my-app", "namespace": "prod"},
+			"status": map[string]interface{}{
+				"phase":   "Degraded",
+				"message": "image pull failed",
+			},
+		},
+	}
+	rollout.SetGroupVersionKind(schema.GroupVersionKind{Group: "argoproj.io", Version: "v1alpha1", Kind: "Rollout"})
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), rollout)
+
+	adapter := health.NewArgoRolloutsAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		ArgoRollouts: health.ArgoRolloutsConfig{Name: "my-app", Namespace: "prod"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy)
+	assert.Contains(t, result.Reason, "Degraded")
+}
+
+// TestArgoRolloutsAdapter_NotFound verifies that a missing Rollout returns Unhealthy.
+func TestArgoRolloutsAdapter_NotFound(t *testing.T) {
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+	adapter := health.NewArgoRolloutsAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		ArgoRollouts: health.ArgoRolloutsConfig{Name: "missing", Namespace: "prod"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy)
+	assert.Contains(t, result.Reason, "not found")
+}
+
+// TestAutoDetector_ArgoRolloutsType verifies that explicit "argoRollouts" type returns
+// an ArgoRolloutsAdapter.
+func TestAutoDetector_ArgoRolloutsType(t *testing.T) {
+	s := buildScheme(t)
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	detector := health.NewAutoDetector(c, dynClient)
+
+	adapter, err := detector.Select(context.Background(), "argoRollouts")
+	require.NoError(t, err)
+	assert.Equal(t, "argoRollouts", adapter.Name())
+}

--- a/pkg/reconciler/promotionstep/reconciler.go
+++ b/pkg/reconciler/promotionstep/reconciler.go
@@ -467,6 +467,10 @@ func (r *Reconciler) handleHealthChecking(ctx context.Context, log zerolog.Logge
 				Name:      pipeline.Name + "-" + ps.Spec.Environment,
 				Namespace: "flux-system",
 			},
+			ArgoRollouts: health.ArgoRolloutsConfig{
+				Name:      pipeline.Name,
+				Namespace: ps.Spec.Environment,
+			},
 		}
 
 		result, checkErr := adapter.Check(ctx, opts)


### PR DESCRIPTION
## Summary

Implements the `ArgoRolloutsAdapter` that checks Argo Rollouts Rollout health.

**Item**: 035-argo-rollouts-adapter
**Closes**: #158, #118

## Acceptance Criteria

- [x] `ArgoRolloutsAdapter` reads `argoproj.io/v1alpha1/Rollout` resource
- [x] Returns `Healthy` when `status.phase == Healthy` (stable rollout)
- [x] Returns `Healthy: false` with phase in reason for all other phases
- [x] `AutoDetector.Select()` handles `argoRollouts` case explicitly
- [x] Unit tests: Healthy Rollout → Healthy, Degraded → Unhealthy, NotFound → Unhealthy
- [x] `go test ./pkg/health/... -race` passes
- [x] Documented in docs/health-adapters.md (removed '(Phase 2)' note)

## Test Output

```
--- PASS: TestArgoRolloutsAdapter_Healthy (0.00s)
--- PASS: TestArgoRolloutsAdapter_Degraded (0.00s)
--- PASS: TestArgoRolloutsAdapter_NotFound (0.00s)
--- PASS: TestAutoDetector_ArgoRolloutsType (0.04s)
PASS
ok  github.com/kardinal-promoter/kardinal-promoter/pkg/health
```

## Build/Test/Lint

- go build ./...: PASS
- go test ./... -race: PASS
- go vet ./...: PASS