### PR TITLE
[STANDALONE-CORE] fix(steps): replace blocking time.After retries with non-blocking ctrl.Result{RequeueAfter}

### DIFF
--- a/pkg/reconciler/promotionstep/reconciler.go
+++ b/pkg/reconciler/promotionstep/reconciler.go
@@ -279,27 +279,37 @@ func (r *Reconciler) handlePromoting(ctx context.Context, log zerolog.Logger, ps
 
 	switch result.Status {
 	case steps.StepPending:
-		// A step is pending (e.g., open-pr step returns Pending while waiting).
-		// Transition to WaitingForMerge. Also patch the PRStatus CRD with PR data
-		// so the PRStatusReconciler can start polling GitHub.
-		ps.Status.State = StateWaitingForMerge
-		prURL := ""
-		if u, ok := state.Outputs["prURL"]; ok && u != "" {
-			prURL = u
+		prURL, hasPRURL := state.Outputs["prURL"]
+		if hasPRURL && prURL != "" {
+			// The open-pr step (or similar) has opened a PR and is waiting for merge.
+			// Transition to WaitingForMerge so the PRStatusReconciler can take over.
+			ps.Status.State = StateWaitingForMerge
 			ps.Status.PRURL = prURL
+			ps.Status.Message = result.Message
+			if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
+				return ctrl.Result{}, fmt.Errorf("patch waiting-for-merge: %w", patchErr)
+			}
+			// Patch the PRStatus CRD spec so PRStatusReconciler can poll it.
+			// This is idempotent — if prStatusRef is not set, skip gracefully.
+			if ps.Spec.PRStatusRef != "" {
+				if prErr := r.patchPRStatusSpec(ctx, ps, state.Outputs); prErr != nil {
+					log.Warn().Err(prErr).Msg("failed to patch PRStatus spec (non-fatal)")
+				}
+			}
+			return ctrl.Result{RequeueAfter: requeueWaitForMerge}, nil
 		}
+
+		// No prURL — this is a non-blocking retry (e.g. custom webhook 5xx backoff).
+		// Stay in Promoting state; use the step's requested RequeueAfter duration if set.
 		ps.Status.Message = result.Message
 		if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
-			return ctrl.Result{}, fmt.Errorf("patch waiting-for-merge: %w", patchErr)
+			return ctrl.Result{}, fmt.Errorf("patch promoting retry: %w", patchErr)
 		}
-		// Patch the PRStatus CRD spec so PRStatusReconciler can poll it.
-		// This is idempotent — if prStatusRef is not set, skip gracefully.
-		if ps.Spec.PRStatusRef != "" && prURL != "" {
-			if prErr := r.patchPRStatusSpec(ctx, ps, state.Outputs); prErr != nil {
-				log.Warn().Err(prErr).Msg("failed to patch PRStatus spec (non-fatal)")
-			}
+		requeue := result.RequeueAfter
+		if requeue == 0 {
+			return ctrl.Result{Requeue: true}, nil
 		}
-		return ctrl.Result{RequeueAfter: requeueWaitForMerge}, nil
+		return ctrl.Result{RequeueAfter: requeue}, nil
 
 	case steps.StepSuccess:
 		if nextIdx >= len(seq) {

--- a/pkg/steps/custom.go
+++ b/pkg/steps/custom.go
@@ -41,16 +41,29 @@ const (
 	// defaultWebhookTimeout is the default timeout when none is specified.
 	defaultWebhookTimeout = 300 * time.Second
 
-	// maxRetries is the number of retry attempts for 5xx errors.
+	// maxRetries is the maximum number of retry attempts for 5xx errors.
 	maxRetries = 3
 
-	// retryBackoff is the wait duration between retries.
-	retryBackoff = 30 * time.Second
+	// RetryBackoff is the wait duration between retries.
+	// Exported so tests can assert that StepResult.RequeueAfter is set correctly.
+	// Instead of blocking with time.After, the step returns StepPending with
+	// RequeueAfter=RetryBackoff, letting controller-runtime handle the delay.
+	RetryBackoff = 30 * time.Second
 )
+
+// outputKeyRetryAttempt is the state.Outputs key used to persist retry attempt count
+// across reconcile iterations. Prefixed with "_custom." to avoid collision with
+// step-provided outputs.
+const outputKeyRetryAttempt = "_custom.retryAttempt"
 
 // CustomWebhookStep dispatches a custom promotion step via HTTP POST.
 // The step name is any non-built-in uses: value from the Pipeline spec.
 // Configuration (URL, timeout, auth) is passed via PromotionStep.Spec.Inputs.
+//
+// Non-blocking retries: on 5xx responses the step returns StepPending with
+// RequeueAfter=retryBackoff. The attempt count is stored in state.Outputs
+// (persisted to PromotionStep.status.outputs) so retries survive controller restarts.
+// This eliminates the time.After blocking sleep that was previously in Execute().
 type CustomWebhookStep struct {
 	// stepName is the step name (the uses: value from the Pipeline spec).
 	stepName string
@@ -88,6 +101,13 @@ type webhookResponse struct {
 
 // Execute sends a POST request to the webhook URL and interprets the response.
 // Idempotent: safe to call multiple times (webhook server must also be idempotent).
+//
+// Retry behaviour (Graph-first, non-blocking):
+//   - On 5xx or network error: increment attempt counter in state.Outputs (persisted to
+//     PromotionStep.status.outputs by the reconciler), return StepPending with
+//     RequeueAfter=retryBackoff. Controller-runtime requeueing replaces blocking
+//     time.After — no goroutine is ever blocked.
+//   - After maxRetries failures: return StepFailed.
 func (s *CustomWebhookStep) Execute(ctx context.Context, state *StepState) (StepResult, error) {
 	log := zerolog.Ctx(ctx).With().Str("custom_step", s.stepName).Logger()
 
@@ -112,6 +132,23 @@ func (s *CustomWebhookStep) Execute(ctx context.Context, state *StepState) (Step
 		authHeader = state.Inputs["webhook.authorization"]
 	}
 
+	// Read the current attempt count from persisted outputs.
+	// attempt is 0-indexed: on the first call attempt==0, on first retry attempt==1.
+	attempt := 0
+	if raw, ok := state.Outputs[outputKeyRetryAttempt]; ok {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			attempt = n
+		}
+	}
+
+	// Check if we have exhausted all retries before making another call.
+	if attempt >= maxRetries {
+		msg := fmt.Sprintf("custom step %q: all %d attempts failed — step is permanently failed", s.stepName, maxRetries)
+		return StepResult{Status: StepFailed, Message: msg}, nil
+	}
+
+	log.Info().Int("attempt", attempt+1).Int("max", maxRetries).Str("url", webhookURL).Msg("invoking custom webhook")
+
 	// Build request body.
 	reqBody := webhookRequest{
 		Bundle:       state.Bundle,
@@ -124,50 +161,45 @@ func (s *CustomWebhookStep) Execute(ctx context.Context, state *StepState) (Step
 		return StepResult{Status: StepFailed, Message: fmt.Sprintf("marshal request: %v", err)}, nil
 	}
 
-	// Execute with retries.
-	var lastErr error
-	var lastStatus int
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		if attempt > 0 {
-			log.Info().Int("attempt", attempt+1).Dur("backoff", retryBackoff).Msg("retrying after backoff")
-			select {
-			case <-ctx.Done():
-				return StepResult{
-					Status:  StepFailed,
-					Message: fmt.Sprintf("custom step %q: context cancelled waiting for retry: %v", s.stepName, ctx.Err()),
-				}, nil
-			case <-time.After(retryBackoff):
-			}
-		}
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	resp, callErr := s.doCall(callCtx, webhookURL, bodyBytes, authHeader)
+	cancel()
 
-		callCtx, cancel := context.WithTimeout(ctx, timeout)
-		resp, callErr := s.doCall(callCtx, webhookURL, bodyBytes, authHeader)
-		cancel()
-
-		if callErr != nil {
-			lastErr = callErr
-			log.Warn().Err(callErr).Int("attempt", attempt+1).Msg("webhook call failed")
-			continue
-		}
-
-		lastStatus = resp.statusCode
-		if resp.statusCode >= 500 {
-			log.Warn().Int("status", resp.statusCode).Int("attempt", attempt+1).Msg("webhook returned 5xx, will retry")
-			lastErr = fmt.Errorf("HTTP %d", resp.statusCode)
-			continue
-		}
-
-		// Non-5xx response — process it.
-		return s.processResponse(resp)
+	if callErr != nil {
+		log.Warn().Err(callErr).Int("attempt", attempt+1).Msg("webhook call failed, scheduling retry")
+		return s.scheduleRetry(state, attempt, fmt.Sprintf("attempt %d/%d: %v", attempt+1, maxRetries, callErr))
 	}
 
-	// All retries exhausted.
-	if lastErr != nil {
-		msg := fmt.Sprintf("custom step %q: all %d attempts failed (last error: %v)", s.stepName, maxRetries, lastErr)
+	if resp.statusCode >= 500 {
+		log.Warn().Int("status", resp.statusCode).Int("attempt", attempt+1).Msg("webhook returned 5xx, scheduling retry")
+		return s.scheduleRetry(state, attempt, fmt.Sprintf("attempt %d/%d: HTTP %d", attempt+1, maxRetries, resp.statusCode))
+	}
+
+	// Non-5xx response — clear the retry counter and process it.
+	delete(state.Outputs, outputKeyRetryAttempt)
+	return s.processResponse(resp)
+}
+
+// scheduleRetry increments the attempt counter in state.Outputs (which are persisted to
+// PromotionStep.status.outputs by the reconciler) and returns StepPending with
+// RequeueAfter=retryBackoff. This is non-blocking: controller-runtime handles the wait.
+func (s *CustomWebhookStep) scheduleRetry(state *StepState, currentAttempt int, reason string) (StepResult, error) {
+	nextAttempt := currentAttempt + 1
+	if state.Outputs == nil {
+		state.Outputs = make(map[string]string)
+	}
+	state.Outputs[outputKeyRetryAttempt] = strconv.Itoa(nextAttempt)
+
+	if nextAttempt >= maxRetries {
+		msg := fmt.Sprintf("custom step %q: all %d attempts failed (last: %s)", s.stepName, maxRetries, reason)
 		return StepResult{Status: StepFailed, Message: msg}, nil
 	}
-	msg := fmt.Sprintf("custom step %q: all %d attempts failed (last HTTP status: %d)", s.stepName, maxRetries, lastStatus)
-	return StepResult{Status: StepFailed, Message: msg}, nil
+
+	return StepResult{
+		Status:       StepPending,
+		Message:      fmt.Sprintf("custom step %q: %s; retry %d/%d after %s", s.stepName, reason, nextAttempt+1, maxRetries, RetryBackoff),
+		RequeueAfter: RetryBackoff,
+	}, nil
 }
 
 // callResult holds the parsed HTTP response.

--- a/pkg/steps/step.go
+++ b/pkg/steps/step.go
@@ -15,6 +15,7 @@ package steps
 
 import (
 	"context"
+	"time"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	"github.com/kardinal-promoter/kardinal-promoter/pkg/scm"
@@ -44,6 +45,11 @@ type StepResult struct {
 
 	// Outputs holds key/value pairs to pass to subsequent steps.
 	Outputs map[string]string
+
+	// RequeueAfter, when set with StepPending, signals to the reconciler how long
+	// to wait before re-executing the step. A zero value means requeue immediately.
+	// Used by steps that need non-blocking retry backoff (e.g. custom webhook retries).
+	RequeueAfter time.Duration
 }
 
 // GitConfig holds Git repository connection details for a step.

--- a/pkg/steps/steps/custom_test.go
+++ b/pkg/steps/steps/custom_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -110,7 +111,9 @@ func TestCustomWebhookStep_Fail(t *testing.T) {
 	assert.Contains(t, result.Message, "integration tests did not pass")
 }
 
-// TestCustomWebhookStep_Timeout verifies that a slow server causes a DeadlineExceeded failure.
+// TestCustomWebhookStep_Timeout verifies that a slow server causes a non-blocking retry
+// (StepPending with RequeueAfter) on the first timeout, not immediate StepFailed.
+// After maxRetries timeouts the step permanently fails.
 func TestCustomWebhookStep_Timeout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Simulate a very slow server that never responds within the timeout.
@@ -119,20 +122,35 @@ func TestCustomWebhookStep_Timeout(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	step := parentsteps.NewCustomWebhookStep("slow-check")
+	step.HTTPClient = &http.Client{}
+
+	// First attempt: timeout → StepPending (non-blocking retry scheduled).
 	state := makeCustomStepState(srv.URL)
 	state.Inputs["webhook.timeoutSeconds"] = "1" // 1 second timeout
-
-	step := parentsteps.NewCustomWebhookStep("slow-check")
-	// Replace HTTP client with one that respects context cancellation quickly.
-	step.HTTPClient = &http.Client{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	result, err := step.Execute(ctx, state)
 	require.NoError(t, err)
-	assert.Equal(t, parentsteps.StepFailed, result.Status)
-	assert.Contains(t, result.Message, "slow-check")
+	assert.Equal(t, parentsteps.StepPending, result.Status, "first timeout should return StepPending (non-blocking retry)")
+	assert.Equal(t, parentsteps.RetryBackoff, result.RequeueAfter, "should request retry backoff requeue")
+	assert.Equal(t, "1", state.Outputs["_custom.retryAttempt"], "attempt counter must be persisted in outputs")
+
+	// Simulate the reconciler persisting outputs and requeueing for attempt 2.
+	state.Inputs["webhook.timeoutSeconds"] = "1"
+
+	result2, err2 := step.Execute(context.Background(), state)
+	require.NoError(t, err2)
+	assert.Equal(t, parentsteps.StepPending, result2.Status, "second timeout should still return StepPending")
+	assert.Equal(t, "2", state.Outputs["_custom.retryAttempt"])
+
+	// Attempt 3 (maxRetries=3, attempt index 2 → next would be 3 = maxRetries): permanently failed.
+	result3, err3 := step.Execute(context.Background(), state)
+	require.NoError(t, err3)
+	assert.Equal(t, parentsteps.StepFailed, result3.Status, "after maxRetries the step must permanently fail")
+	assert.Contains(t, result3.Message, "all 3 attempts failed")
 }
 
 // TestCustomWebhookStep_AuthHeader verifies that the Authorization header is sent from Inputs.
@@ -159,9 +177,10 @@ func TestCustomWebhookStep_AuthHeader(t *testing.T) {
 	assert.Equal(t, "Bearer super-secret-token", capturedAuthHeader)
 }
 
-// TestCustomWebhookStep_5xxRetry verifies that 5xx errors are retried up to maxRetries
-// and eventually return Failed when all attempts fail.
-func TestCustomWebhookStep_5xxRetry(t *testing.T) {
+// TestCustomWebhookStep_5xxRetry_NonBlocking verifies that a 5xx response returns
+// StepPending with RequeueAfter on the first failure — no blocking goroutine sleep.
+// The retry counter is persisted in state.Outputs (which maps to PromotionStep.status.outputs).
+func TestCustomWebhookStep_5xxRetry_NonBlocking(t *testing.T) {
 	var callCount int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&callCount, 1)
@@ -170,25 +189,118 @@ func TestCustomWebhookStep_5xxRetry(t *testing.T) {
 	defer srv.Close()
 
 	state := makeCustomStepState(srv.URL)
-	// Set a tiny timeout to speed up test — retryBackoff won't apply since we
-	// override the client; the retries happen with the context-deadline timeout.
-	state.Inputs["webhook.timeoutSeconds"] = "2"
-
 	step := parentsteps.NewCustomWebhookStep("flaky-check")
-	// Inject a fast client so retries resolve quickly.
 	step.HTTPClient = &http.Client{Timeout: 2 * time.Second}
 
-	// This test is slow because of 3×30s backoff — override by cancelling context
-	// after the first round-trip so we just get an immediate failure without waiting
-	// for all retries.  We verify that 5xx triggers retrying logic.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	// Execute must return within milliseconds — no blocking time.After.
+	start := time.Now()
+	result, err := step.Execute(context.Background(), state)
+	elapsed := time.Since(start)
 
-	result, err := step.Execute(ctx, state)
 	require.NoError(t, err)
-	assert.Equal(t, parentsteps.StepFailed, result.Status)
-	// At least 1 call must have been made.
-	assert.GreaterOrEqual(t, atomic.LoadInt32(&callCount), int32(1))
+	assert.Equal(t, parentsteps.StepPending, result.Status, "5xx on attempt 0 should return StepPending")
+	assert.Equal(t, parentsteps.RetryBackoff, result.RequeueAfter, "should set RequeueAfter for retry backoff")
+	assert.Equal(t, "1", state.Outputs["_custom.retryAttempt"], "attempt counter must be stored in outputs")
+	assert.Less(t, elapsed, 5*time.Second, "Execute must return without blocking for retryBackoff duration")
+	assert.EqualValues(t, 1, atomic.LoadInt32(&callCount), "exactly one HTTP call on first attempt")
+}
+
+// TestCustomWebhookStep_5xxRetryExhausted verifies that after maxRetries 5xx failures
+// the step returns StepFailed.
+func TestCustomWebhookStep_5xxRetryExhausted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	step := parentsteps.NewCustomWebhookStep("exhausted-check")
+	step.HTTPClient = &http.Client{Timeout: 2 * time.Second}
+
+	// Simulate 3 reconcile cycles (one per attempt, each reconciler iteration persists outputs).
+	// The reconciler restores state.Outputs from PromotionStep.status.outputs between cycles.
+	state := makeCustomStepState(srv.URL)
+
+	// Cycle 1: attempt 0 → StepPending, attempt=1 in outputs
+	r1, err := step.Execute(context.Background(), state)
+	require.NoError(t, err)
+	assert.Equal(t, parentsteps.StepPending, r1.Status)
+	assert.Equal(t, "1", state.Outputs["_custom.retryAttempt"])
+
+	// Cycle 2: attempt 1 → StepPending, attempt=2 in outputs
+	r2, err := step.Execute(context.Background(), state)
+	require.NoError(t, err)
+	assert.Equal(t, parentsteps.StepPending, r2.Status)
+	assert.Equal(t, "2", state.Outputs["_custom.retryAttempt"])
+
+	// Cycle 3: attempt 2 → last attempt, StepFailed (nextAttempt=3 == maxRetries)
+	r3, err := step.Execute(context.Background(), state)
+	require.NoError(t, err)
+	assert.Equal(t, parentsteps.StepFailed, r3.Status)
+	assert.Contains(t, r3.Message, "all 3 attempts failed")
+}
+
+// TestCustomWebhookStep_5xxThenPass verifies recovery: after a 5xx the server recovers
+// and returns "pass" on the next reconcile cycle.
+func TestCustomWebhookStep_5xxThenPass(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&callCount, 1)
+		if call == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		// Second call succeeds.
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(webhookResponseBody{ //nolint:errcheck
+			Result:  "pass",
+			Message: "recovered",
+		})
+	}))
+	defer srv.Close()
+
+	step := parentsteps.NewCustomWebhookStep("recovering-check")
+	step.HTTPClient = &http.Client{Timeout: 2 * time.Second}
+
+	// Cycle 1: 5xx → StepPending
+	state := makeCustomStepState(srv.URL)
+	r1, err := step.Execute(context.Background(), state)
+	require.NoError(t, err)
+	assert.Equal(t, parentsteps.StepPending, r1.Status)
+	assert.Equal(t, "1", state.Outputs["_custom.retryAttempt"])
+
+	// Cycle 2: pass → StepSuccess; retry counter cleared from outputs
+	r2, err := step.Execute(context.Background(), state)
+	require.NoError(t, err)
+	assert.Equal(t, parentsteps.StepSuccess, r2.Status)
+	assert.Equal(t, "recovered", r2.Message)
+	assert.Empty(t, state.Outputs["_custom.retryAttempt"], "retry counter must be cleared on success")
+}
+
+// TestCustomWebhookStep_Idempotent verifies that re-executing after a crash
+// (same attempt counter in outputs) does not double-count attempts.
+func TestCustomWebhookStep_Idempotent(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(webhookResponseBody{Result: "pass"})
+	}))
+	defer srv.Close()
+
+	step := parentsteps.NewCustomWebhookStep("idempotent-check")
+	step.HTTPClient = &http.Client{Timeout: 2 * time.Second}
+
+	// Simulate: controller crashed after Execute returned StepPending on attempt 0
+	// but before the reconciler could patch status (attempt counter in outputs = "1").
+	// On restart, state.Outputs is restored from CRD status — still "1".
+	state := makeCustomStepState(srv.URL)
+	state.Outputs["_custom.retryAttempt"] = "1" // pre-loaded from restored CRD outputs
+
+	result, err := step.Execute(context.Background(), state)
+	require.NoError(t, err)
+	// Attempt 1 should now execute (not skip) and succeed.
+	assert.Equal(t, parentsteps.StepSuccess, result.Status)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&callCount), "one HTTP call on retry attempt 1")
 }
 
 // TestCustomWebhookStep_MissingURL verifies that a missing webhook.url input returns Failed.
