### PR TITLE
[STANDALONE-REFACTOR] fix(policygate): write bundle version to status.reason for CRD observability

### DIFF
--- a/pkg/reconciler/policygate/reconciler.go
+++ b/pkg/reconciler/policygate/reconciler.go
@@ -72,8 +72,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	recheckInterval := parseRecheckInterval(gate.Spec.RecheckInterval)
 
-	// Build CEL context
-	celCtx, err := r.buildContext(ctx, &gate, bundleName)
+	// Build CEL context. bundleVersion is returned separately so it can be
+	// written to status.reason, making the evaluated bundle version CRD-observable
+	// (PG-6: extractVersion result was previously invisible to the Graph).
+	celCtx, bundleVersion, err := r.buildContext(ctx, &gate, bundleName)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to build CEL context, setting gate to blocked")
 		if patchErr := r.patchStatus(ctx, &gate, false,
@@ -95,6 +97,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: recheckInterval}, nil
 	}
 
+	// Prefix reason with bundle version so it is CRD-observable without a
+	// separate status field (PG-6 partial fix — full fix requires api/v1alpha1
+	// field addition for a dedicated status.bundleVersion field).
+	if bundleVersion != "" {
+		reason = fmt.Sprintf("bundle.version=%s: %s", bundleVersion, reason)
+	}
+
 	log.Info().
 		Bool("ready", pass).
 		Str("reason", reason).
@@ -109,21 +118,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 // buildContext constructs the Phase 1 CEL context for gate evaluation.
+// It also returns the bundle version string (second return value) so the caller
+// can write it to status.reason — making the version CRD-observable (PG-6 partial fix).
 func (r *Reconciler) buildContext(ctx context.Context, gate *kardinalv1alpha1.PolicyGate,
-	bundleName string) (map[string]interface{}, error) {
+	bundleName string) (map[string]interface{}, string, error) {
 	var bundle kardinalv1alpha1.Bundle
 	if err := r.Get(ctx, types.NamespacedName{
 		Name:      bundleName,
 		Namespace: gate.Namespace,
 	}, &bundle); err != nil {
-		return nil, fmt.Errorf("load bundle %s: %w", bundleName, err)
+		return nil, "", fmt.Errorf("load bundle %s: %w", bundleName, err)
 	}
 
 	now := r.now()
+	version := extractVersion(&bundle)
 
 	bundleCtx := map[string]interface{}{
 		"type":    bundle.Spec.Type,
-		"version": extractVersion(&bundle),
+		"version": version,
 		"provenance": map[string]interface{}{
 			"author":    "",
 			"commitSHA": "",
@@ -171,7 +183,7 @@ func (r *Reconciler) buildContext(ctx context.Context, gate *kardinalv1alpha1.Po
 		},
 		"metrics":  metricsCtx,
 		"upstream": upstreamCtx,
-	}, nil
+	}, version, nil
 }
 
 // buildMetricsContext lists all MetricCheck objects in the given namespace and

--- a/pkg/reconciler/policygate/reconciler_test.go
+++ b/pkg/reconciler/policygate/reconciler_test.go
@@ -565,3 +565,50 @@ func TestPolicyGateReconciler_UpstreamSoakContext_ZeroWhenNotHealthChecked(t *te
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "soak-gate", Namespace: "default"}, &got))
 	assert.False(t, got.Status.Ready, "gate must block when uat has not been health-checked (soakMinutes=0)")
 }
+
+// makeBundleWithImage builds a Bundle with an image ref (for version extraction tests).
+func makeBundleWithImage(name, ns, repo, tag string) *kardinalv1alpha1.Bundle {
+	b := makeBundle(name, ns)
+	b.Spec.Images = []kardinalv1alpha1.ImageRef{{Repository: repo, Tag: tag}}
+	return b
+}
+
+// TestPolicyGateReconciler_StatusReasonContainsVersion verifies that when a bundle
+// has an image tag, the evaluated status.reason includes the bundle version.
+// This makes the routing info (bundle version used for evaluation) CRD-observable
+// rather than staying in Go memory only (PG-6 in docs/design/11-graph-purity-tech-debt.md).
+func TestPolicyGateReconciler_StatusReasonContainsVersion(t *testing.T) {
+	bundle := makeBundleWithImage("nginx-demo-v1", "default", "ghcr.io/nginx/nginx", "1.29.0")
+	gate := makeGateInstance("version-gate", "default", "nginx-demo-v1",
+		`!schedule.isWeekend`, "5m")
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gate, bundle).
+		WithStatusSubresource(gate).
+		Build()
+
+	tuesday := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return tuesday },
+	}
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "version-gate", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "version-gate", Namespace: "default"}, &got))
+	assert.True(t, got.Status.Ready, "gate must pass on weekday")
+	// PG-6: bundle version must be visible in status.reason so Graph and operators can observe it
+	assert.Contains(t, got.Status.Reason, "1.29.0",
+		"status.reason must include bundle version to make routing info CRD-observable")
+}


### PR DESCRIPTION
Fixes #148

[🔨 Refactor Agent]

## Summary

Partial fix for PG-6: `extractVersion()` result was computed in Go but never written to any CRD status field, making it invisible to the Graph and operators reading `kubectl`.

`buildContext` now returns the bundle version as a second value. The reconciler prefixes `status.reason` with `bundle.version=<ver>: <reason>` when the bundle has a version. This makes the routing info CRD-observable using the existing status field.

## Architecture note

Full PG-5 and PG-6 fixes (first-class `spec.isInstance` or `status.bundleVersion` fields) require `api/v1alpha1` additions — outside this session's DENY_PACKAGES. This PR captures the achievable improvement within `pkg/reconciler/policygate`.

**Packages modified**: pkg/reconciler/policygate