### PR TITLE
[STANDALONE-REFACTOR] fix(scm): pre-compute elapsed time before PR template render

### DIFF
--- a/pkg/scm/pr_template.go
+++ b/pkg/scm/pr_template.go
@@ -19,8 +19,46 @@ import (
 	"text/template"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 )
+
+// PRBodyUpstreamEnv holds per-environment upstream verification evidence for the
+// PR body template. Elapsed is pre-computed by the caller (not derived at render time)
+// to eliminate time.Since() calls inside template execution (SCM-4 logic leak).
+type PRBodyUpstreamEnv struct {
+	// Name is the environment name.
+	Name string
+	// Phase is the PromotionStep phase (e.g. "Verified").
+	Phase string
+	// HealthCheckedAt is the timestamp the environment was last health-checked.
+	// Nil means not yet health-checked.
+	HealthCheckedAt *metav1.Time
+	// Elapsed is a pre-computed human-readable elapsed time since HealthCheckedAt.
+	// Computed by the caller at the time the PR body is rendered, not by the template.
+	// Empty string is rendered as "—" in the table.
+	Elapsed string
+}
+
+// FormatElapsed formats a duration as a human-readable elapsed time string
+// (e.g. "45m", "2h30m", "3d"). Used by callers to pre-compute PRBodyUpstreamEnv.Elapsed
+// before calling RenderPRBody.
+func FormatElapsed(since time.Time, now time.Time) string {
+	d := now.Sub(since)
+	if d < 0 {
+		d = -d
+	}
+	minutes := int(d.Minutes())
+	if minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	hours := int(d.Hours())
+	if hours < 24 {
+		return fmt.Sprintf("%dh%dm", hours, minutes%60)
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}
 
 // PRBody holds the data used to render the PR body template.
 type PRBody struct {
@@ -43,29 +81,12 @@ type PRBody struct {
 	GateResults []v1alpha1.GateResult
 
 	// UpstreamEnvironments holds verification evidence for upstream environments.
-	UpstreamEnvironments []v1alpha1.EnvironmentStatus
+	// Each entry includes a pre-computed Elapsed string to avoid time.Since in
+	// template execution (SCM-4 logic leak fix).
+	UpstreamEnvironments []PRBodyUpstreamEnv
 }
 
-// elapsedSince returns a human-readable elapsed time string since t.
-func elapsedSince(t time.Time) string {
-	d := time.Since(t)
-	if d < 0 {
-		d = -d
-	}
-	minutes := int(d.Minutes())
-	if minutes < 60 {
-		return fmt.Sprintf("%dm", minutes)
-	}
-	hours := int(d.Hours())
-	if hours < 24 {
-		return fmt.Sprintf("%dh%dm", hours, minutes%60)
-	}
-	return fmt.Sprintf("%dd", int(d.Hours()/24))
-}
-
-var prBodyTemplate = template.Must(template.New("pr-body").Funcs(template.FuncMap{
-	"elapsed": elapsedSince,
-}).Parse(`
+var prBodyTemplate = template.Must(template.New("pr-body").Parse(`
 <!-- kardinal-promoter auto-generated PR -->
 ## Promotion: {{.BundleName}} → {{.PipelineName}}/{{.Environment}}
 
@@ -94,7 +115,7 @@ var prBodyTemplate = template.Must(template.New("pr-body").Funcs(template.FuncMa
 | Environment | Health Checked At | Elapsed |
 |---|---|---|
 {{- range .UpstreamEnvironments}}
-| {{.Name}} | {{if .HealthCheckedAt}}{{.HealthCheckedAt.UTC.Format "2006-01-02T15:04Z"}}{{else}}—{{end}} | {{if .HealthCheckedAt}}{{elapsed .HealthCheckedAt.Time}}{{else}}—{{end}} |
+| {{.Name}} | {{if .HealthCheckedAt}}{{.HealthCheckedAt.UTC.Format "2006-01-02T15:04Z"}}{{else}}—{{end}} | {{if .Elapsed}}{{.Elapsed}}{{else}}—{{end}} |
 {{- else}}
 | _(none)_ | — | — |
 {{- end}}

--- a/pkg/scm/scm_test.go
+++ b/pkg/scm/scm_test.go
@@ -186,7 +186,7 @@ func TestRenderPRBody(t *testing.T) {
 		GateResults: []v1alpha1.GateResult{
 			{GateName: "no-weekend-deploys", Result: "pass", Reason: "weekday"},
 		},
-		UpstreamEnvironments: []v1alpha1.EnvironmentStatus{
+		UpstreamEnvironments: []scm.PRBodyUpstreamEnv{
 			{Name: "test", Phase: "Verified"},
 			{Name: "uat", Phase: "Verified"},
 		},
@@ -302,7 +302,7 @@ func TestPRTemplate_GateComplianceWithNamespace(t *testing.T) {
 		GateResults: []v1alpha1.GateResult{
 			{GateName: "no-weekend-deploys", GateNamespace: "platform-policies", Result: "pass", Reason: "weekday", EvaluatedAt: evalTime},
 		},
-		UpstreamEnvironments: []v1alpha1.EnvironmentStatus{
+		UpstreamEnvironments: []scm.PRBodyUpstreamEnv{
 			{Name: "test", Phase: "Verified"},
 			{Name: "uat", Phase: "Verified"},
 		},
@@ -551,6 +551,32 @@ func TestGitLabProvider_APIError(t *testing.T) {
 }
 
 // ─── NewProvider factory tests ────────────────────────────────────────────────
+
+// TestRenderPRBody_ElapsedPrecomputed verifies that upstream environment elapsed
+// time is pre-computed by the caller and rendered verbatim from PRBodyUpstreamEnv.Elapsed.
+// This eliminates SCM-4: time.Since() called inside PR template execution.
+func TestRenderPRBody_ElapsedPrecomputed(t *testing.T) {
+	healthCheckedAt := metav1.NewTime(time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC))
+	data := scm.PRBody{
+		PipelineName: "nginx-demo",
+		Environment:  "prod",
+		BundleName:   "nginx-demo-v1-29-0",
+		Bundle:       v1alpha1.BundleSpec{Type: "image"},
+		UpstreamEnvironments: []scm.PRBodyUpstreamEnv{
+			{Name: "uat", Phase: "Verified", HealthCheckedAt: &healthCheckedAt, Elapsed: "45m"},
+			{Name: "test", Phase: "Verified", HealthCheckedAt: nil, Elapsed: ""},
+		},
+	}
+
+	body, err := scm.RenderPRBody(data)
+	require.NoError(t, err)
+
+	// Pre-computed elapsed must appear verbatim — no time.Since in template
+	assert.Contains(t, body, "45m", "pre-computed elapsed must appear in PR body")
+	assert.Contains(t, body, "uat")
+	assert.Contains(t, body, "test")
+	assert.Contains(t, body, "Upstream Verification")
+}
 
 func TestNewProvider_GitHub(t *testing.T) {
 	p, err := scm.NewProvider("github", "token", "https://api.github.com", "")

--- a/pkg/steps/steps/open_pr.go
+++ b/pkg/steps/steps/open_pr.go
@@ -16,7 +16,9 @@ package steps
 import (
 	"context"
 	"fmt"
+	"time"
 
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	"github.com/kardinal-promoter/kardinal-promoter/pkg/scm"
 	parentsteps "github.com/kardinal-promoter/kardinal-promoter/pkg/steps"
 )
@@ -58,7 +60,7 @@ func (s *openPRStep) Execute(ctx context.Context, state *parentsteps.StepState) 
 		BundleName:           state.BundleName,
 		Bundle:               state.Bundle,
 		GateResults:          state.GateResults,
-		UpstreamEnvironments: state.UpstreamEnvironments,
+		UpstreamEnvironments: buildPRBodyUpstreamEnvs(state.UpstreamEnvironments),
 		Pipeline:             state.Pipeline,
 	})
 	if err != nil {
@@ -107,4 +109,24 @@ func extractRepo(url string) string {
 		}
 	}
 	return url
+}
+
+// buildPRBodyUpstreamEnvs converts []v1alpha1.EnvironmentStatus to []scm.PRBodyUpstreamEnv,
+// pre-computing the elapsed time for each environment at call time rather than at
+// template render time. This eliminates SCM-4: time.Since() inside PR template execution.
+func buildPRBodyUpstreamEnvs(envs []v1alpha1.EnvironmentStatus) []scm.PRBodyUpstreamEnv {
+	now := time.Now().UTC()
+	result := make([]scm.PRBodyUpstreamEnv, 0, len(envs))
+	for _, env := range envs {
+		e := scm.PRBodyUpstreamEnv{
+			Name:            env.Name,
+			Phase:           env.Phase,
+			HealthCheckedAt: env.HealthCheckedAt,
+		}
+		if env.HealthCheckedAt != nil && !env.HealthCheckedAt.IsZero() {
+			e.Elapsed = scm.FormatElapsed(env.HealthCheckedAt.Time, now)
+		}
+		result = append(result, e)
+	}
+	return result
 }


### PR DESCRIPTION
Fixes #154

[🔨 Refactor Agent]

## Summary

Eliminates SCM-4: `elapsedSince()` called `time.Since(t)` inside Go text/template execution to render the 'Elapsed' column in the Upstream Verification table. This made PR body non-deterministic and placed time arithmetic inside the template layer.

## Changes

- Add `PRBodyUpstreamEnv` struct to `pkg/scm` with pre-computed `Elapsed` field
- Replace `UpstreamEnvironments []v1alpha1.EnvironmentStatus` in `PRBody` with `[]PRBodyUpstreamEnv`
- Add `FormatElapsed(since, now time.Time)` exported helper for callers to pre-compute elapsed
- Remove `elapsedSince()` and `elapsed` template func — template renders `.Elapsed` verbatim
- `open_pr.go`: add `buildPRBodyUpstreamEnvs()` converter that calls `time.Now()` once before `RenderPRBody`

## Architecture note (SCM-3)

The `EnsureLabels` function exists but is not called on the promotion hot path. No structural change needed for SCM-3 — the function is a utility called at controller startup.

**Packages modified**: pkg/scm, pkg/steps/steps