### PR TITLE
[STANDALONE-REFACTOR] fix(policygate): add MetricCheck Watch to make reconciler event-driven

### DIFF
--- a/pkg/reconciler/policygate/reconciler.go
+++ b/pkg/reconciler/policygate/reconciler.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	"github.com/kardinal-promoter/kardinal-promoter/pkg/cel"
@@ -234,9 +236,44 @@ func (r *Reconciler) now() time.Time {
 }
 
 // SetupWithManager registers the PolicyGateReconciler with the controller-runtime Manager.
+// It adds a Watch on MetricCheck objects so that when any MetricCheck in a namespace
+// changes (status updated by the MetricCheckReconciler), all PolicyGates in that
+// same namespace are queued for re-evaluation. This is the controller-runtime
+// equivalent of a "Watch node" — the PolicyGate reconciler reacts to MetricCheck
+// status changes rather than waiting for recheckInterval alone.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// metricCheckMapper enqueues all PolicyGates in the same namespace as the
+	// changed MetricCheck. This ensures PolicyGates with metrics.* expressions
+	// are re-evaluated immediately when a MetricCheck result changes.
+	metricCheckMapper := func(ctx context.Context, obj client.Object) []reconcile.Request {
+		var gateList kardinalv1alpha1.PolicyGateList
+		if err := r.List(ctx, &gateList, client.InNamespace(obj.GetNamespace())); err != nil {
+			return nil
+		}
+		reqs := make([]reconcile.Request, 0, len(gateList.Items))
+		for _, gate := range gateList.Items {
+			// Only enqueue instance gates (those with a bundle label) —
+			// templates have no bundle label and are always skipped by Reconcile.
+			if gate.Labels[labelBundle] == "" {
+				continue
+			}
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      gate.Name,
+					Namespace: gate.Namespace,
+				},
+			})
+		}
+		return reqs
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kardinalv1alpha1.PolicyGate{}).
+		// Watch MetricCheck objects: when a MetricCheck status changes (Pass/Fail),
+		// all PolicyGates in the same namespace are re-evaluated immediately.
+		// This replaces the polling-only model with an event-driven one,
+		// moving toward the Graph-first Watch node architecture.
+		Watches(&kardinalv1alpha1.MetricCheck{}, handler.EnqueueRequestsFromMapFunc(metricCheckMapper)).
 		Complete(r)
 }
 

--- a/pkg/reconciler/policygate/reconciler_test.go
+++ b/pkg/reconciler/policygate/reconciler_test.go
@@ -454,6 +454,82 @@ func TestPolicyGateReconciler_UpstreamSoakContext_Blocks(t *testing.T) {
 	assert.False(t, got.Status.Ready, "gate must block when uat has only soaked for 10 min (< 30 threshold)")
 }
 
+// TestPolicyGateReconciler_MetricsContext_NamespaceIsolation verifies that
+// buildMetricsContext only includes MetricChecks from the gate's own namespace.
+// A MetricCheck in a different namespace must not appear in the metrics context.
+func TestPolicyGateReconciler_MetricsContext_NamespaceIsolation(t *testing.T) {
+	mcSameNS := makeMetricCheck("error-rate", "default", "0.005", "Pass")
+	// MetricCheck in a different namespace — must NOT appear in metrics context
+	mcOtherNS := makeMetricCheck("error-rate", "other-ns", "0.999", "Fail")
+	gate := makeGateInstance("metric-gate", "default", "nginx-demo-v1",
+		`metrics["error-rate"].result == "Pass"`, "1m")
+	bundle := makeBundle("nginx-demo-v1", "default")
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gate, bundle, mcSameNS, mcOtherNS).
+		WithStatusSubresource(gate, mcSameNS, mcOtherNS).
+		Build()
+
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC) },
+	}
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "metric-gate", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "metric-gate", Namespace: "default"}, &got))
+	// Must pass — the "default" namespace MetricCheck has result=Pass
+	// If it had picked up the "other-ns" one (Fail), this would fail
+	assert.True(t, got.Status.Ready, "gate must pass using only same-namespace MetricChecks")
+}
+
+// TestPolicyGateReconciler_MetricsContext_EmptyWhenNoMetricChecks verifies that
+// a gate not referencing metrics can still evaluate when no MetricChecks exist.
+func TestPolicyGateReconciler_MetricsContext_EmptyWhenNoMetricChecks(t *testing.T) {
+	gate := makeGateInstance("no-metric-gate", "default", "nginx-demo-v1",
+		`!schedule.isWeekend`, "5m")
+	bundle := makeBundle("nginx-demo-v1", "default")
+	// No MetricCheck objects created
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gate, bundle).
+		WithStatusSubresource(gate).
+		Build()
+
+	tuesday := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return tuesday },
+	}
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "no-metric-gate", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "no-metric-gate", Namespace: "default"}, &got))
+	assert.True(t, got.Status.Ready, "schedule gate must pass on weekday even with empty metrics context")
+}
+
 // TestPolicyGateReconciler_UpstreamSoakContext_ZeroWhenNotHealthChecked verifies
 // soakMinutes is 0 when HealthCheckedAt is nil.
 func TestPolicyGateReconciler_UpstreamSoakContext_ZeroWhenNotHealthChecked(t *testing.T) {


### PR DESCRIPTION
Fixes #131

[🔨 Refactor Agent]

Add controller-runtime Watches on MetricCheck objects in SetupWithManager so that PolicyGate instances are immediately re-evaluated when MetricCheck status changes. Moves toward Graph-first Watch node pattern.

**Scope**: Graph purity
**Packages modified**: pkg/reconciler/policygate