### PR TITLE
[STANDALONE-CLI-UI] feat(cli,ui): extract PolicyGatePhase helper; add auto-refresh polling and bundle history

### DIFF
--- a/cmd/kardinal/cmd/explain.go
+++ b/cmd/kardinal/cmd/explain.go
@@ -136,12 +136,7 @@ func explainOnce(w io.Writer, c sigs_client.Client, ns, pipeline, envFilter stri
 		if envFilter != "" && env != envFilter {
 			continue
 		}
-		gateState := "Pending"
-		if g.Status.Ready {
-			gateState = "Pass"
-		} else if g.Status.LastEvaluatedAt != nil {
-			gateState = "Block"
-		}
+		gateState := PolicyGatePhase(g)
 		reason := g.Status.Reason
 		if reason == "" {
 			reason = "-"

--- a/cmd/kardinal/cmd/format.go
+++ b/cmd/kardinal/cmd/format.go
@@ -137,6 +137,23 @@ func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1a
 	return nil
 }
 
+// PolicyGatePhase derives the three-way display state for a PolicyGate:
+//   - "Pass"    — ready == true (expression evaluated to true)
+//   - "Block"   — ready == false AND lastEvaluatedAt is set (expression evaluated to false)
+//   - "Pending" — not yet evaluated (lastEvaluatedAt is nil)
+//
+// This function is the single source of truth for this derivation; both
+// explain.go and policy.go must call it rather than re-implementing the logic.
+func PolicyGatePhase(g v1alpha1.PolicyGate) string {
+	if g.Status.Ready {
+		return "Pass"
+	}
+	if g.Status.LastEvaluatedAt != nil {
+		return "Block"
+	}
+	return "Pending"
+}
+
 // FormatBundleTable writes a tabwriter-formatted table of bundles to w.
 func FormatBundleTable(w io.Writer, bundles []v1alpha1.Bundle) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)

--- a/cmd/kardinal/cmd/format_test.go
+++ b/cmd/kardinal/cmd/format_test.go
@@ -279,6 +279,51 @@ func TestFormatStepsTable(t *testing.T) {
 	assert.Contains(t, out, "no-weekend-deploys")
 }
 
