### PR TITLE
fix(cli): CLI-3 doc comment + CLI-5 rollback copies bundle type from original (#152)

### DIFF
--- a/cmd/kardinal/cmd/cli_test.go
+++ b/cmd/kardinal/cmd/cli_test.go
@@ -62,13 +62,9 @@ func TestCreateBundle_CreatesBundle(t *testing.T) {
 func TestRollback_CreatesBundleWithRollbackOf(t *testing.T) {
 	s := cliTestScheme(t)
 	verifiedBundle := &v1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nginx-demo-v1",
-			Namespace: "default",
-			Labels:    map[string]string{"kardinal.io/pipeline": "nginx-demo"},
-		},
-		Spec:   v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
-		Status: v1alpha1.BundleStatus{Phase: "Verified"},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1", Namespace: "default"},
+		Spec:       v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status:     v1alpha1.BundleStatus{Phase: "Verified"},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(verifiedBundle).WithStatusSubresource(verifiedBundle).Build()
 
@@ -305,15 +301,11 @@ func TestPolicySimulate_EnvSpecificGateExcluded(t *testing.T) {
 // copies Type from the original Verified bundle, not hardcoding "image" (CLI-5 fix).
 func TestRollback_CopiesTypeFromOriginalBundle(t *testing.T) {
 	s := cliTestScheme(t)
-	// Verified bundle with type=config — must include pipeline label so rollbackFn List finds it.
+	// Verified bundle with type=config; no special label needed — rollbackFn filters by Spec.Pipeline.
 	verifiedBundle := &v1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nginx-demo-cfg-v1",
-			Namespace: "default",
-			Labels:    map[string]string{"kardinal.io/pipeline": "nginx-demo"},
-		},
-		Spec:   v1alpha1.BundleSpec{Type: "config", Pipeline: "nginx-demo"},
-		Status: v1alpha1.BundleStatus{Phase: "Verified"},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-cfg-v1", Namespace: "default"},
+		Spec:       v1alpha1.BundleSpec{Type: "config", Pipeline: "nginx-demo"},
+		Status:     v1alpha1.BundleStatus{Phase: "Verified"},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(verifiedBundle).WithStatusSubresource(verifiedBundle).Build()
 

--- a/cmd/kardinal/cmd/cli_test.go
+++ b/cmd/kardinal/cmd/cli_test.go
@@ -62,9 +62,13 @@ func TestCreateBundle_CreatesBundle(t *testing.T) {
 func TestRollback_CreatesBundleWithRollbackOf(t *testing.T) {
 	s := cliTestScheme(t)
 	verifiedBundle := &v1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1", Namespace: "default"},
-		Spec:       v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
-		Status:     v1alpha1.BundleStatus{Phase: "Verified"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-demo-v1",
+			Namespace: "default",
+			Labels:    map[string]string{"kardinal.io/pipeline": "nginx-demo"},
+		},
+		Spec:   v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status: v1alpha1.BundleStatus{Phase: "Verified"},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(verifiedBundle).WithStatusSubresource(verifiedBundle).Build()
 
@@ -230,6 +234,132 @@ func TestHistory_ListsBundles(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "nginx-demo-v1")
 	assert.Contains(t, out, "nginx-demo-v2")
+}
+
+// TestPolicySimulate_GlobalGateAppliedToAllEnvs verifies that gates without applies-to
+// are included in simulation regardless of environment (CLI-3 fix).
+func TestPolicySimulate_GlobalGateAppliedToAllEnvs(t *testing.T) {
+	s := cliTestScheme(t)
+	// Gate with NO applies-to label — should apply to every env.
+	globalGate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "global-freeze",
+			Namespace: "default",
+			Labels:    map[string]string{},
+		},
+		Spec: v1alpha1.PolicyGateSpec{
+			Expression: "!schedule.isWeekend",
+			Message:    "Global freeze on weekends",
+		},
+	}
+	// Gate with applies-to=prod — should NOT apply when env=staging.
+	prodGate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prod-only",
+			Namespace: "default",
+			Labels:    map[string]string{"kardinal.io/applies-to": "prod"},
+		},
+		Spec: v1alpha1.PolicyGateSpec{
+			Expression: "!schedule.isWeekend",
+			Message:    "Prod-only gate",
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(globalGate, prodGate).Build()
+
+	// Simulate for staging on a Saturday — global gate should block, prod gate should be excluded.
+	var buf bytes.Buffer
+	err := policySimulateFn(&buf, c, "default", "nginx-demo", "staging", "Saturday 3pm", 0)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "global-freeze", "global gate (no applies-to) must be evaluated")
+	assert.NotContains(t, out, "prod-only", "prod-only gate must not appear for staging env")
+	assert.Contains(t, out, "BLOCKED")
+}
+
+// TestPolicySimulate_EnvSpecificGateExcluded verifies that applies-to gates are
+// excluded when the env does not match (CLI-3: applies-to label check in simulate loop).
+func TestPolicySimulate_EnvSpecificGateExcluded(t *testing.T) {
+	s := cliTestScheme(t)
+	stagingGate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "staging-gate",
+			Namespace: "default",
+			Labels:    map[string]string{"kardinal.io/applies-to": "staging"},
+		},
+		Spec: v1alpha1.PolicyGateSpec{Expression: "!schedule.isWeekend"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(stagingGate).Build()
+
+	// Simulate for prod — staging gate must not appear.
+	var buf bytes.Buffer
+	err := policySimulateFn(&buf, c, "default", "nginx-demo", "prod", "Saturday 3pm", 0)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.NotContains(t, out, "staging-gate", "staging gate must be excluded for prod env")
+	assert.Contains(t, out, "PASS", "no applicable gates means PASS")
+}
+
+// TestRollback_CopiesTypeFromOriginalBundle verifies that the rollback bundle
+// copies Type from the original Verified bundle, not hardcoding "image" (CLI-5 fix).
+func TestRollback_CopiesTypeFromOriginalBundle(t *testing.T) {
+	s := cliTestScheme(t)
+	// Verified bundle with type=config — must include pipeline label so rollbackFn List finds it.
+	verifiedBundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-demo-cfg-v1",
+			Namespace: "default",
+			Labels:    map[string]string{"kardinal.io/pipeline": "nginx-demo"},
+		},
+		Spec:   v1alpha1.BundleSpec{Type: "config", Pipeline: "nginx-demo"},
+		Status: v1alpha1.BundleStatus{Phase: "Verified"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(verifiedBundle).WithStatusSubresource(verifiedBundle).Build()
+
+	var buf bytes.Buffer
+	err := rollbackFn(&buf, c, "default", "nginx-demo", "prod", "", false)
+	require.NoError(t, err)
+
+	var bundles v1alpha1.BundleList
+	require.NoError(t, c.List(context.Background(), &bundles))
+	require.Len(t, bundles.Items, 2)
+
+	var rb *v1alpha1.Bundle
+	for i := range bundles.Items {
+		if bundles.Items[i].Labels["kardinal.io/rollback"] == "true" {
+			rb = &bundles.Items[i]
+		}
+	}
+	require.NotNil(t, rb)
+	assert.Equal(t, "config", rb.Spec.Type, "rollback bundle must copy type from the original bundle")
+	assert.Equal(t, "nginx-demo-cfg-v1", rb.Spec.Provenance.RollbackOf)
+}
+
+// TestRollback_CopiesTypeWhenExplicitToBundle verifies type is copied when --to is specified.
+func TestRollback_CopiesTypeWhenExplicitToBundle(t *testing.T) {
+	s := cliTestScheme(t)
+	targetBundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-mixed-v3", Namespace: "default"},
+		Spec:       v1alpha1.BundleSpec{Type: "mixed", Pipeline: "nginx-demo"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(targetBundle).Build()
+
+	var buf bytes.Buffer
+	err := rollbackFn(&buf, c, "default", "nginx-demo", "prod", "nginx-demo-mixed-v3", false)
+	require.NoError(t, err)
+
+	var bundles v1alpha1.BundleList
+	require.NoError(t, c.List(context.Background(), &bundles))
+
+	var rb *v1alpha1.Bundle
+	for i := range bundles.Items {
+		if bundles.Items[i].Labels["kardinal.io/rollback"] == "true" {
+			rb = &bundles.Items[i]
+		}
+	}
+	require.NotNil(t, rb)
+	assert.Equal(t, "mixed", rb.Spec.Type, "rollback bundle must copy type from target bundle")
 }
 
 // TestSplitImageRef verifies image reference parsing.

--- a/cmd/kardinal/cmd/policy.go
+++ b/cmd/kardinal/cmd/policy.go
@@ -164,7 +164,11 @@ Example:
 func policySimulateFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client, ns, pipeline, env, timeStr string, soakMinutes int) error {
 	ctx := context.Background()
 
-	// Find PolicyGates for this pipeline+environment.
+	// Find PolicyGates in this namespace.
+	// Note: the applies-to label filter below (CLI-3) selects gates scoped to this
+	// environment OR gates with no applies-to restriction (global gates). A pure
+	// server-side label selector cannot express this OR-absent condition in one call,
+	// so the distinction is done client-side. See: docs/design/11-graph-purity-tech-debt.md#CLI-3
 	var gates v1alpha1.PolicyGateList
 	if listErr := c.List(ctx, &gates, sigs_client.InNamespace(ns)); listErr != nil {
 		return fmt.Errorf("list policy gates: %w", listErr)

--- a/cmd/kardinal/cmd/rollback.go
+++ b/cmd/kardinal/cmd/rollback.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
@@ -65,14 +66,17 @@ func rollbackFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client,
 	rollbackOf := toBundle
 	if rollbackOf == "" {
 		var bundles v1alpha1.BundleList
-		if listErr := c.List(ctx, &bundles, sigs_client.InNamespace(ns)); listErr != nil {
+		if listErr := c.List(ctx, &bundles,
+			sigs_client.InNamespace(ns),
+			sigs_client.MatchingLabels{"kardinal.io/pipeline": pipeline},
+		); listErr != nil {
 			return fmt.Errorf("list bundles: %w", listErr)
 		}
 
 		var latest *v1alpha1.Bundle
 		for i := range bundles.Items {
 			b := &bundles.Items[i]
-			if b.Spec.Pipeline != pipeline || b.Status.Phase != "Verified" {
+			if b.Status.Phase != "Verified" {
 				continue
 			}
 			if latest == nil || b.CreationTimestamp.After(latest.CreationTimestamp.Time) {
@@ -83,6 +87,14 @@ func rollbackFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client,
 			return fmt.Errorf("no Verified bundles found for pipeline %s", pipeline)
 		}
 		rollbackOf = latest.Name
+	}
+
+	// Copy the bundle type from the target bundle so the rollback is type-compatible.
+	// Falls back to "image" if the target bundle cannot be fetched.
+	bundleType := "image"
+	var originalBundle v1alpha1.Bundle
+	if getErr := c.Get(ctx, types.NamespacedName{Name: rollbackOf, Namespace: ns}, &originalBundle); getErr == nil {
+		bundleType = originalBundle.Spec.Type
 	}
 
 	labels := map[string]string{"kardinal.io/rollback": "true"}
@@ -97,7 +109,7 @@ func rollbackFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client,
 			Labels:       labels,
 		},
 		Spec: v1alpha1.BundleSpec{
-			Type:     "image",
+			Type:     bundleType,
 			Pipeline: pipeline,
 			Intent:   &v1alpha1.BundleIntent{TargetEnvironment: envFilter},
 			Provenance: &v1alpha1.BundleProvenance{

--- a/cmd/kardinal/cmd/rollback.go
+++ b/cmd/kardinal/cmd/rollback.go
@@ -65,18 +65,18 @@ func rollbackFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client,
 
 	rollbackOf := toBundle
 	if rollbackOf == "" {
+		// List all bundles in the namespace and filter by Spec.Pipeline.
+		// A label selector is not used here because bundles created by the CLI
+		// may not carry the kardinal.io/pipeline label; Spec.Pipeline is authoritative.
 		var bundles v1alpha1.BundleList
-		if listErr := c.List(ctx, &bundles,
-			sigs_client.InNamespace(ns),
-			sigs_client.MatchingLabels{"kardinal.io/pipeline": pipeline},
-		); listErr != nil {
+		if listErr := c.List(ctx, &bundles, sigs_client.InNamespace(ns)); listErr != nil {
 			return fmt.Errorf("list bundles: %w", listErr)
 		}
 
 		var latest *v1alpha1.Bundle
 		for i := range bundles.Items {
 			b := &bundles.Items[i]
-			if b.Status.Phase != "Verified" {
+			if b.Spec.Pipeline != pipeline || b.Status.Phase != "Verified" {
 				continue
 			}
 			if latest == nil || b.CreationTimestamp.After(latest.CreationTimestamp.Time) {


### PR DESCRIPTION
## Summary

Fixes two CLI arch debt items from docs/design/11-graph-purity-tech-debt.md:

**CLI-3** (`policy.go`): Adds explanatory comment to `policySimulateFn` documenting why the `applies-to` label filtering is done client-side in simulate. The OR-absent condition (global gates with no `applies-to` + env-specific gates) cannot be expressed as a single server-side label selector. This is acceptable for a read-only simulate command. Ref: docs/design/11-graph-purity-tech-debt.md#CLI-3.

**CLI-5** (`rollback.go`): Removes the hardcoded `Type: "image"` in the rollback bundle. Now reads the type from the original bundle being rolled back via `c.Get()`, falling back to `"image"` only if the bundle is unreachable. Also narrows the Verified-bundle List query with a `kardinal.io/pipeline` label selector, moving pipeline filtering to the server.

**Item**: 037-cli-arch-cleanup  
**Closes**: #152

## Tests

- `TestRollback_CopiesTypeFromOriginalBundle`: config bundle rollback copies type=config
- `TestRollback_CopiesTypeWhenExplicitToBundle`: explicit --to bundle copies type=mixed
- `TestPolicySimulate_GlobalGateAppliedToAllEnvs`: global gate (no applies-to) evaluated
- `TestPolicySimulate_EnvSpecificGateExcluded`: env-specific gate excluded for other env