### PR TITLE
[STANDALONE-CORE] fix(bundle): invert evidence sync direction to eliminate PS-9 cross-CRD mutation

### DIFF
--- a/pkg/reconciler/bundle/reconciler.go
+++ b/pkg/reconciler/bundle/reconciler.go
@@ -15,7 +15,8 @@
 
 // Package bundle implements the BundleReconciler which watches Bundle objects,
 // sets status.phase = Available on newly-created Bundles, triggers the
-// Pipeline-to-Graph translation, and handles Bundle supersession.
+// Pipeline-to-Graph translation, handles Bundle supersession, and syncs
+// per-environment promotion evidence from PromotionStep status.
 package bundle
 
 import (
@@ -25,8 +26,11 @@ import (
 
 	"github.com/rs/zerolog"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 )
@@ -38,7 +42,8 @@ type BundleTranslator interface {
 }
 
 // Reconciler watches Bundle objects, sets Available phase, triggers translation,
-// and manages Bundle supersession.
+// manages Bundle supersession, and syncs evidence from PromotionStep status
+// into Bundle.status.environments.
 type Reconciler struct {
 	client.Client
 	// Translator creates the kro Graph for a Bundle+Pipeline pair.
@@ -46,13 +51,14 @@ type Reconciler struct {
 	Translator BundleTranslator
 }
 
-// Reconcile is called whenever a Bundle is created, updated, or deleted.
+// Reconcile is called whenever a Bundle is created, updated, or deleted,
+// or whenever a PromotionStep for this bundle changes (via the Watch in SetupWithManager).
 //
 // State machine:
 //   - Phase = "" (new Bundle): supersede older Promoting bundles, set to Available
 //   - Phase = "Available" (ready to promote): look up Pipeline, call Translator,
 //     set phase to Promoting
-//   - All other phases: idempotent no-op
+//   - Phase = "Promoting" | "Verified" | "Failed": sync evidence from PromotionStep status
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := zerolog.Ctx(ctx).With().
 		Str("bundle", req.Name).
@@ -74,8 +80,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	case "Available":
 		return r.handleAvailable(ctx, log, &b)
 	default:
-		log.Debug().Str("phase", b.Status.Phase).Msg("bundle phase already advanced, skipping")
-		return ctrl.Result{}, nil
+		// For Promoting, Verified, Failed: sync evidence from PromotionStep status.
+		// This replaces the cross-CRD write in the PromotionStep reconciler (PS-9).
+		return r.handleSyncEvidence(ctx, log, &b)
 	}
 }
 
@@ -216,6 +223,88 @@ func (r *Reconciler) handleAvailable(ctx context.Context, log zerolog.Logger,
 	return ctrl.Result{}, nil
 }
 
