### PR TITLE
[STANDALONE-REFACTOR] fix(health): remove AutoDetector CRD probing; require explicit health.type

### DIFF
--- a/pkg/health/adapter.go
+++ b/pkg/health/adapter.go
@@ -457,10 +457,16 @@ func NewAutoDetector(k8s sigs_client.Client, dynClient dynamic.Interface) *AutoD
 	return &AutoDetector{k8s: k8s, dynamic: dynClient}
 }
 
-// Select returns the best available adapter for the given health type.
-// If healthType is empty, auto-detects based on installed CRDs.
-func (d *AutoDetector) Select(ctx context.Context, healthType string) (Adapter, error) {
+// Select returns the adapter for the given health type.
+// healthType must be one of: "resource", "argocd", "flux", "argoRollouts", "flagger".
+// An empty or unknown healthType returns an error — health.type must be
+// explicitly configured in Pipeline.spec.environments[*].health.type.
+// Silent fallback (auto-detection via CRD probing) is removed to prevent
+// misconfiguration being silently masked (HE-4 in docs/design/11-graph-purity-tech-debt.md).
+func (d *AutoDetector) Select(_ context.Context, healthType string) (Adapter, error) {
 	switch healthType {
+	case "resource":
+		return NewDeploymentAdapter(d.k8s), nil
 	case "argocd":
 		return NewArgoCDAdapter(d.dynamic), nil
 	case "flux":
@@ -469,30 +475,13 @@ func (d *AutoDetector) Select(ctx context.Context, healthType string) (Adapter, 
 		return NewArgoRolloutsAdapter(d.dynamic), nil
 	case "flagger":
 		return NewFlaggerAdapter(d.dynamic), nil
-	case "resource", "":
-		// Auto-detect: try argocd, then flux, fall back to resource.
-		if healthType == "" {
-			if crdAvailable(ctx, d.dynamic, "applications.argoproj.io") {
-				return NewArgoCDAdapter(d.dynamic), nil
-			}
-			if crdAvailable(ctx, d.dynamic, "kustomizations.kustomize.toolkit.fluxcd.io") {
-				return NewFluxAdapter(d.dynamic), nil
-			}
-		}
-		return NewDeploymentAdapter(d.k8s), nil
+	case "":
+		return nil, fmt.Errorf(
+			"health.type is required in Pipeline spec environments: " +
+				"set health.type to one of [resource, argocd, flux, argoRollouts, flagger]")
 	default:
-		return NewDeploymentAdapter(d.k8s), nil
+		return nil, fmt.Errorf(
+			"unknown health.type %q: must be one of [resource, argocd, flux, argoRollouts, flagger]",
+			healthType)
 	}
-}
-
-// crdAvailable checks whether a CRD (by plural resource name) is installed in the cluster.
-// It uses the dynamic client to attempt a list of the CRD resource at the apiextensions group.
-func crdAvailable(ctx context.Context, dynClient dynamic.Interface, crdName string) bool {
-	crdGVR := schema.GroupVersionResource{
-		Group:    "apiextensions.k8s.io",
-		Version:  "v1",
-		Resource: "customresourcedefinitions",
-	}
-	_, err := dynClient.Resource(crdGVR).Get(ctx, crdName, metav1.GetOptions{})
-	return err == nil
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -254,14 +254,41 @@ func TestFluxAdapter_Progressing(t *testing.T) {
 // TestAutoDetector_SelectsDeploymentWhenNoGitOpsCRDs verifies fallback to Deployment adapter.
 func TestAutoDetector_SelectsDeploymentWhenNoGitOpsCRDs(t *testing.T) {
 	s := buildScheme(t)
-	// No ArgoCD or Flux CRDs
+	// No ArgoCD or Flux CRDs — but explicit "resource" type is provided
 	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
 	c := fake.NewClientBuilder().WithScheme(s).Build()
 
 	detector := health.NewAutoDetector(c, dynClient)
-	adapter, err := detector.Select(context.Background(), "")
+	adapter, err := detector.Select(context.Background(), "resource")
 	require.NoError(t, err)
 	assert.Equal(t, "resource", adapter.Name())
+}
+
+// TestAutoDetector_EmptyTypeReturnsError verifies that an empty health type
+// returns an error instead of silently auto-detecting. Operators must configure
+// health.type explicitly in Pipeline spec to prevent misconfiguration.
+func TestAutoDetector_EmptyTypeReturnsError(t *testing.T) {
+	s := buildScheme(t)
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	detector := health.NewAutoDetector(c, dynClient)
+	_, err := detector.Select(context.Background(), "")
+	require.Error(t, err, "empty health type must return error — health.type must be explicit in Pipeline spec")
+	assert.Contains(t, err.Error(), "health.type")
+}
+
+// TestAutoDetector_UnknownTypeReturnsError verifies that an unknown health type
+// returns an error rather than silently falling back to Deployment.
+func TestAutoDetector_UnknownTypeReturnsError(t *testing.T) {
+	s := buildScheme(t)
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	detector := health.NewAutoDetector(c, dynClient)
+	_, err := detector.Select(context.Background(), "unknownType")
+	require.Error(t, err, "unknown health type must return error")
+	assert.Contains(t, err.Error(), "unknownType")
 }
 
 // TestAutoDetector_PreferredByType verifies explicit type selection.


### PR DESCRIPTION
Fixes #143

[🔨 Refactor Agent]

## Summary

Remove `AutoDetector.Select()` runtime CRD probing (`crdAvailable`) and silent fallback to Deployment adapter. An empty or unrecognized `health.type` now returns a clear error with a message directing operators to configure `Pipeline.spec.environments[*].health.type`.

## Architecture impact (HE-4 from tech debt doc)

Eliminates the live CRD probe (`apiextensions.k8s.io` API call) on every health-check reconcile. The AutoDetector was making a Kubernetes API call on every reconcile pass to probe for ArgoCD/Flux CRDs — this is the HE-4 and HE-5 logic leak.

Operators must now explicitly configure `health.type` in their Pipeline spec. If unset, the PromotionStep reconciler will write a clear error to its status conditions.

## Changes

- `AutoDetector.Select()`: explicit dispatch only; empty/unknown type → error
- Removed `crdAvailable()` function and all runtime CRD probing
- Tests: empty type returns error, unknown type returns error, explicit type still works

**Packages modified**: pkg/health