@@ -223,6 +335,32 @@ func TestCustomWebhookStep_UnexpectedResult(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, parentsteps.StepFailed, result.Status)
 	assert.Contains(t, result.Message, "unexpected result")
+}
+
+// TestCustomWebhookStep_5xxRetryAttemptTrackedInOutputs verifies that the retry counter
+// in state.Outputs is correctly serialised as a decimal integer string (so the reconciler
+// can persist it to PromotionStep.status.outputs which stores map[string]string).
+func TestCustomWebhookStep_5xxRetryAttemptTrackedInOutputs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	step := parentsteps.NewCustomWebhookStep("tracker-check")
+	step.HTTPClient = &http.Client{Timeout: 2 * time.Second}
+
+	state := makeCustomStepState(srv.URL)
+
+	for wantAttempt := 1; wantAttempt <= 2; wantAttempt++ {
+		result, err := step.Execute(context.Background(), state)
+		require.NoError(t, err)
+		assert.Equal(t, parentsteps.StepPending, result.Status)
+		got, ok := state.Outputs["_custom.retryAttempt"]
+		require.True(t, ok, "retry attempt must be present in outputs")
+		n, err := strconv.Atoi(got)
+		require.NoError(t, err, "retry attempt must be a valid integer")
+		assert.Equal(t, wantAttempt, n)
+	}
 }
 
 // TestLookup_CustomStepFallback verifies that Lookup returns a CustomWebhookStep for unknown names.