+// handleSyncEvidence reads all PromotionSteps for this Bundle and merges their
+// per-environment state into Bundle.status.environments. This is the Graph-first
+// replacement for the PromotionStep reconciler's copyEvidenceToBundle (PS-9):
+// the Bundle reconciler writes to its own CRD status, not a foreign one.
+//
+// Graph-purity: the PromotionStep reconciler no longer writes to Bundle.status.
+// The Bundle reconciler is triggered by PromotionStep changes via the Watch added
+// in SetupWithManager, so evidence is still propagated promptly.
+func (r *Reconciler) handleSyncEvidence(ctx context.Context, log zerolog.Logger,
+	b *kardinalv1alpha1.Bundle) (ctrl.Result, error) {
+	var psList kardinalv1alpha1.PromotionStepList
+	if err := r.List(ctx, &psList,
+		client.InNamespace(b.Namespace),
+		client.MatchingLabels{"kardinal.io/bundle": b.Name},
+	); err != nil {
+		return ctrl.Result{}, fmt.Errorf("list promotion steps for bundle %s: %w", b.Name, err)
+	}
+
+	if len(psList.Items) == 0 {
+		log.Debug().Msg("no promotion steps found for bundle, nothing to sync")
+		return ctrl.Result{}, nil
+	}
+
+	// Build a map of current environment statuses so we can update idempotently.
+	envMap := make(map[string]kardinalv1alpha1.EnvironmentStatus, len(b.Status.Environments))
+	for _, env := range b.Status.Environments {
+		envMap[env.Name] = env
+	}
+
+	changed := false
+	for _, ps := range psList.Items {
+		envName := ps.Spec.Environment
+		prev := envMap[envName]
+
+		updated := kardinalv1alpha1.EnvironmentStatus{
+			Name:            envName,
+			Phase:           ps.Status.State,
+			PRURL:           ps.Status.PRURL,
+			HealthCheckedAt: prev.HealthCheckedAt, // preserve if already set
+		}
+
+		// Use the prURL from outputs if available (more reliable than status.PRURL).
+		if prURL, ok := ps.Status.Outputs["prURL"]; ok && prURL != "" {
+			updated.PRURL = prURL
+		}
+
+		// Set HealthCheckedAt when step reaches Verified state.
+		// time.Now() is used here inside a CRD status write — Graph-first compliant.
+		if ps.Status.State == "Verified" && prev.HealthCheckedAt == nil {
+			now := metav1.NewTime(time.Now().UTC())
+			updated.HealthCheckedAt = &now
+		}
+
+		// Only mark changed if something actually differs.
+		if prev.Phase != updated.Phase || prev.PRURL != updated.PRURL ||
+			(updated.HealthCheckedAt != nil && prev.HealthCheckedAt == nil) {
+			envMap[envName] = updated
+			changed = true
+		}
+	}
+
+	if !changed {
+		log.Debug().Msg("bundle evidence already up to date")
+		return ctrl.Result{}, nil
+	}
+
+	// Rebuild the environments slice from the updated map.
+	envs := make([]kardinalv1alpha1.EnvironmentStatus, 0, len(envMap))
+	for _, env := range envMap {
+		envs = append(envs, env)
+	}
+
+	patch := client.MergeFrom(b.DeepCopy())
+	b.Status.Environments = envs
+	if err := r.Status().Patch(ctx, b, patch); err != nil {
+		return ctrl.Result{}, fmt.Errorf("patch bundle evidence: %w", err)
+	}
+
+	log.Info().Int("environments", len(envs)).Msg("bundle evidence synced from PromotionStep status")
+	return ctrl.Result{}, nil
+}
+
 // Start implements manager.Runnable. It is called by controller-runtime after the
 // informer cache is synced. With the PRStatus CRD architecture, startup reconciliation
 // of PR merge state is no longer needed here: the PRStatusReconciler polls GitHub and
@@ -234,11 +323,33 @@ func (r *Reconciler) Start(ctx context.Context) error {
 // SetupWithManager registers the BundleReconciler with the controller-runtime Manager.
 // It also registers the reconciler as a Runnable so that Start() is called after
 // cache sync to perform startup reconciliation.
+//
+// It adds a Watch on PromotionStep objects: when any PromotionStep for a Bundle
+// changes state (e.g. Verified, Failed), the Bundle is re-queued to sync evidence.
+// This replaces the PromotionStep reconciler's cross-CRD copyEvidenceToBundle write.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.Add(r); err != nil {
 		return fmt.Errorf("add reconciler as runnable: %w", err)
 	}
+
+	// promotionStepMapper maps a PromotionStep change event to a Bundle reconcile request.
+	// It reads the kardinal.io/bundle label set by the Graph builder on PromotionStep nodes.
+	promotionStepMapper := func(ctx context.Context, obj client.Object) []reconcile.Request {
+		bundleName := obj.GetLabels()["kardinal.io/bundle"]
+		if bundleName == "" {
+			return nil
+		}
+		return []reconcile.Request{
+			{NamespacedName: client.ObjectKey{
+				Name:      bundleName,
+				Namespace: obj.GetNamespace(),
+			}},
+		}
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kardinalv1alpha1.Bundle{}).
+		// Watch PromotionSteps: evidence sync when PS state changes.
+		Watches(&kardinalv1alpha1.PromotionStep{}, handler.EnqueueRequestsFromMapFunc(promotionStepMapper)).
 		Complete(r)
 }

--- a/pkg/reconciler/bundle/reconciler_test.go
+++ b/pkg/reconciler/bundle/reconciler_test.go
@@ -649,3 +649,125 @@ func TestBundleReconciler_PausedIdempotent(t *testing.T) {
 	// Translator must never have been called.
 	assert.False(t, translator.called, "translator must not be called for paused pipeline (idempotent)")
 }
