### PR TITLE
[STANDALONE-EXTENSIONS] feat(scm): implement Forgejo/Gitea SCM provider

### DIFF
--- a/docs/scm-providers.md
+++ b/docs/scm-providers.md
@@ -10,6 +10,8 @@ controller at startup.
 |---|---|---|---|
 | GitHub | `github` (default) | Pull Requests | HMAC-SHA256 (`X-Hub-Signature-256`) |
 | GitLab | `gitlab` | Merge Requests | Token comparison (`X-Gitlab-Token`) |
+| Forgejo / Codeberg | `forgejo` | Pull Requests | HMAC-SHA256 (`X-Gitea-Signature`) |
+| Gitea | `gitea` | Pull Requests | HMAC-SHA256 (`X-Gitea-Signature`) |
 
 ---
 
@@ -116,6 +118,64 @@ kardinal-controller \
 
 ---
 
+## Forgejo / Gitea
+
+Forgejo (including Codeberg.org) and Gitea share the same REST API v1. Use `forgejo`
+for Forgejo instances and `gitea` for Gitea instances — both map to the same provider
+implementation.
+
+### Controller flags
+
+```bash
+kardinal-controller \
+  --scm-provider forgejo \
+  --github-token $FORGEJO_TOKEN \
+  --scm-api-url https://codeberg.org \
+  --webhook-secret $KARDINAL_WEBHOOK_SECRET
+```
+
+Alternatively, set environment variables:
+
+```bash
+export GITHUB_TOKEN=your-forgejo-token
+export KARDINAL_WEBHOOK_SECRET=my-hmac-secret
+export KARDINAL_SCM_PROVIDER=forgejo
+export KARDINAL_SCM_API_URL=https://codeberg.org   # or your self-hosted Forgejo URL
+```
+
+### Required token scopes
+
+| Scope | Purpose |
+|---|---|
+| `write:issue` | Post comments on pull requests |
+| `write:repository` | Create and close pull requests, add labels |
+
+Create an API token in your Forgejo/Gitea instance under **Settings → Applications → Access Tokens**.
+
+### Webhook configuration
+
+1. In your Forgejo/Gitea repository, go to **Settings → Webhooks → Add Webhook → Gitea**.
+2. Set **Target URL** to `http://<controller-host>:8083/webhook`.
+3. Set **Secret** to the same value as `--webhook-secret`.
+4. Select **Pull Request** events.
+5. Click **Add Webhook**.
+
+> Forgejo/Gitea validates webhooks using HMAC-SHA256 (same algorithm as GitHub).
+> The signature is sent in the `X-Gitea-Signature` header.
+
+### Codeberg.org (public Forgejo instance)
+
+Codeberg is the primary public Forgejo instance. Use `--scm-api-url https://codeberg.org`:
+
+```bash
+kardinal-controller \
+  --scm-provider forgejo \
+  --github-token $CODEBERG_TOKEN \
+  --scm-api-url https://codeberg.org
+```
+
+---
+
 ## Pipeline CRD configuration
 
 Set `spec.git.provider` in your Pipeline to document which SCM is used for that pipeline.
@@ -128,8 +188,8 @@ metadata:
   name: my-pipeline
 spec:
   git:
-    provider: gitlab          # Informational: "github" or "gitlab"
-    repo: "mygroup/myrepo"
+    provider: forgejo          # Informational: "github", "gitlab", "forgejo", or "gitea"
+    repo: "myorg/myrepo"
     branch: main
   environments:
     - name: dev

--- a/pkg/scm/factory.go
+++ b/pkg/scm/factory.go
@@ -16,7 +16,7 @@ package scm
 import "fmt"
 
 // NewProvider constructs an SCMProvider for the given provider type.
