### PR TITLE
[STANDALONE-EXTENSIONS] feat(health): implement Flagger health adapter

### DIFF
--- a/docs/health-adapters.md
+++ b/docs/health-adapters.md
@@ -131,7 +131,7 @@ This adapter is used when `delivery.delegate: argoRollouts` is set on the enviro
 | `Healthy` | Healthy (canary completed successfully) |
 | `Degraded` | Fail (canary failed, Argo Rollouts rolled back) |
 
-## Adapter: flagger (Phase 2)
+## Adapter: flagger
 
 Watches a Flagger Canary's phase.
 

--- a/pkg/health/adapter.go
+++ b/pkg/health/adapter.go
@@ -18,7 +18,7 @@
 // deployment is healthy after a promotion PR is merged.
 //
 // Phase 1 adapters: resource (Deployment), argocd (Argo CD Application), flux (Flux Kustomization).
-// Phase 2 adapters: argoRollouts, flagger.
+// Phase 2 adapters: argoRollouts (Argo Rollouts Rollout), flagger (Flagger Canary).
 package health
 
 import (
@@ -49,7 +49,7 @@ type HealthStatus struct {
 
 // CheckOptions carries the health check configuration for a specific environment.
 type CheckOptions struct {
-	// Type selects the adapter: "resource", "argocd", "flux", "argoRollouts".
+	// Type selects the adapter: "resource", "argocd", "flux", "argoRollouts", "flagger".
 	// Empty means auto-detect.
 	Type string
 
@@ -64,6 +64,9 @@ type CheckOptions struct {
 
 	// ArgoRollouts configuration (for type: argoRollouts).
 	ArgoRollouts ArgoRolloutsConfig
+
+	// Flagger configuration (for type: flagger).
+	Flagger FlaggerConfig
 
 	// Timeout is the maximum time to wait for health. Default: 10 minutes.
 	Timeout time.Duration
@@ -100,6 +103,14 @@ type ArgoRolloutsConfig struct {
 	// Name is the Rollout name. Defaults to pipeline name.
 	Name string
 	// Namespace is the Rollout namespace. Defaults to environment name.
+	Namespace string
+}
+
+// FlaggerConfig is the health check configuration for a Flagger Canary.
+type FlaggerConfig struct {
+	// Name is the Canary name. Defaults to pipeline name.
+	Name string
+	// Namespace is the Canary namespace. Defaults to environment name.
 	Namespace string
 }
 
@@ -371,6 +382,72 @@ func (a *ArgoRolloutsAdapter) Check(ctx context.Context, opts CheckOptions) (Hea
 	return HealthStatus{Healthy: false, Reason: reason, CheckedAt: time.Now()}, nil
 }
 
+// --- FlaggerAdapter ---
+
+// FlaggerAdapter checks Flagger Canary health status.
+// A Canary is healthy when status.phase == "Succeeded".
+// Uses the dynamic client to avoid a compile-time dependency on the Flagger SDK.
+type FlaggerAdapter struct {
+	dynamic dynamic.Interface
+}
+
+// NewFlaggerAdapter constructs a FlaggerAdapter.
+func NewFlaggerAdapter(dynClient dynamic.Interface) *FlaggerAdapter {
+	return &FlaggerAdapter{dynamic: dynClient}
+}
+
+// Name returns "flagger".
+func (a *FlaggerAdapter) Name() string { return "flagger" }
+
+var flaggerGVR = schema.GroupVersionResource{
+	Group:    "flagger.app",
+	Version:  "v1beta1",
+	Resource: "canaries",
+}
+
+// Check verifies that the Flagger Canary is in the Succeeded phase.
+func (a *FlaggerAdapter) Check(ctx context.Context, opts CheckOptions) (HealthStatus, error) {
+	cfg := opts.Flagger
+	if cfg.Namespace == "" {
+		cfg.Namespace = "default"
+	}
+	if cfg.Name == "" {
+		return HealthStatus{Healthy: false, Reason: "Flagger.Name not configured", CheckedAt: time.Now()}, nil
+	}
+
+	canary, err := a.dynamic.Resource(flaggerGVR).
+		Namespace(cfg.Namespace).
+		Get(ctx, cfg.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return HealthStatus{
+				Healthy:   false,
+				Reason:    fmt.Sprintf("Canary %s/%s not found", cfg.Namespace, cfg.Name),
+				CheckedAt: time.Now(),
+			}, nil
+		}
+		return HealthStatus{}, fmt.Errorf("get canary %s/%s: %w", cfg.Namespace, cfg.Name, err)
+	}
+
+	phase, _, _ := unstructured.NestedString(canary.Object, "status", "phase")
+	message, _, _ := unstructured.NestedString(canary.Object, "status", "canaryWeight")
+	statusMessage, _, _ := unstructured.NestedString(canary.Object, "status", "failedChecks")
+
+	if phase == "Succeeded" {
+		reason := "Canary phase: Succeeded"
+		return HealthStatus{Healthy: true, Reason: reason, CheckedAt: time.Now()}, nil
+	}
+
+	reason := fmt.Sprintf("Canary phase: %s", phase)
+	if message != "" {
+		reason += fmt.Sprintf(" (canaryWeight: %s)", message)
+	}
+	if statusMessage != "" {
+		reason += fmt.Sprintf(" failedChecks: %s", statusMessage)
+	}
+	return HealthStatus{Healthy: false, Reason: reason, CheckedAt: time.Now()}, nil
+}
+
 // --- AutoDetector ---
 
 // AutoDetector selects the appropriate health adapter based on what is available
@@ -395,6 +472,8 @@ func (d *AutoDetector) Select(ctx context.Context, healthType string) (Adapter, 
 		return NewFluxAdapter(d.dynamic), nil
 	case "argoRollouts":
 		return NewArgoRolloutsAdapter(d.dynamic), nil
+	case "flagger":
+		return NewFlaggerAdapter(d.dynamic), nil
 	case "resource", "":
 		// Auto-detect: try argocd, then flux, fall back to resource.
 		if healthType == "" {

--- a/pkg/health/adapter.go
+++ b/pkg/health/adapter.go
@@ -430,20 +430,15 @@ func (a *FlaggerAdapter) Check(ctx context.Context, opts CheckOptions) (HealthSt
 	}
 
 	phase, _, _ := unstructured.NestedString(canary.Object, "status", "phase")
-	message, _, _ := unstructured.NestedString(canary.Object, "status", "canaryWeight")
-	statusMessage, _, _ := unstructured.NestedString(canary.Object, "status", "failedChecks")
+	statusMsg, _, _ := unstructured.NestedString(canary.Object, "status", "lastTransitionTime")
 
 	if phase == "Succeeded" {
-		reason := "Canary phase: Succeeded"
-		return HealthStatus{Healthy: true, Reason: reason, CheckedAt: time.Now()}, nil
+		return HealthStatus{Healthy: true, Reason: "Canary phase: Succeeded", CheckedAt: time.Now()}, nil
 	}
 
 	reason := fmt.Sprintf("Canary phase: %s", phase)
-	if message != "" {
-		reason += fmt.Sprintf(" (canaryWeight: %s)", message)
-	}
-	if statusMessage != "" {
-		reason += fmt.Sprintf(" failedChecks: %s", statusMessage)
+	if statusMsg != "" {
+		reason += fmt.Sprintf(" (lastTransition: %s)", statusMsg)
 	}
 	return HealthStatus{Healthy: false, Reason: reason, CheckedAt: time.Now()}, nil
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -363,3 +363,110 @@ func TestAutoDetector_ArgoRolloutsType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "argoRollouts", adapter.Name())
 }
+
+// TestFlaggerAdapter_Succeeded verifies that a Canary with phase=Succeeded is Healthy.
+func TestFlaggerAdapter_Succeeded(t *testing.T) {
+	canary := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "flagger.app/v1beta1",
+			"kind":       "Canary",
+			"metadata":   map[string]interface{}{"name": "my-app", "namespace": "prod"},
+			"status": map[string]interface{}{
+				"phase": "Succeeded",
+			},
+		},
+	}
+	canary.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "flagger.app",
+		Version: "v1beta1",
+		Kind:    "Canary",
+	})
+
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), canary)
+
+	adapter := health.NewFlaggerAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		Flagger: health.FlaggerConfig{Name: "my-app", Namespace: "prod"},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Healthy)
+	assert.Contains(t, result.Reason, "Succeeded")
+}
+
+// TestFlaggerAdapter_Failed verifies that a Canary with phase=Failed is Unhealthy.
+func TestFlaggerAdapter_Failed(t *testing.T) {
+	canary := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "flagger.app/v1beta1",
+			"kind":       "Canary",
+			"metadata":   map[string]interface{}{"name": "my-app", "namespace": "prod"},
+			"status": map[string]interface{}{
+				"phase": "Failed",
+			},
+		},
+	}
+	canary.SetGroupVersionKind(schema.GroupVersionKind{Group: "flagger.app", Version: "v1beta1", Kind: "Canary"})
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), canary)
+
+	adapter := health.NewFlaggerAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		Flagger: health.FlaggerConfig{Name: "my-app", Namespace: "prod"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy)
+	assert.Contains(t, result.Reason, "Failed")
+}
+
+// TestFlaggerAdapter_Progressing verifies that a Canary in Progressing phase is Unhealthy.
+func TestFlaggerAdapter_Progressing(t *testing.T) {
+	canary := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "flagger.app/v1beta1",
+			"kind":       "Canary",
+			"metadata":   map[string]interface{}{"name": "my-app", "namespace": "prod"},
+			"status": map[string]interface{}{
+				"phase": "Progressing",
+			},
+		},
+	}
+	canary.SetGroupVersionKind(schema.GroupVersionKind{Group: "flagger.app", Version: "v1beta1", Kind: "Canary"})
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), canary)
+
+	adapter := health.NewFlaggerAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		Flagger: health.FlaggerConfig{Name: "my-app", Namespace: "prod"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy)
+	assert.Contains(t, result.Reason, "Progressing")
+}
+
+// TestFlaggerAdapter_NotFound verifies that a missing Canary returns Unhealthy.
+func TestFlaggerAdapter_NotFound(t *testing.T) {
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+	adapter := health.NewFlaggerAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		Flagger: health.FlaggerConfig{Name: "missing", Namespace: "prod"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy)
+	assert.Contains(t, result.Reason, "not found")
+}
+
+// TestAutoDetector_FlaggerType verifies that explicit "flagger" type returns a FlaggerAdapter.
+func TestAutoDetector_FlaggerType(t *testing.T) {
+	s := buildScheme(t)
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	detector := health.NewAutoDetector(c, dynClient)
+
+	adapter, err := detector.Select(context.Background(), "flagger")
+	require.NoError(t, err)
+	assert.Equal(t, "flagger", adapter.Name())
+}


### PR DESCRIPTION
Fixes #175

[🔨 Extensions Agent] Implements FlaggerAdapter in pkg/health — Flagger Canary health checks. Phase 2 health adapter listed in vision F5.

**Changes**: FlaggerConfig + FlaggerAdapter + 5 tests + docs update.
**Boundary**: area/health | pkg/health | v0.4.0
**No logic leaks**: read-only adapter, same pattern as ArgoRolloutsAdapter (PR #163).