+
+// TestBundleReconciler_SyncEvidenceFromPromotionStep verifies that when a Promoting
+// Bundle is reconciled and a PromotionStep with the matching bundle label exists,
+// the PromotionStep's status is copied into Bundle.status.environments.
+// This replaces the cross-CRD write that was previously in the PromotionStep reconciler (PS-9).
+func TestBundleReconciler_SyncEvidenceFromPromotionStep(t *testing.T) {
+	s := newScheme()
+
+	b := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1", Namespace: "default"},
+		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status:     kardinalv1alpha1.BundleStatus{Phase: "Promoting"},
+	}
+
+	// PromotionStep for the "test" environment, Verified state.
+	prURL := "https://github.com/test/repo/pull/42"
+	ps := &kardinalv1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "step-test",
+			Namespace: "default",
+			Labels:    map[string]string{"kardinal.io/bundle": "nginx-demo-v1"},
+		},
+		Spec: kardinalv1alpha1.PromotionStepSpec{
+			PipelineName: "nginx-demo",
+			BundleName:   "nginx-demo-v1",
+			Environment:  "test",
+			StepType:     "auto",
+		},
+		Status: kardinalv1alpha1.PromotionStepStatus{
+			State: "Verified",
+			PRURL: prURL,
+			Outputs: map[string]string{
+				"prURL": prURL,
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(b, ps).
+		WithStatusSubresource(b).
+		Build()
+
+	r := &bundle.Reconciler{Client: c}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var updated kardinalv1alpha1.Bundle
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &updated))
+
+	require.Len(t, updated.Status.Environments, 1, "should have one environment status")
+	env := updated.Status.Environments[0]
+	assert.Equal(t, "test", env.Name)
+	assert.Equal(t, "Verified", env.Phase)
+	assert.Equal(t, prURL, env.PRURL)
+	require.NotNil(t, env.HealthCheckedAt, "HealthCheckedAt must be set when state is Verified")
+}
+
+// TestBundleReconciler_SyncEvidence_Idempotent verifies that syncing evidence twice
+// does not change the HealthCheckedAt timestamp (idempotent).
+func TestBundleReconciler_SyncEvidence_Idempotent(t *testing.T) {
+	s := newScheme()
+
+	fixedTime := metav1.NewTime(time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC))
+	b := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1", Namespace: "default"},
+		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status: kardinalv1alpha1.BundleStatus{
+			Phase: "Verified",
+			Environments: []kardinalv1alpha1.EnvironmentStatus{
+				{Name: "test", Phase: "Verified", PRURL: "https://github.com/test/repo/pull/42", HealthCheckedAt: &fixedTime},
+			},
+		},
+	}
+	ps := &kardinalv1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "step-test",
+			Namespace: "default",
+			Labels:    map[string]string{"kardinal.io/bundle": "nginx-demo-v1"},
+		},
+		Spec: kardinalv1alpha1.PromotionStepSpec{
+			PipelineName: "nginx-demo",
+			BundleName:   "nginx-demo-v1",
+			Environment:  "test",
+			StepType:     "auto",
+		},
+		Status: kardinalv1alpha1.PromotionStepStatus{
+			State: "Verified",
+			PRURL: "https://github.com/test/repo/pull/42",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(b, ps).
+		WithStatusSubresource(b).
+		Build()
+
+	r := &bundle.Reconciler{Client: c}
+
+	// Reconcile twice — HealthCheckedAt must remain the fixed value, not be updated.
+	for i := 0; i < 2; i++ {
+		_, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"},
+		})
+		require.NoError(t, err)
+	}
+
+	var updated kardinalv1alpha1.Bundle
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &updated))
+
+	require.Len(t, updated.Status.Environments, 1)
+	env := updated.Status.Environments[0]
+	require.NotNil(t, env.HealthCheckedAt)
+	assert.Equal(t, fixedTime.UTC(), env.HealthCheckedAt.UTC(),
+		"HealthCheckedAt must not be overwritten on subsequent syncs")
+}

--- a/pkg/reconciler/promotionstep/reconciler.go
+++ b/pkg/reconciler/promotionstep/reconciler.go
@@ -273,7 +273,6 @@ func (r *Reconciler) handlePromoting(ctx context.Context, log zerolog.Logger, ps
 		if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
 			return ctrl.Result{}, fmt.Errorf("patch failed state: %w", patchErr)
 		}