-// Supported types: "github" (default), "gitlab".
+// Supported types: "github" (default), "gitlab", "forgejo", "gitea".
 // Returns an error for unknown provider types.
 func NewProvider(providerType, token, apiURL, webhookSecret string) (SCMProvider, error) {
 	switch providerType {
@@ -24,7 +24,9 @@ func NewProvider(providerType, token, apiURL, webhookSecret string) (SCMProvider
 		return NewGitHubProvider(token, apiURL, webhookSecret), nil
 	case "gitlab":
 		return NewGitLabProvider(token, apiURL, webhookSecret), nil
+	case "forgejo", "gitea":
+		return NewForgejoProvider(token, apiURL, webhookSecret), nil
 	default:
-		return nil, fmt.Errorf("unknown SCM provider type %q: supported types are \"github\" and \"gitlab\"", providerType)
+		return nil, fmt.Errorf("unknown SCM provider type %q: supported types are \"github\", \"gitlab\", \"forgejo\", \"gitea\"", providerType)
 	}
 }

--- a/pkg/scm/forgejo.go
+++ b/pkg/scm/forgejo.go
@@ -1,0 +1,324 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scm
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ForgejoProvider implements SCMProvider against the Forgejo/Gitea REST API v1.
+// The Forgejo API is compatible with Gitea and uses the same endpoint paths.
+// Requests are authenticated with a token in the Authorization header.
+// All methods are safe for concurrent use.
+type ForgejoProvider struct {
+	// Token is the Forgejo/Gitea API token.
+	Token string
+
+	// APIURL is the Forgejo/Gitea base URL (e.g., "https://forgejo.example.com").
+	// The /api/v1 prefix is appended automatically.
+	APIURL string
+
+	// WebhookSecret is the secret for validating incoming webhook payloads.
+	// Forgejo/Gitea signs payloads with HMAC-SHA256 and sends the result in
+	// the X-Gitea-Signature header (same scheme as GitHub's X-Hub-Signature-256).
+	WebhookSecret string
+
+	client *http.Client
+}
+
+// NewForgejoProvider constructs a ForgejoProvider for the given base URL and token.
+// The apiURL must point to the Forgejo/Gitea instance root (e.g., "https://forgejo.example.com").
+func NewForgejoProvider(token, apiURL, webhookSecret string) *ForgejoProvider {
+	if apiURL == "" {
+		apiURL = "https://codeberg.org" // Codeberg is the primary public Forgejo instance
+	}
+	return &ForgejoProvider{
+		Token:         token,
+		APIURL:        strings.TrimRight(apiURL, "/"),
+		WebhookSecret: webhookSecret,
+		client:        &http.Client{},
+	}
+}
+
+// OpenPR creates a Forgejo pull request and returns the PR URL and number.
+// It is idempotent: if a PR already exists for the head branch, returns the existing PR.
+func (f *ForgejoProvider) OpenPR(ctx context.Context, repo, title, body, head, base string) (string, int, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return "", 0, err
+	}
+
+	payload := map[string]interface{}{
+		"title": title,
+		"body":  body,
+		"head":  head,
+		"base":  base,
+	}
+	var result struct {
+		Number  int    `json:"number"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := f.do(ctx, http.MethodPost,
+		fmt.Sprintf("/api/v1/repos/%s/%s/pulls", owner, name), payload, &result); err != nil {
+		// Forgejo/Gitea returns 409 when a PR already exists for the same head/base.
+		if isForgejoExistingPRErr(err) {
+			return f.findExistingPR(ctx, owner, name, head)
+		}
+		return "", 0, fmt.Errorf("open PR %s: %w", repo, err)
+	}
+	return result.HTMLURL, result.Number, nil
+}
+
+// findExistingPR lists open PRs for the repository and returns the one with the
+// matching head branch.
+func (f *ForgejoProvider) findExistingPR(ctx context.Context, owner, repo, head string) (string, int, error) {
+	var prs []struct {
+		Number  int    `json:"number"`
+		HTMLURL string `json:"html_url"`
+		Head    struct {
+			Label string `json:"label"`
+		} `json:"head"`
+	}
+	if err := f.do(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v1/repos/%s/%s/pulls?state=open&limit=50", owner, repo),
+		nil, &prs); err != nil {
+		return "", 0, fmt.Errorf("list PRs to find existing %s: %w", head, err)
+	}
+	for _, pr := range prs {
+		// The head label is "owner:branch" in Forgejo
+		if pr.Head.Label == head || strings.HasSuffix(pr.Head.Label, ":"+head) {
+			return pr.HTMLURL, pr.Number, nil
+		}
+	}
+	return "", 0, fmt.Errorf("PR already exists for %s but could not find it in open PRs", head)
+}
+
+// isForgejoExistingPRErr returns true when Forgejo rejected the PR creation
+// because one already exists.
+func isForgejoExistingPRErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "409") ||
+		strings.Contains(msg, "already exists") ||
+		strings.Contains(msg, "pull request already exists")
+}
+
+// splitRepo splits "owner/repo" into owner and repo name.
+func splitRepo(repo string) (string, string, error) {
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid repo format %q: expected \"owner/repo\"", repo)
+	}
+	return parts[0], parts[1], nil
+}
+
+// ClosePR closes the pull request.
+func (f *ForgejoProvider) ClosePR(ctx context.Context, repo string, prNumber int) error {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return err
+	}
+	payload := map[string]string{"state": "closed"}
+	if err := f.do(ctx, http.MethodPatch,
+		fmt.Sprintf("/api/v1/repos/%s/%s/pulls/%d", owner, name, prNumber), payload, nil); err != nil {
+		return fmt.Errorf("close PR %s#%d: %w", repo, prNumber, err)
+	}
+	return nil
+}
+
+// CommentOnPR posts a comment on the pull request.
+// Forgejo/Gitea uses the issues endpoint for PR comments.
+func (f *ForgejoProvider) CommentOnPR(ctx context.Context, repo string, prNumber int, body string) error {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return err
+	}
+	payload := map[string]string{"body": body}
+	if err := f.do(ctx, http.MethodPost,
+		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/comments", owner, name, prNumber), payload, nil); err != nil {
+		return fmt.Errorf("comment on PR %s#%d: %w", repo, prNumber, err)
+	}
+	return nil
+}
+
+// GetPRStatus returns whether the PR has been merged and whether it is still open.
+func (f *ForgejoProvider) GetPRStatus(ctx context.Context, repo string, prNumber int) (bool, bool, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return false, false, err
+	}
+	var result struct {
+		State  string `json:"state"`
+		Merged bool   `json:"merged"`
+	}
+	if err := f.do(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v1/repos/%s/%s/pulls/%d", owner, name, prNumber), nil, &result); err != nil {
+		return false, false, fmt.Errorf("get PR status %s#%d: %w", repo, prNumber, err)
+	}
+	open := result.State == "open"
+	return result.Merged, open, nil
+}
+
+// ParseWebhookEvent parses a Forgejo/Gitea pull request webhook payload.
+// Forgejo signs payloads with HMAC-SHA256 and sends the hex digest in
+// the X-Gitea-Signature header (same algorithm as GitHub's X-Hub-Signature-256).
+func (f *ForgejoProvider) ParseWebhookEvent(payload []byte, signature string) (WebhookEvent, error) {
+	if f.WebhookSecret != "" {
+		mac := hmac.New(sha256.New, []byte(f.WebhookSecret))
+		mac.Write(payload)
+		expected := hex.EncodeToString(mac.Sum(nil))
+		if subtle.ConstantTimeCompare([]byte(signature), []byte(expected)) != 1 {
+			return WebhookEvent{}, fmt.Errorf("webhook HMAC mismatch")
+		}
+	}
+
+	var raw struct {
+		Action      string `json:"action"`
+		Number      int    `json:"number"`
+		PullRequest struct {
+			HTMLURL string `json:"html_url"`
+			Merged  bool   `json:"merged"`
+			State   string `json:"state"`
+		} `json:"pull_request"`
+		Repository struct {
+			FullName string `json:"full_name"`
+		} `json:"repository"`
+	}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return WebhookEvent{}, fmt.Errorf("parse Forgejo webhook payload: %w", err)
+	}
+
+	merged := raw.PullRequest.Merged || (raw.Action == "closed" && raw.PullRequest.State == "closed" && raw.PullRequest.Merged)
+	return WebhookEvent{
+		EventType:    "pull_request",
+		PRNumber:     raw.Number,
+		RepoFullName: raw.Repository.FullName,
+		Merged:       merged,
+		Action:       raw.Action,
+	}, nil
+}
+
+// AddLabelsToPR replaces the label set on the pull request issue.
+// Forgejo/Gitea uses the issues/labels endpoint with a label ID list.
+// Since we only have label names, we first create labels (idempotent), then apply.
+func (f *ForgejoProvider) AddLabelsToPR(ctx context.Context, repo string, prNumber int, labels []string) error {
+	if len(labels) == 0 {
+		return nil
+	}
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return err
+	}
+
+	// Resolve label names to IDs (create if missing).
+	ids, err := f.ensureLabels(ctx, owner, name, labels)
+	if err != nil {
+		return fmt.Errorf("ensure labels for %s#%d: %w", repo, prNumber, err)
+	}
+
+	payload := map[string]interface{}{"labels": ids}
+	if err := f.do(ctx, http.MethodPost,
+		fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/labels", owner, name, prNumber), payload, nil); err != nil {
+		return fmt.Errorf("add labels to PR %s#%d: %w", repo, prNumber, err)
+	}
+	return nil
+}
+
+// ensureLabels returns the IDs of the given label names, creating them if they do not exist.
+func (f *ForgejoProvider) ensureLabels(ctx context.Context, owner, repo string, names []string) ([]int, error) {
+	// List existing labels.
+	var existing []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := f.do(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v1/repos/%s/%s/labels?limit=50", owner, repo), nil, &existing); err != nil {
+		return nil, fmt.Errorf("list labels: %w", err)
+	}
+	labelIDs := make(map[string]int, len(existing))
+	for _, l := range existing {
+		labelIDs[l.Name] = l.ID
+	}
+
+	ids := make([]int, 0, len(names))
+	for _, n := range names {
+		if id, ok := labelIDs[n]; ok {
+			ids = append(ids, id)
+			continue
+		}
+		// Create label with a default color.
+		var created struct {
+			ID int `json:"id"`
+		}
+		if err := f.do(ctx, http.MethodPost,
+			fmt.Sprintf("/api/v1/repos/%s/%s/labels", owner, repo),
+			map[string]string{"name": n, "color": "#0075ca"}, &created); err != nil {
+			return nil, fmt.Errorf("create label %q: %w", n, err)
+		}
+		ids = append(ids, created.ID)
+	}
+	return ids, nil
+}
+
+// do executes an authenticated Forgejo/Gitea API request.
+func (f *ForgejoProvider) do(ctx context.Context, method, path string, body, result interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, f.APIURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "token "+f.Token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute request %s %s: %w", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("Forgejo API %s %s: status %d: %s", method, path, resp.StatusCode, string(raw))
+	}
+
+	if result != nil {
+		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/scm/forgejo.go
+++ b/pkg/scm/forgejo.go
@@ -312,7 +312,7 @@ func (f *ForgejoProvider) do(ctx context.Context, method, path string, body, res
 
 	if resp.StatusCode >= 400 {
 		raw, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("Forgejo API %s %s: status %d: %s", method, path, resp.StatusCode, string(raw))
+		return fmt.Errorf("forgejo API %s %s: status %d: %s", method, path, resp.StatusCode, string(raw))
 	}
 
 	if result != nil {

--- a/pkg/scm/scm_test.go
+++ b/pkg/scm/scm_test.go
@@ -576,3 +576,172 @@ func TestNewProvider_EmptyType_DefaultsToGitHub(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, p)
 }
+
+// ─── Forgejo/Gitea SCM Provider Tests ─────────────────────────────────────────
+
+func TestForgejoProvider_OpenPR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/repos/owner/repo/pulls", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.Header.Get("Authorization"), "token test-token")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"number":   55,
+			"html_url": "https://forgejo.example.com/owner/repo/pulls/55",
+		})
+	}))
+	defer server.Close()
+
+	p := scm.NewForgejoProvider("test-token", server.URL, "")
+	url, num, err := p.OpenPR(context.Background(), "owner/repo", "Test PR", "body", "feature", "main")
+	require.NoError(t, err)
+	assert.Equal(t, 55, num)
+	assert.Equal(t, "https://forgejo.example.com/owner/repo/pulls/55", url)
+}
+
+func TestForgejoProvider_OpenPR_AlreadyExists(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			// First call: POST to create → 409 conflict
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"message":"pull request already exists"}`))
+			return
+		}
+		// Second call: GET to list open PRs
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"number":   55,
+				"html_url": "https://forgejo.example.com/owner/repo/pulls/55",
+				"head":     map[string]interface{}{"label": "owner:feature"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	p := scm.NewForgejoProvider("test-token", server.URL, "")
+	url, num, err := p.OpenPR(context.Background(), "owner/repo", "Test PR", "body", "feature", "main")
+	require.NoError(t, err)
+	assert.Equal(t, 55, num)
+	assert.Equal(t, "https://forgejo.example.com/owner/repo/pulls/55", url)
+}
+
+func TestForgejoProvider_ClosePR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/repos/owner/repo/pulls/55", r.URL.Path)
+		assert.Equal(t, http.MethodPatch, r.Method)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	p := scm.NewForgejoProvider("test-token", server.URL, "")
+	require.NoError(t, p.ClosePR(context.Background(), "owner/repo", 55))
+}
+
+func TestForgejoProvider_CommentOnPR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/repos/owner/repo/issues/55/comments", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	p := scm.NewForgejoProvider("test-token", server.URL, "")
+	require.NoError(t, p.CommentOnPR(context.Background(), "owner/repo", 55, "hello"))
+}
+
+func TestForgejoProvider_GetPRStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiState   string
+		apiMerged  bool
+		wantMerged bool
+		wantOpen   bool
+	}{
+		{name: "open", apiState: "open", apiMerged: false, wantMerged: false, wantOpen: true},
+		{name: "merged", apiState: "closed", apiMerged: true, wantMerged: true, wantOpen: false},
+		{name: "closed_unmerged", apiState: "closed", apiMerged: false, wantMerged: false, wantOpen: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"state":  tc.apiState,
+					"merged": tc.apiMerged,
+				})
+			}))
+			defer server.Close()
+
+			p := scm.NewForgejoProvider("test-token", server.URL, "")
+			merged, open, err := p.GetPRStatus(context.Background(), "owner/repo", 55)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantMerged, merged, "merged mismatch")
+			assert.Equal(t, tc.wantOpen, open, "open mismatch")
+		})
+	}
+}
+
+func TestForgejoProvider_ParseWebhookEvent_ValidSignature(t *testing.T) {
+	secret := "forgejo-secret"
+	payload := []byte(`{"action":"closed","number":55,"pull_request":{"merged":true,"state":"closed","html_url":"https://forgejo.example.com/owner/repo/pulls/55"},"repository":{"full_name":"owner/repo"}}`)
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	sig := hex.EncodeToString(mac.Sum(nil))
+
+	p := scm.NewForgejoProvider("token", "", secret)
+	evt, err := p.ParseWebhookEvent(payload, sig)
+	require.NoError(t, err)
+	assert.Equal(t, 55, evt.PRNumber)
+	assert.Equal(t, "owner/repo", evt.RepoFullName)
+	assert.True(t, evt.Merged)
+}
+
+func TestForgejoProvider_ParseWebhookEvent_InvalidSignature(t *testing.T) {
+	p := scm.NewForgejoProvider("token", "", "correct-secret")
+	_, err := p.ParseWebhookEvent([]byte(`{}`), "wrong-sig")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HMAC")
+}
+
+func TestForgejoProvider_ParseWebhookEvent_NoSecret(t *testing.T) {
+	p := scm.NewForgejoProvider("token", "", "")
+	evt, err := p.ParseWebhookEvent([]byte(`{"action":"opened","number":10,"pull_request":{},"repository":{"full_name":"owner/repo"}}`), "")
+	require.NoError(t, err)
+	assert.Equal(t, 10, evt.PRNumber)
+}
+
+func TestForgejoProvider_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"401 Unauthorized"}`))
+	}))
+	defer server.Close()
+
+	p := scm.NewForgejoProvider("bad-token", server.URL, "")
+	_, _, err := p.OpenPR(context.Background(), "owner/repo", "Test", "body", "head", "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+// ─── NewProvider factory tests (Forgejo) ─────────────────────────────────────
+
+func TestNewProvider_Forgejo(t *testing.T) {
+	p, err := scm.NewProvider("forgejo", "token", "https://codeberg.org", "")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+}
+
+func TestNewProvider_Gitea(t *testing.T) {
+	p, err := scm.NewProvider("gitea", "token", "https://gitea.example.com", "")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+}


### PR DESCRIPTION
Fixes #74

[🔨 Extensions Agent] Implements ForgejoProvider for Forgejo and Gitea instances.

**Changes**:
- `pkg/scm/forgejo.go`: ForgejoProvider with all 6 SCMProvider methods
- `pkg/scm/factory.go`: NewProvider handles 'forgejo' and 'gitea' types
- `pkg/scm/scm_test.go`: 11 new tests (httptest servers, webhook HMAC)
- `docs/scm-providers.md`: Forgejo/Gitea section added

**11 new tests**: OpenPR, OpenPR_AlreadyExists, ClosePR, CommentOnPR, GetPRStatus (3 subtests), ParseWebhookEvent_Valid/Invalid/NoSecret, APIError, factory tests.

**Boundary**: area/scm | pkg/scm | v0.4.0
**No logic leaks**: SCMProvider is a pure interface. ForgejoProvider makes HTTP calls only when explicitly invoked by the step engine (same pattern as GitHub/GitLab providers).