### PR TITLE
[STANDALONE-CORE] chore(graph): document sequential default and dual-slug convention explicitly

### DIFF
--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -13,7 +13,12 @@ type PipelineSpec struct {
 	// environments in this pipeline.
 	Git PipelineGit `json:"git"`
 
-	// Environments lists the promotion path in order.
+	// Environments lists the promotion path.
+	// Sequential ordering (GB-1): when an environment does not specify dependsOn,
+	// it implicitly depends on the previous entry in this list. The first environment
+	// has no upstream dependency. This sequential default means a list of N environments
+	// without dependsOn fields produces a linear chain. Override with dependsOn to
+	// express parallel fan-out or explicit DAG structure.
 	// +kubebuilder:validation:MinItems=1
 	Environments []EnvironmentSpec `json:"environments"`
 

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -705,13 +705,24 @@ func gateNodeK8sName(bundleSlugK8s, gateName, gateNS, envName string) string {
 	return slugify(fmt.Sprintf("%s-%s-%s--%s", gateName, ns, envName, bundleSlugK8s))
 }
 
-// bundleVersionSlug returns a slug from the bundle name suitable for node naming.
+// bundleVersionSlug returns a CEL-safe slug from the bundle name for use in node IDs.
+//
+// Dual-slug convention (GB-3/GB-4 in docs/design/11-graph-purity-tech-debt.md):
+//   - celSafeSlug / bundleVersionSlug → underscores, valid CEL identifiers
+//     Used in: node IDs, readyWhen/propagateWhen CEL expressions, gateNodeName
+//   - slugify → hyphens, valid Kubernetes resource names
+//     Used in: metadata.name fields only
+//
+// Always use celSafeSlug for IDs appearing in CEL expressions.
+// Always use slugify for Kubernetes resource names.
 func bundleVersionSlug(bundleName string) string {
 	return celSafeSlug(bundleName)
 }
 
 // slugify replaces characters not valid in Kubernetes names with dashes.
-// Use celSafeSlug for node IDs that appear in CEL expressions.
+// Produces kebab-case (hyphens) suitable for metadata.name fields.
+// Do NOT use for CEL expression identifiers — use celSafeSlug instead.
+// See dual-slug convention in bundleVersionSlug doc comment.
 func slugify(s string) string {
 	var b strings.Builder
 	for _, c := range s {
@@ -730,6 +741,7 @@ func slugify(s string) string {
 // celSafeSlug creates an identifier safe for use as a CEL variable name.
 // CEL identifiers follow Go rules: letters, digits, underscores; must not
 // start with a digit. Hyphens and other special chars are replaced with '_'.
+// See dual-slug convention in bundleVersionSlug doc comment.
 func celSafeSlug(s string) string {
 	var b strings.Builder
 	for i, c := range s {


### PR DESCRIPTION
[🔨 Core Agent] Fixes #150

**Scope**: Core — graph builder, api/v1alpha1
**Boundary**: area/graph | v0.2.1
**Packages modified**: api/v1alpha1, pkg/graph

## Summary

Documentation-only fix addressing GB-1, GB-3, GB-4 from docs/design/11-graph-purity-tech-debt.md.

### GB-1

Updated `PipelineSpec.Environments` field comment to explicitly document the sequential ordering default: when an environment does not specify `dependsOn`, it implicitly depends on the previous entry. Makes the convention observable from the CRD spec.

### GB-3/GB-4

Added explicit dual-slug convention documentation to `bundleVersionSlug`, `slugify`, and `celSafeSlug": CEL-safe (underscores) vs K8s-safe (hyphens).

No behavior changes.