-		_ = r.copyEvidenceToBundle(ctx, ps, bundle)
 		return ctrl.Result{}, nil
 	}
 
@@ -337,7 +336,6 @@ func (r *Reconciler) handlePromoting(ctx context.Context, log zerolog.Logger, ps
 		if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
 			return ctrl.Result{}, fmt.Errorf("patch failed: %w", patchErr)
 		}
-		_ = r.copyEvidenceToBundle(ctx, ps, bundle)
 		return ctrl.Result{}, nil
 	}
 }
@@ -388,15 +386,11 @@ func (r *Reconciler) handleWaitingForMerge(ctx context.Context, log zerolog.Logg
 			Str("prStatusRef", prStatusName).
 			Int("prNumber", prs.Spec.PRNumber).
 			Msg("PRStatus reports PR closed without merge — failing")
-		bundle, _ := r.loadBundle(ctx, ps)
 		patch := client.MergeFrom(ps.DeepCopy())
 		ps.Status.State = StateFailed
 		ps.Status.Message = fmt.Sprintf("PR #%d was closed without merging", prs.Spec.PRNumber)
 		if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
 			return ctrl.Result{}, fmt.Errorf("patch failed on closed PR: %w", patchErr)
-		}
-		if bundle != nil {
-			_ = r.copyEvidenceToBundle(ctx, ps, bundle)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -454,9 +448,6 @@ func (r *Reconciler) handleHealthChecking(ctx context.Context, log zerolog.Logge
 			if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
 				return ctrl.Result{}, fmt.Errorf("patch failed (health timeout): %w", patchErr)
 			}
-			if bundle != nil {
-				_ = r.copyEvidenceToBundle(ctx, ps, bundle)
-			}
 			return ctrl.Result{}, nil
 		}
 
@@ -504,9 +495,6 @@ func (r *Reconciler) handleHealthChecking(ctx context.Context, log zerolog.Logge
 			ps.Status.Conditions = appendCondition(ps.Status.Conditions, "Verified", metav1.ConditionTrue, "Verified", "promotion complete", now.Time)
 			if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
 				return ctrl.Result{}, fmt.Errorf("patch verified: %w", patchErr)
-			}
-			if bundle != nil {
-				_ = r.copyEvidenceToBundle(ctx, ps, bundle)
 			}
 			return ctrl.Result{}, nil
 		}
@@ -561,9 +549,6 @@ func (r *Reconciler) handleHealthChecking(ctx context.Context, log zerolog.Logge
 		if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
 			return ctrl.Result{}, fmt.Errorf("patch failed (health): %w", patchErr)
 		}
-		if bundle != nil {
-			_ = r.copyEvidenceToBundle(ctx, ps, bundle)
-		}
 		return ctrl.Result{}, nil
 	}
 
@@ -578,9 +563,6 @@ func (r *Reconciler) handleHealthChecking(ctx context.Context, log zerolog.Logge
 		if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
 			return ctrl.Result{}, fmt.Errorf("patch verified: %w", patchErr)
 		}
-		if bundle != nil {
-			_ = r.copyEvidenceToBundle(ctx, ps, bundle)
-		}
 		return ctrl.Result{}, nil
 
 	case steps.StepPending:
@@ -592,9 +574,6 @@ func (r *Reconciler) handleHealthChecking(ctx context.Context, log zerolog.Logge
 		ps.Status.Message = result.Message
 		if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
 			return ctrl.Result{}, fmt.Errorf("patch failed (health): %w", patchErr)
-		}
-		if bundle != nil {
-			_ = r.copyEvidenceToBundle(ctx, ps, bundle)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -609,41 +588,6 @@ func (r *Reconciler) patchState(ctx context.Context, ps *v1alpha1.PromotionStep,
 		return ctrl.Result{}, fmt.Errorf("patch state %s: %w", state, err)
 	}
 	return ctrl.Result{Requeue: true}, nil
-}
-
-// copyEvidenceToBundle writes per-environment evidence into Bundle.status.environments.
-// This persists audit data beyond the PromotionStep's lifetime.
-func (r *Reconciler) copyEvidenceToBundle(ctx context.Context, ps *v1alpha1.PromotionStep, bundle *v1alpha1.Bundle) error {
-	envStatus := v1alpha1.EnvironmentStatus{
-		Name:  ps.Spec.Environment,
-		Phase: ps.Status.State,
-		PRURL: ps.Status.PRURL,
-	}
-	if prURL, ok := ps.Status.Outputs["prURL"]; ok && prURL != "" {
-		envStatus.PRURL = prURL
-	}
-	if ps.Status.State == StateVerified {
-		now := metav1.NewTime(time.Now().UTC())
-		envStatus.HealthCheckedAt = &now
-	}
-
-	patch := client.MergeFrom(bundle.DeepCopy())
-	updated := false
-	for i, env := range bundle.Status.Environments {
-		if env.Name == ps.Spec.Environment {
-			bundle.Status.Environments[i] = envStatus
-			updated = true
-			break
-		}
-	}
-	if !updated {
-		bundle.Status.Environments = append(bundle.Status.Environments, envStatus)
-	}
-
-	if err := r.Status().Patch(ctx, bundle, patch); err != nil {
-		return fmt.Errorf("patch bundle evidence for env %s: %w", ps.Spec.Environment, err)
-	}
-	return nil
 }
 
 // SetupWithManager registers the PromotionStep reconciler with controller-runtime.

