### PR TITLE
feat(scm): implement GitLab SCM provider (#120)

### DIFF
--- a/cmd/kardinal-controller/main.go
+++ b/cmd/kardinal-controller/main.go
@@ -71,6 +71,8 @@ func main() {
 		policyNamespaces       string
 		githubToken            string
 		webhookSecret          string
+		scmProviderType        string
+		scmAPIURL              string
 	)
 
 	flag.BoolVar(&leaderElect, "leader-elect", false,
@@ -86,9 +88,13 @@ func main() {
 	flag.StringVar(&policyNamespaces, "policy-namespaces", "platform-policies",
 		"Comma-separated list of namespaces to scan for org-level PolicyGates.")
 	flag.StringVar(&githubToken, "github-token", os.Getenv("GITHUB_TOKEN"),
-		"GitHub personal access token for SCM operations.")
+		"SCM token for API operations (GitHub PAT or GitLab private token).")
 	flag.StringVar(&webhookSecret, "webhook-secret", os.Getenv("KARDINAL_WEBHOOK_SECRET"),
-		"HMAC secret for validating incoming SCM webhooks.")
+		"Secret for validating incoming SCM webhooks (HMAC for GitHub, plaintext token for GitLab).")
+	flag.StringVar(&scmProviderType, "scm-provider", os.Getenv("KARDINAL_SCM_PROVIDER"),
+		"SCM provider type: \"github\" (default) or \"gitlab\".")
+	flag.StringVar(&scmAPIURL, "scm-api-url", os.Getenv("KARDINAL_SCM_API_URL"),
+		"SCM API base URL override (e.g. for GitHub Enterprise or self-managed GitLab).")
 
 	var bundleToken string
 	flag.StringVar(&bundleToken, "bundle-api-token", os.Getenv("KARDINAL_BUNDLE_TOKEN"),
@@ -126,8 +132,11 @@ func main() {
 		logger.Fatal().Err(err).Msg("unable to create manager")
 	}
 
-	// SCM provider (GitHub with token from flag or env).
-	scmProvider := scm.NewGitHubProvider(githubToken, "", webhookSecret)
+	// SCM provider — dispatches to GitHub or GitLab based on --scm-provider flag.
+	scmProvider, err := scm.NewProvider(scmProviderType, githubToken, scmAPIURL, webhookSecret)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("unable to create SCM provider")
+	}
 	gitClient := scm.NewExecGitClient()
 
 	if err := (&bundlereconciler.Reconciler{

--- a/docs/scm-providers.md
+++ b/docs/scm-providers.md
@@ -1,0 +1,157 @@
+# SCM Providers
+
+kardinal-promoter supports multiple Source Control Management (SCM) providers for
+pull request and merge request lifecycle operations. The provider is configured on the
+controller at startup.
+
+## Supported Providers
+
+| Provider | `--scm-provider` value | PR type | Webhook validation |
+|---|---|---|---|
+| GitHub | `github` (default) | Pull Requests | HMAC-SHA256 (`X-Hub-Signature-256`) |
+| GitLab | `gitlab` | Merge Requests | Token comparison (`X-Gitlab-Token`) |
+
+---
+
+## GitHub
+
+### Controller flags
+
+```bash
+kardinal-controller \
+  --scm-provider github \
+  --github-token $GITHUB_TOKEN \
+  --webhook-secret $KARDINAL_WEBHOOK_SECRET
+```
+
+Alternatively, set environment variables:
+
+```bash
+export GITHUB_TOKEN=ghp_...
+export KARDINAL_WEBHOOK_SECRET=my-hmac-secret
+export KARDINAL_SCM_PROVIDER=github
+```
+
+### Required token scopes
+
+| Scope | Purpose |
+|---|---|
+| `repo` | Create/close pull requests, post comments, read PR status |
+| `write:repo_hook` | (Optional) Register webhooks programmatically |
+
+### Webhook configuration
+
+1. In your GitHub repository, go to **Settings → Webhooks → Add webhook**.
+2. Set **Payload URL** to `http://<controller-host>:8083/webhook`.
+3. Set **Content type** to `application/json`.
+4. Set **Secret** to the same value as `--webhook-secret`.
+5. Select **Pull request** events.
+
+### GitHub Enterprise
+
+Use `--scm-api-url` to override the API base URL:
+
+```bash
+kardinal-controller \
+  --scm-provider github \
+  --github-token $GITHUB_TOKEN \
+  --scm-api-url https://github.example.com/api/v3
+```
+
+---
+
+## GitLab
+
+### Controller flags
+
+```bash
+kardinal-controller \
+  --scm-provider gitlab \
+  --github-token $GITLAB_TOKEN \
+  --webhook-secret $KARDINAL_WEBHOOK_SECRET
+```
+
+> Note: `--github-token` is the SCM token for both providers. For GitLab, pass a
+> **private token** (e.g., `glpat-...`) or a project access token.
+
+Alternatively, set environment variables:
+
+```bash
+export GITHUB_TOKEN=glpat-...         # GitLab private token
+export KARDINAL_WEBHOOK_SECRET=my-token
+export KARDINAL_SCM_PROVIDER=gitlab
+export KARDINAL_SCM_API_URL=https://gitlab.com  # or your self-managed URL
+```
+
+### Required token scopes
+
+| Scope | Purpose |
+|---|---|
+| `api` | Full API access — required for MR creation, comments, and label updates |
+
+A **project access token** with `api` scope is recommended over a personal access token
+for production deployments.
+
+### Webhook configuration
+
+1. In your GitLab project, go to **Settings → Webhooks**.
+2. Set **URL** to `http://<controller-host>:8083/webhook`.
+3. Set **Secret token** to the same value as `--webhook-secret`.
+4. Enable **Merge request events**.
+5. Click **Add webhook**.
+
+> GitLab validates webhooks by comparing the `X-Gitlab-Token` header against the
+> configured secret (plaintext comparison, not HMAC).
+
+### Self-managed GitLab
+
+Use `--scm-api-url` to override the API base URL:
+
+```bash
+kardinal-controller \
+  --scm-provider gitlab \
+  --github-token $GITLAB_TOKEN \
+  --scm-api-url https://gitlab.example.com
+```
+
+---
+
+## Pipeline CRD configuration
+
+Set `spec.git.provider` in your Pipeline to document which SCM is used for that pipeline.
+The controller reads the provider from the startup flag, not from the Pipeline CRD.
+
+```yaml
+apiVersion: kardinal.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: my-pipeline
+spec:
+  git:
+    provider: gitlab          # Informational: "github" or "gitlab"
+    repo: "mygroup/myrepo"
+    branch: main
+  environments:
+    - name: dev
+    - name: prod
+      promotionPolicy: pr-review
+```
+
+---
+
+## Adding a new SCM provider
+
+Implement the `SCMProvider` interface in `pkg/scm/` and register it in
+`pkg/scm/factory.go`:
+
+```go
+func NewProvider(providerType, token, apiURL, webhookSecret string) (SCMProvider, error) {
+    switch providerType {
+    case "github", "":
+        return NewGitHubProvider(token, apiURL, webhookSecret), nil
+    case "gitlab":
+        return NewGitLabProvider(token, apiURL, webhookSecret), nil
+    // Add your provider here.
+    }
+}
+```

--- a/pkg/scm/factory.go
+++ b/pkg/scm/factory.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scm
+
+import "fmt"
+
+// NewProvider constructs an SCMProvider for the given provider type.
+// Supported types: "github" (default), "gitlab".
+// Returns an error for unknown provider types.
+func NewProvider(providerType, token, apiURL, webhookSecret string) (SCMProvider, error) {
+	switch providerType {
+	case "github", "":
+		return NewGitHubProvider(token, apiURL, webhookSecret), nil
+	case "gitlab":
+		return NewGitLabProvider(token, apiURL, webhookSecret), nil
+	default:
+		return nil, fmt.Errorf("unknown SCM provider type %q: supported types are \"github\" and \"gitlab\"", providerType)
+	}
+}

--- a/pkg/scm/gitlab.go
+++ b/pkg/scm/gitlab.go
@@ -1,0 +1,254 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scm
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// GitLabProvider implements SCMProvider against the GitLab REST API v4.
+// Requests are authenticated with a private token (PRIVATE-TOKEN header).
+// All methods are safe for concurrent use.
+type GitLabProvider struct {
+	// Token is the GitLab private token (e.g., glpat-...) or project access token.
+	Token string
+
+	// APIURL is the GitLab API base URL. Defaults to "https://gitlab.com" if empty.
+	APIURL string
+
+	// WebhookSecret is the secret token for validating incoming GitLab webhook payloads.
+	// GitLab sends the token in the X-Gitlab-Token header (plaintext comparison).
+	WebhookSecret string
+
+	client *http.Client
+}
+
+// NewGitLabProvider constructs a GitLabProvider with the given token and optional
+// API URL override (for self-managed GitLab instances).
+func NewGitLabProvider(token, apiURL, webhookSecret string) *GitLabProvider {
+	if apiURL == "" {
+		apiURL = "https://gitlab.com"
+	}
+	return &GitLabProvider{
+		Token:         token,
+		APIURL:        strings.TrimRight(apiURL, "/"),
+		WebhookSecret: webhookSecret,
+		client:        &http.Client{},
+	}
+}
+
+// encodeProjectID URL-encodes the repo path (owner/repo → owner%2Frepo) for use
+// in GitLab API paths that require the project ID or URL-encoded namespace/path.
+func encodeProjectID(repo string) string {
+	return url.PathEscape(repo)
+}
+
+// OpenPR creates a GitLab merge request and returns the MR web URL and IID.
+// It is idempotent: if an MR already exists for the source branch, it returns the
+// existing MR's URL and IID rather than failing.
+func (g *GitLabProvider) OpenPR(ctx context.Context, repo, title, body, head, base string) (string, int, error) {
+	projectID := encodeProjectID(repo)
+	payload := map[string]string{
+		"title":         title,
+		"description":   body,
+		"source_branch": head,
+		"target_branch": base,
+	}
+	var result struct {
+		IID    int    `json:"iid"`
+		WebURL string `json:"web_url"`
+		State  string `json:"state"`
+	}
+	if err := g.do(ctx, http.MethodPost,
+		fmt.Sprintf("/api/v4/projects/%s/merge_requests", projectID), payload, &result); err != nil {
+		// GitLab returns 409 Conflict when an MR already exists for the source branch.
+		if isGitLabExistingMRErr(err) {
+			return g.findExistingMR(ctx, repo, head)
+		}
+		return "", 0, fmt.Errorf("open MR %s: %w", repo, err)
+	}
+	return result.WebURL, result.IID, nil
+}
+
+// findExistingMR lists open MRs for the project and returns the one with the matching
+// source branch.
+func (g *GitLabProvider) findExistingMR(ctx context.Context, repo, sourceBranch string) (string, int, error) {
+	projectID := encodeProjectID(repo)
+	var mrs []struct {
+		IID          int    `json:"iid"`
+		WebURL       string `json:"web_url"`
+		SourceBranch string `json:"source_branch"`
+		State        string `json:"state"`
+	}
+	if err := g.do(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v4/projects/%s/merge_requests?state=opened&per_page=100", projectID),
+		nil, &mrs); err != nil {
+		return "", 0, fmt.Errorf("list MRs to find existing %s: %w", sourceBranch, err)
+	}
+	for _, mr := range mrs {
+		if mr.SourceBranch == sourceBranch {
+			return mr.WebURL, mr.IID, nil
+		}
+	}
+	return "", 0, fmt.Errorf("MR already exists for %s but could not find it in open MRs", sourceBranch)
+}
+
+// isGitLabExistingMRErr returns true when GitLab rejected the MR creation with 409
+// because an open MR already exists for the source branch.
+func isGitLabExistingMRErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "409") ||
+		strings.Contains(msg, "already exists") ||
+		strings.Contains(msg, "open merge request")
+}
+
+// ClosePR closes the merge request by setting state_event to "close".
+func (g *GitLabProvider) ClosePR(ctx context.Context, repo string, prNumber int) error {
+	projectID := encodeProjectID(repo)
+	payload := map[string]string{"state_event": "close"}
+	if err := g.do(ctx, http.MethodPut,
+		fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d", projectID, prNumber), payload, nil); err != nil {
+		return fmt.Errorf("close MR %s!%d: %w", repo, prNumber, err)
+	}
+	return nil
+}
+
+// CommentOnPR posts a note (comment) on the merge request.
+func (g *GitLabProvider) CommentOnPR(ctx context.Context, repo string, prNumber int, body string) error {
+	projectID := encodeProjectID(repo)
+	payload := map[string]string{"body": body}
+	if err := g.do(ctx, http.MethodPost,
+		fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d/notes", projectID, prNumber), payload, nil); err != nil {
+		return fmt.Errorf("comment on MR %s!%d: %w", repo, prNumber, err)
+	}
+	return nil
+}
+
+// GetPRStatus returns whether the MR has been merged and whether it is still open.
+func (g *GitLabProvider) GetPRStatus(ctx context.Context, repo string, prNumber int) (bool, bool, error) {
+	projectID := encodeProjectID(repo)
+	var result struct {
+		State string `json:"state"`
+	}
+	if err := g.do(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d", projectID, prNumber), nil, &result); err != nil {
+		return false, false, fmt.Errorf("get MR status %s!%d: %w", repo, prNumber, err)
+	}
+	merged := result.State == "merged"
+	open := result.State == "opened"
+	return merged, open, nil
+}
+
+// ParseWebhookEvent parses a GitLab merge request webhook payload and validates
+// the X-Gitlab-Token header using constant-time comparison.
+// The caller must pass the value of the X-Gitlab-Token header as signature.
+func (g *GitLabProvider) ParseWebhookEvent(payload []byte, signature string) (WebhookEvent, error) {
+	if g.WebhookSecret != "" {
+		// GitLab uses a plaintext token, not HMAC. Constant-time comparison prevents timing attacks.
+		if subtle.ConstantTimeCompare([]byte(signature), []byte(g.WebhookSecret)) != 1 {
+			return WebhookEvent{}, fmt.Errorf("webhook token mismatch")
+		}
+	}
+
+	var raw struct {
+		ObjectKind string `json:"object_kind"`
+		ObjectAttr struct {
+			IID    int    `json:"iid"`
+			State  string `json:"state"`
+			Action string `json:"action"`
+		} `json:"object_attributes"`
+		Project struct {
+			PathWithNamespace string `json:"path_with_namespace"`
+		} `json:"project"`
+	}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return WebhookEvent{}, fmt.Errorf("parse GitLab webhook payload: %w", err)
+	}
+
+	merged := raw.ObjectAttr.State == "merged"
+	return WebhookEvent{
+		EventType:    raw.ObjectKind,
+		PRNumber:     raw.ObjectAttr.IID,
+		RepoFullName: raw.Project.PathWithNamespace,
+		Merged:       merged,
+		Action:       raw.ObjectAttr.Action,
+	}, nil
+}
+
+// AddLabelsToPR applies labels to the merge request by updating the MR with the
+// comma-separated label list.
+func (g *GitLabProvider) AddLabelsToPR(ctx context.Context, repo string, prNumber int, labels []string) error {
+	if len(labels) == 0 {
+		return nil
+	}
+	projectID := encodeProjectID(repo)
+	payload := map[string]string{
+		"labels": strings.Join(labels, ","),
+	}
+	if err := g.do(ctx, http.MethodPut,
+		fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d", projectID, prNumber), payload, nil); err != nil {
+		return fmt.Errorf("add labels to MR %s!%d: %w", repo, prNumber, err)
+	}
+	return nil
+}
+
+// do executes an authenticated GitLab API request.
+func (g *GitLabProvider) do(ctx context.Context, method, path string, body, result interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, g.APIURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("PRIVATE-TOKEN", g.Token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute request %s %s: %w", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("GitLab API %s %s: status %d: %s", method, path, resp.StatusCode, string(raw))
+	}
+
+	if result != nil {
+		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/scm/scm_test.go
+++ b/pkg/scm/scm_test.go
@@ -327,3 +327,254 @@ func TestInjectToken(t *testing.T) {
 	// Error should mention git, not URL injection
 	assert.NotContains(t, err.Error(), "unsupported remote URL")
 }
+
+// ─── GitLab SCM Provider Tests ────────────────────────────────────────────────
+
+func TestGitLabProvider_OpenPR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// GitLab API: POST /api/v4/projects/:id/merge_requests
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "merge_requests")
+		assert.Equal(t, "glpat-test-token", r.Header.Get("PRIVATE-TOKEN"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"iid":     77,
+			"web_url": "https://gitlab.com/owner/repo/-/merge_requests/77",
+			"state":   "opened",
+		})
+	}))
+	defer server.Close()
+
+	p := scm.NewGitLabProvider("glpat-test-token", server.URL, "")
+	url, num, err := p.OpenPR(context.Background(), "owner/repo", "Test MR", "body", "feature", "main")
+	require.NoError(t, err)
+	assert.Equal(t, 77, num)
+	assert.Equal(t, "https://gitlab.com/owner/repo/-/merge_requests/77", url)
+}
+
+func TestGitLabProvider_OpenPR_AlreadyExists(t *testing.T) {
+	// When a MR already exists for the source branch, OpenPR returns the existing MR.
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Method == http.MethodPost {
+			// First call: return 409 Conflict to signal MR exists.
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"message":["Another open merge request already exists for this source branch"]}`))
+			return
+		}
+		// Second call: GET list of open MRs.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"iid":           88,
+				"web_url":       "https://gitlab.com/owner/repo/-/merge_requests/88",
+				"state":         "opened",
+				"source_branch": "feature",
+			},
+		})
+	}))
+	defer server.Close()
+
+	p := scm.NewGitLabProvider("glpat-test-token", server.URL, "")
+	url, num, err := p.OpenPR(context.Background(), "owner/repo", "Test MR", "body", "feature", "main")
+	require.NoError(t, err)
+	assert.Equal(t, 88, num)
+	assert.Equal(t, "https://gitlab.com/owner/repo/-/merge_requests/88", url)
+}
+
+func TestGitLabProvider_ClosePR(t *testing.T) {
+	var capturedMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		assert.Contains(t, r.URL.Path, "merge_requests/42")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"state":"closed"}`))
+	}))
+	defer server.Close()
+
+	p := scm.NewGitLabProvider("glpat-test-token", server.URL, "")
+	require.NoError(t, p.ClosePR(context.Background(), "owner/repo", 42))
+	assert.Equal(t, http.MethodPut, capturedMethod)
+}
+
+func TestGitLabProvider_CommentOnPR(t *testing.T) {
+	var capturedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "notes")
+		var payload map[string]string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		capturedBody = payload["body"]
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	p := scm.NewGitLabProvider("glpat-test-token", server.URL, "")
+	require.NoError(t, p.CommentOnPR(context.Background(), "owner/repo", 42, "hello gitlab"))
+	assert.Equal(t, "hello gitlab", capturedBody)
+}
+
+func TestGitLabProvider_GetPRStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverResponse map[string]interface{}
+		wantMerged     bool
+		wantOpen       bool
+	}{
+		{
+			name:           "opened MR",
+			serverResponse: map[string]interface{}{"state": "opened"},
+			wantMerged:     false,
+			wantOpen:       true,
+		},
+		{
+			name:           "merged MR",
+			serverResponse: map[string]interface{}{"state": "merged"},
+			wantMerged:     true,
+			wantOpen:       false,
+		},
+		{
+			name:           "closed MR",
+			serverResponse: map[string]interface{}{"state": "closed"},
+			wantMerged:     false,
+			wantOpen:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(tc.serverResponse)
+			}))
+			defer server.Close()
+
+			p := scm.NewGitLabProvider("glpat-test-token", server.URL, "")
+			merged, open, err := p.GetPRStatus(context.Background(), "owner/repo", 42)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantMerged, merged)
+			assert.Equal(t, tc.wantOpen, open)
+		})
+	}
+}
+
+func TestGitLabProvider_ParseWebhookEvent_ValidToken(t *testing.T) {
+	secret := "my-gitlab-webhook-secret"
+	payload := []byte(`{
+		"object_kind": "merge_request",
+		"object_attributes": {
+			"iid": 42,
+			"state": "merged",
+			"action": "merge"
+		},
+		"project": {"path_with_namespace": "owner/repo"}
+	}`)
+
+	p := scm.NewGitLabProvider("token", "", secret)
+	event, err := p.ParseWebhookEvent(payload, secret)
+	require.NoError(t, err)
+	assert.Equal(t, "merge_request", event.EventType)
+	assert.Equal(t, 42, event.PRNumber)
+	assert.True(t, event.Merged)
+	assert.Equal(t, "owner/repo", event.RepoFullName)
+	assert.Equal(t, "merge", event.Action)
+}
+
+func TestGitLabProvider_ParseWebhookEvent_InvalidToken(t *testing.T) {
+	p := scm.NewGitLabProvider("token", "", "correct-secret")
+	payload := []byte(`{"object_kind": "merge_request"}`)
+	_, err := p.ParseWebhookEvent(payload, "wrong-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token")
+}
+
+func TestGitLabProvider_ParseWebhookEvent_NoSecret(t *testing.T) {
+	// When no secret is configured, any token passes.
+	p := scm.NewGitLabProvider("token", "", "")
+	payload := []byte(`{
+		"object_kind": "merge_request",
+		"object_attributes": {"iid": 5, "state": "opened", "action": "open"},
+		"project": {"path_with_namespace": "g/r"}
+	}`)
+	event, err := p.ParseWebhookEvent(payload, "anything")
+	require.NoError(t, err)
+	assert.Equal(t, 5, event.PRNumber)
+}
+
+func TestGitLabProvider_AddLabelsToPR(t *testing.T) {
+	var capturedLabels string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Contains(t, r.URL.Path, "merge_requests/42")
+		var payload map[string]string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		capturedLabels = payload["labels"]
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	p := scm.NewGitLabProvider("glpat-test-token", server.URL, "")
+	err := p.AddLabelsToPR(context.Background(), "owner/repo", 42, []string{"kardinal", "kardinal/promotion"})
+	require.NoError(t, err)
+	assert.Contains(t, capturedLabels, "kardinal")
+}
+
+func TestGitLabProvider_AddLabelsToPR_Empty(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	p := scm.NewGitLabProvider("glpat-test-token", server.URL, "")
+	err := p.AddLabelsToPR(context.Background(), "owner/repo", 42, nil)
+	require.NoError(t, err)
+	assert.False(t, called, "no HTTP call for empty labels")
+}
+
+func TestGitLabProvider_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"403 Forbidden"}`))
+	}))
+	defer server.Close()
+
+	p := scm.NewGitLabProvider("bad-token", server.URL, "")
+	_, _, err := p.OpenPR(context.Background(), "owner/repo", "Test", "body", "head", "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+// ─── NewProvider factory tests ────────────────────────────────────────────────
+
+func TestNewProvider_GitHub(t *testing.T) {
+	p, err := scm.NewProvider("github", "token", "https://api.github.com", "")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	// Must implement SCMProvider interface.
+	var _ scm.SCMProvider = p
+}
+
+func TestNewProvider_GitLab(t *testing.T) {
+	p, err := scm.NewProvider("gitlab", "token", "https://gitlab.com", "")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	var _ scm.SCMProvider = p
+}
+
+func TestNewProvider_Unknown(t *testing.T) {
+	_, err := scm.NewProvider("bitbucket", "token", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bitbucket")
+}
+
+func TestNewProvider_EmptyType_DefaultsToGitHub(t *testing.T) {
+	p, err := scm.NewProvider("", "token", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+}

--- a/pkg/scm/scm_test.go
+++ b/pkg/scm/scm_test.go
@@ -555,16 +555,14 @@ func TestGitLabProvider_APIError(t *testing.T) {
 func TestNewProvider_GitHub(t *testing.T) {
 	p, err := scm.NewProvider("github", "token", "https://api.github.com", "")
 	require.NoError(t, err)
+	// require.NotNil also verifies the interface is non-nil.
 	require.NotNil(t, p)
-	// Must implement SCMProvider interface.
-	var _ scm.SCMProvider = p
 }
 
 func TestNewProvider_GitLab(t *testing.T) {
 	p, err := scm.NewProvider("gitlab", "token", "https://gitlab.com", "")
 	require.NoError(t, err)
 	require.NotNil(t, p)
-	var _ scm.SCMProvider = p
 }
 
 func TestNewProvider_Unknown(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements the GitLab SCM provider (issue #120) needed for Workshop 2 (multi-cluster fleet with GitLab SCM).

### Changes

- **`pkg/scm/gitlab.go`** — `GitLabProvider` implementing all 6 `SCMProvider` methods against GitLab REST API v4:
  - `OpenPR` → `POST /api/v4/projects/:id/merge_requests` (idempotent: returns existing MR on 409)
  - `ClosePR` → `PUT .../merge_requests/:iid` with `state_event=close`
  - `CommentOnPR` → `POST .../merge_requests/:iid/notes`
  - `GetPRStatus` → `GET .../merge_requests/:iid` (state: opened/merged/closed)
  - `ParseWebhookEvent` → `X-Gitlab-Token` constant-time comparison
  - `AddLabelsToPR` → `PUT .../merge_requests/:iid` with comma-separated labels

- **`pkg/scm/factory.go`** — `NewProvider(type, token, apiURL, webhookSecret)` factory: dispatches to `GitHubProvider` or `GitLabProvider`

- **`cmd/kardinal-controller/main.go`** — adds `--scm-provider` (default: `github`) and `--scm-api-url` flags; uses `NewProvider` instead of hardcoding `NewGitHubProvider`

- **`docs/scm-providers.md`** — new: GitHub and GitLab configuration docs with token scopes and webhook setup

### Tests

28 tests total (all passing). New GitLab tests:
- `TestGitLabProvider_OpenPR` — success + already-exists (idempotent)
- `TestGitLabProvider_ClosePR`, `CommentOnPR`, `GetPRStatus` (table: opened/merged/closed)
- `TestGitLabProvider_ParseWebhookEvent` — valid token, wrong token, no secret
- `TestGitLabProvider_AddLabelsToPR` — labels + empty
- `TestGitLabProvider_APIError`
- `TestNewProvider_GitHub`, `GitLab`, `Unknown`, `EmptyType`

Closes #120