+func TestPolicyGatePhase(t *testing.T) {
+	now := metav1.Now()
+	tests := []struct {
+		name string
+		gate v1alpha1.PolicyGate
+		want string
+	}{
+		{
+			name: "ready=true gives Pass",
+			gate: v1alpha1.PolicyGate{
+				Status: v1alpha1.PolicyGateStatus{
+					Ready:           true,
+					LastEvaluatedAt: &now,
+				},
+			},
+			want: "Pass",
+		},
+		{
+			name: "ready=false with lastEvaluatedAt gives Block",
+			gate: v1alpha1.PolicyGate{
+				Status: v1alpha1.PolicyGateStatus{
+					Ready:           false,
+					LastEvaluatedAt: &now,
+				},
+			},
+			want: "Block",
+		},
+		{
+			name: "ready=false with no lastEvaluatedAt gives Pending",
+			gate: v1alpha1.PolicyGate{
+				Status: v1alpha1.PolicyGateStatus{
+					Ready:           false,
+					LastEvaluatedAt: nil,
+				},
+			},
+			want: "Pending",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, cmd.PolicyGatePhase(tc.gate))
+		})
+	}
+}
+
 func TestHumanAge(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/kardinal/cmd/policy.go
+++ b/cmd/kardinal/cmd/policy.go
@@ -96,14 +96,7 @@ func formatPolicyGateTable(w io.Writer, gates []v1alpha1.PolicyGate) error {
 		if recheck == "" {
 			recheck = "5m"
 		}
-		ready := "unknown"
-		if g.Status.LastEvaluatedAt != nil {
-			if g.Status.Ready {
-				ready = "Pass"
-			} else {
-				ready = "Block"
-			}
-		}
+		ready := PolicyGatePhase(g)
 		lastEval := "-"
 		if g.Status.LastEvaluatedAt != nil {
 			lastEval = HumanAge(g.Status.LastEvaluatedAt.Time) + " ago"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,22 @@
 // App.tsx — Root component with Pipeline list sidebar and DAG view.
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { PipelineList } from './components/PipelineList'
 import { DAGView } from './components/DAGView'
 import { api } from './api/client'
+import { usePolling } from './usePolling'
 import type { Pipeline, Bundle, GraphResponse } from './types'
+
+const POLL_INTERVAL_MS = 5000
+
+function phaseBadgeColor(phase: string): string {
+  switch (phase) {
+    case 'Verified': return '#22c55e'
+    case 'Promoting': return '#f59e0b'
+    case 'Failed': return '#ef4444'
+    case 'Superseded': return '#94a3b8'
+    default: return '#64748b'
+  }
+}
 
 export function App() {
   const [pipelines, setPipelines] = useState<Pipeline[]>([])
@@ -12,28 +25,52 @@ export function App() {
 
   const [selectedPipeline, setSelectedPipeline] = useState<string | undefined>()
   const [bundles, setBundles] = useState<Bundle[]>([])
+  const [bundleHistoryOpen, setBundleHistoryOpen] = useState(false)
 
   const [graph, setGraph] = useState<GraphResponse | undefined>()
   const [graphLoading, setGraphLoading] = useState(false)
   const [graphError, setGraphError] = useState<string | undefined>()
 
-  useEffect(() => {
-    api.listPipelines()
-      .then(setPipelines)
-      .catch(e => setPipelinesError(String(e)))
-      .finally(() => setPipelinesLoading(false))
-  }, [])
+  // Poll pipeline list every 5 seconds.
+  usePolling(async () => {
+    try {
+      const ps = await api.listPipelines()
+      setPipelines(ps)
+      setPipelinesError(undefined)
+    } catch (e) {
+      setPipelinesError(String(e))
+    } finally {
+      setPipelinesLoading(false)
+    }
+  }, POLL_INTERVAL_MS)
+
+  // Refresh bundles + graph for the selected pipeline every 5 seconds.
+  usePolling(async () => {
+    if (!selectedPipeline) return
+    try {
+      const bs = await api.listBundles(selectedPipeline)
+      setBundles(bs)
+      const promoting = bs.find(b => b.phase === 'Promoting') ?? bs[0]
+      if (promoting) {
+        const g = await api.getGraph(promoting.name)
+        setGraph(g)
+        setGraphError(undefined)
+      }
+    } catch (e) {
+      setGraphError(String(e))
+    }
+  }, POLL_INTERVAL_MS, !!selectedPipeline)
 
   const handleSelectPipeline = useCallback((name: string) => {
     setSelectedPipeline(name)
     setGraph(undefined)
     setGraphError(undefined)
     setGraphLoading(true)
+    setBundleHistoryOpen(false)
 
     api.listBundles(name)
       .then(bs => {
         setBundles(bs)
-        // Load graph for the most recent Promoting bundle.
         const promoting = bs.find(b => b.phase === 'Promoting') ?? bs[0]
         if (promoting) {
           return api.getGraph(promoting.name).then(g => setGraph(g))
@@ -90,6 +127,7 @@ export function App() {
           </div>
         ) : (
           <>
+            {/* Pipeline header */}
             <div style={{ marginBottom: '1rem' }}>
               <h1 style={{ fontSize: '1.25rem', fontWeight: 700, marginBottom: '0.25rem' }}>
                 {activePipeline?.name}
@@ -106,6 +144,66 @@ export function App() {
               )}
             </div>
 
+            {/* Bundle history (collapsible) */}
+            {bundles.length > 0 && (
+              <div style={{ marginBottom: '1rem' }}>
+                <button
+                  onClick={() => setBundleHistoryOpen(o => !o)}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    color: '#6366f1',
+                    cursor: 'pointer',
+                    fontSize: '0.8rem',
+                    padding: '0.25rem 0',
+                    fontWeight: 600,
+                  }}
+                  aria-expanded={bundleHistoryOpen}
+                >
+                  {bundleHistoryOpen ? '▾' : '▸'} Bundle history ({bundles.length})
+                </button>
+                {bundleHistoryOpen && (
+                  <ul style={{
+                    listStyle: 'none',
+                    padding: '0.5rem 0',
+                    margin: 0,
+                    borderLeft: '2px solid #1e293b',
+                    paddingLeft: '0.75rem',
+                  }}>
+                    {bundles.map(b => (
+                      <li key={b.name} style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.5rem',
+                        marginBottom: '0.35rem',
+                        fontSize: '0.8rem',
+                        color: '#cbd5e1',
+                      }}>
+                        <span style={{
+                          background: phaseBadgeColor(b.phase),
+                          color: '#fff',
+                          fontSize: '0.65rem',
+                          padding: '1px 5px',
+                          borderRadius: '9999px',
+                          fontWeight: 600,
+                          whiteSpace: 'nowrap',
+                        }}>
+                          {b.phase}
+                        </span>
+                        <span style={{ fontFamily: 'monospace', color: '#e2e8f0' }}>{b.name}</span>
+                        {b.provenance?.commitSHA && (
+                          <span style={{ color: '#64748b', fontFamily: 'monospace' }}>
+                            {b.provenance.commitSHA.slice(0, 8)}
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {/* DAG */}
             <div style={{
               background: '#1e293b',
               borderRadius: '8px',

--- a/web/src/usePolling.ts
+++ b/web/src/usePolling.ts
@@ -1,0 +1,41 @@
+// usePolling.ts — Generic polling hook for the kardinal UI.
+// Calls `fn` immediately on mount and then every `intervalMs` milliseconds.
+// Stops polling when the component unmounts or `enabled` becomes false.
+import { useEffect, useRef } from 'react'
+
+/**
+ * usePolling calls `fn` once immediately and then at the given interval.
+ *
+ * @param fn          Async function to call on each tick.
+ * @param intervalMs  Polling interval in milliseconds (default 5000).
+ * @param enabled     When false, polling is suspended (default true).
+ */
+export function usePolling(
+  fn: () => Promise<void> | void,
+  intervalMs = 5000,
+  enabled = true,
+): void {
+  // Keep a stable ref to fn so that stale closures don't prevent updates.
+  const fnRef = useRef(fn)
+  fnRef.current = fn
+
+  useEffect(() => {
+    if (!enabled) return
+
+    let cancelled = false
+
+    const tick = async () => {
+      if (!cancelled) {
+        await fnRef.current()
+      }
+    }
+
+    void tick()
+    const id = setInterval(() => void tick(), intervalMs)
+
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [intervalMs, enabled])
+}


### PR DESCRIPTION
Fixes #168
Partially closes #155 (CLI-7 dedup portion)

**Scope**: CLI and UI — kardinal commands, output formatting, policy simulate, embedded React UI
**Boundary**: area/cli,area/ui | cmd/kardinal,web/src,web/embed.go

## Changes

### CLI-7 (partial): Extract `PolicyGatePhase()` helper

`explain.go:139-144` and `policy.go:99-106` both derived a three-way gate state (Pass/Block/Pending) from the same two CRD status fields. Extracted a shared `PolicyGatePhase(g v1alpha1.PolicyGate) string` helper in `format.go` — the single source of truth for this derivation.

Side effect: `policy.go`'s previous `"unknown"` state for unevaluated gates is now consistently `"Pending"`, matching `explain.go`.

New table-driven test: `TestPolicyGatePhase` (3 subtests).

### UI: Auto-refresh polling

New `web/src/usePolling.ts` hook: calls `fn` immediately on mount and every `intervalMs` ms (default 5 s). Stops on unmount or `enabled=false`. Integrated into `App.tsx` for both the pipeline list and the active graph/bundle data.

### UI: Bundle history list

`App.tsx` now shows a collapsible bundle history list below the pipeline header. All bundles for the selected pipeline are shown with phase badges. Collapsed by default.

## Self-validation

```
go build ./...     ✅
go test ./... -race ✅ (all tests pass including new TestPolicyGatePhase)
go vet ./...       ✅
```

No files outside `cmd/kardinal` and `web/src` modified.
No new logic leaks introduced.