### PR DESCRIPTION
[🔨 Core Agent] Fixes #135

**Scope**: Core — PromotionStep reconciler fixes
**Boundary**: area/controller | v0.2.1
**Packages modified**: pkg/steps, pkg/reconciler/promotionstep

## Summary

Eliminates ST-4 from docs/design/11-graph-purity-tech-debt.md.

`CustomWebhookStep.Execute()` previously used `time.After(30s)` blocking sleep between 5xx retry attempts inside the reconcile goroutine. This violates the controller-runtime contract which requires reconcilers to return quickly.

### Changes

- `pkg/steps/step.go`: add `RequeueAfter time.Duration` to `StepResult` so steps can signal desired retry delay without blocking
- `pkg/steps/custom.go`: on 5xx/network error, store attempt count in `state.Outputs` (persisted to `PromotionStep.status.outputs` via etcd), return `StepPending` with `RequeueAfter=30s`. No goroutine ever blocks for retryBackoff. Retries survive controller restarts.
- `pkg/reconciler/promotionstep/reconciler.go`: update `StepPending` handler to distinguish PR-wait (prURL in outputs → WaitingForMerge) from retry-with-backoff (no prURL → stay Promoting, honor `RequeueAfter`)

### Architecture

Graph-first compliant: no new logic leaks. Retry state stored in CRD status fields, observable via kubectl.