### PR TITLE
[STANDALONE-CORE] chore(api): document type-aware supersession rule in BundleSpec.Type (BU-4)

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -10,6 +10,9 @@ import (
 // BundleSpec defines the desired state of a Bundle.
 type BundleSpec struct {
 	// Type classifies the bundle content.
+	// Supersession rule (BU-4): each bundle type supersedes only bundles of the same type.
+	// An image bundle does NOT supersede a config bundle and vice versa.
+	// This allows image and config promotions to coexist independently in the same pipeline.
 	// +kubebuilder:validation:Enum=image;config;mixed
 	// +kubebuilder:validation:Required
 	Type string `json:"type"`


### PR DESCRIPTION
[🔨 Core Agent] Partially fixes #153

**Scope**: Core — api/v1alpha1
**Boundary**: area/controller | v0.2.1
**Packages modified**: api/v1alpha1

## Summary

Documents the BU-4 type-aware supersession rule (from docs/design/11-graph-purity-tech-debt.md) at the CRD spec level.

The rule is: each bundle type supersedes only bundles of the same type. Added this to `BundleSpec.Type` field comment.

**WH-2 note**: The webhook.go URL parsing duplication requires `cmd/kardinal-controller/webhook.go` which is outside STANDALONE-CORE boundary. The `bundle/reconciler.go` duplication mentioned in the issue was already removed in PR #184.