--- a/pkg/reconciler/promotionstep/reconciler_test.go
+++ b/pkg/reconciler/promotionstep/reconciler_test.go
@@ -377,8 +377,10 @@ func TestVerifiedIsTerminal(t *testing.T) {
 	assert.Equal(t, time.Duration(0), result.RequeueAfter)
 }
 
-// TestEvidenceCopiedToBundle verifies that Verified state copies PRURL to Bundle.status.environments.
-func TestEvidenceCopiedToBundle(t *testing.T) {
+// TestEvidenceNotCopiedByPromotionStepReconciler verifies that the PromotionStep reconciler
+// does NOT write evidence to Bundle.status.environments (PS-9 elimination).
+// Evidence sync is now handled by the Bundle reconciler watching PromotionStep changes.
+func TestEvidenceNotCopiedByPromotionStepReconciler(t *testing.T) {
 	scheme := buildScheme(t)
 	step := makeStep("step-hc", "nginx-demo", "bundle-1", "test")
 	step.Status.State = "HealthChecking"
@@ -403,17 +405,12 @@ func TestEvidenceCopiedToBundle(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// The PromotionStep reconciler must NOT write to Bundle.status.environments.
+	// The Bundle reconciler (watching PromotionStep events) handles evidence sync.
 	var updatedBundle v1alpha1.Bundle
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "bundle-1", Namespace: "default"}, &updatedBundle))
-
-	found := false
-	for _, env := range updatedBundle.Status.Environments {
-		if env.Name == "test" {
-			found = true
-			assert.Equal(t, "https://github.com/test/repo/pull/7", env.PRURL)
-		}
-	}
-	assert.True(t, found, "test environment status should be in bundle")
+	assert.Empty(t, updatedBundle.Status.Environments,
+		"PromotionStep reconciler must NOT write to Bundle.status.environments (PS-9 eliminated; Bundle reconciler handles this)")
 }
 
 // TestShardFiltering verifies that PromotionSteps with non-matching shard labels are skipped.


### PR DESCRIPTION
[🔨 Core Agent] Fixes #142

**Scope**: Core — PromotionStep reconciler fixes, Bundle reconciler
**Boundary**: area/controller | v0.4.0
**Packages modified**: pkg/reconciler/bundle, pkg/reconciler/promotionstep

## Summary

Eliminates PS-9 from docs/design/11-graph-purity-tech-debt.md.

Previously: PromotionStep reconciler called `copyEvidenceToBundle()` — writing to a foreign CRD's status. This is a cross-CRD mutation violation.

### Fix

**Inverted the direction:**

1. `pkg/reconciler/promotionstep/reconciler.go`: Remove `copyEvidenceToBundle()` and all 8 call sites. PromotionStep now only writes its own CRD status.

2. `pkg/reconciler/bundle/reconciler.go`: Add `handleSyncEvidence()` that lists PromotionSteps for the Bundle (via `kardinal.io/bundle` label) and copies their status to `Bundle.status.environments`. Add PromotionStep Watch in `SetupWithManager` for prompt evidence propagation.

### Architecture

`PromotionStep.status` (written by PS reconciler) → Bundle reconciler reads it → `Bundle.status.environments` (written by Bundle reconciler). Each reconciler writes only to its own CRD.