### PR TITLE
[STANDALONE-CORE] fix(graph): move ValidateSkipPermissions out of Build() to make result CRD-observable

### DIFF
--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -68,10 +68,11 @@ func (b *Builder) Build(input BuildInput) (*BuildResult, error) {
 		return nil, fmt.Errorf("build: all environments skipped")
 	}
 
-	// Step 3: validate skip permissions
-	if err := validateSkipPermissions(input.Pipeline, input.Bundle, input.PolicyGates); err != nil {
-		return nil, err
-	}
+	// Step 3: validate skip permissions — REMOVED from Build().
+	// Skip-permission validation is now done by the caller (Translator.Translate)
+	// before calling Build(), so the result is written to Bundle.status by the
+	// Bundle reconciler (Graph-first: validation result flows through CRD status).
+	// See docs/design/11-graph-purity-tech-debt.md GB-2.
 
 	// Step 4: collect and match PolicyGates by environment
 	gatesByEnv := matchGatesByEnv(filteredEnvs, input.PolicyGates)
@@ -264,7 +265,14 @@ func removeEnv(envs []string, name string) []string {
 
 // --- Step 3: validate skip permissions ---
 
-func validateSkipPermissions(pipeline *kardinalv1alpha1.Pipeline,
+// ValidateSkipPermissions checks whether the Bundle's intent to skip environments
+// is permitted by the org-level PolicyGates. Returns an error if any skip is denied.
+//
+// This function was previously called inside Build() which made the check invisible
+// to the Graph. It is now exported so callers (Translator) can call it before Build(),
+// allowing the Bundle reconciler to write the result to Bundle.status (Graph-first).
+// See docs/design/11-graph-purity-tech-debt.md GB-2 (elimination in progress).
+func ValidateSkipPermissions(pipeline *kardinalv1alpha1.Pipeline,
 	bundle *kardinalv1alpha1.Bundle, allGates []kardinalv1alpha1.PolicyGate) error {
 	if bundle.Spec.Intent == nil {
 		return nil

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -217,7 +217,9 @@ func TestBuilder_SkipEnvironments_WithPermission(t *testing.T) {
 }
 
 // Test 6: intent.skipEnvironments = [staging] without SkipPermission.
-// Expected: error (SkipDenied).
+// ValidateSkipPermissions must return an error; Build must succeed (check moved outside Build).
+// Graph-purity: GB-2 eliminated — skip-permission check is no longer inside Build(),
+// it is called by the Translator and the result flows through Bundle.status.
 func TestBuilder_SkipEnvironments_WithoutPermission(t *testing.T) {
 	b := graph.NewBuilder()
 	pipeline := makeLinearPipeline("nginx-demo", "test", "staging", "prod")
@@ -237,14 +239,23 @@ func TestBuilder_SkipEnvironments_WithoutPermission(t *testing.T) {
 		},
 		Spec: kardinalv1alpha1.PolicyGateSpec{Expression: "true"},
 	}
+	gates := []kardinalv1alpha1.PolicyGate{orgGate}
 
-	_, err := b.Build(graph.BuildInput{
-		Pipeline:    pipeline,
-		Bundle:      bundle,
-		PolicyGates: []kardinalv1alpha1.PolicyGate{orgGate},
-	})
+	// ValidateSkipPermissions must return an error — skip is denied.
+	// The Translator calls this before Build() and returns the error to the Bundle reconciler.
+	err := graph.ValidateSkipPermissions(pipeline, bundle, gates)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "skip denied", "error must mention skip denied")
+
+	// Build itself must succeed — the skip-environment is filtered out by filterByIntent.
+	// The caller (Translator) is responsible for preventing Build from being called
+	// when ValidateSkipPermissions fails.
+	_, buildErr := b.Build(graph.BuildInput{
+		Pipeline:    pipeline,
+		Bundle:      bundle,
+		PolicyGates: gates,
+	})
+	require.NoError(t, buildErr, "Build must succeed when skip check has been separated out")
 }
 
 // Test 7: Shard label on prod environment.

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -65,6 +65,15 @@ func (t *Translator) Translate(ctx context.Context,
 
 	log.Debug().Int("gates", len(gates)).Msg("collected policy gates")
 
+	// Validate skip permissions before building the Graph.
+	// The result of this check flows into Bundle.status via the Bundle reconciler
+	// (which sets phase=Failed if Translate returns an error). This makes the
+	// skip-permission decision observable via CRD status rather than invisible
+	// inside graph.Builder. Eliminates GB-2 from 11-graph-purity-tech-debt.md.
+	if err := graph.ValidateSkipPermissions(pipeline, bundle, gates); err != nil {
+		return "", fmt.Errorf("translator.Translate: skip permission denied: %w", err)
+	}
+
 	// Build Graph spec
 	result, err := t.builder.Build(graph.BuildInput{
 		Pipeline:    pipeline,


### PR DESCRIPTION
[🔨 Core Agent] Fixes #145

**Scope**: Core — graph/translator
**Boundary**: area/graph | v0.2.1
**Packages modified**: pkg/graph, pkg/translator

## Summary

Eliminates GB-2 from docs/design/11-graph-purity-tech-debt.md.

Previously: `validateSkipPermissions()` was called inside `graph.Build()` — a pure function with no observable CRD result. The Graph never saw skip denials.

### Fix

1. `pkg/graph/builder.go`: Export `ValidateSkipPermissions` and remove the call from `Build()`
2. `pkg/translator/translator.go`: Call `graph.ValidateSkipPermissions()` after collecting gates, before `Build()`. Error propagates to Bundle reconciler → `Bundle.status.phase=Failed` — a Graph-observable CRD status write.

### Architecture

Skip-permission result → `Bundle.status.phase` → observable via kubectl and Graph CEL. Graph-first compliant.