### PR TITLE
[Extensions Agent] feat(health): add WatchNodeTemplate for krocodile ShapeWatch node generation

### DIFF
--- a/pkg/health/watch_node.go
+++ b/pkg/health/watch_node.go
@@ -1,0 +1,187 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"fmt"
+)
+
+// WatchNodeSpec describes a krocodile ShapeWatch node template for health verification.
+//
+// The translator uses this struct to emit a Watch node in the Graph spec instead of
+// calling the Go health adapter at reconcile time. This moves health verification
+// into the Graph layer (HE-1, HE-2, HE-3 from docs/design/11-graph-purity-tech-debt.md).
+//
+// The node variable name in ReadyWhen is always "healthNode" — the translator assigns
+// a unique Graph node ID (e.g. "health_prod") and must substitute "healthNode" with
+// the actual ID when generating the Graph spec.
+type WatchNodeSpec struct {
+	// APIVersion is the Kubernetes API version of the resource to watch.
+	// Example: "apps/v1", "argoproj.io/v1alpha1".
+	APIVersion string
+
+	// Kind is the Kubernetes Kind of the resource to watch.
+	// Example: "Deployment", "Application", "Kustomization".
+	Kind string
+
+	// Name is the resource name to watch.
+	Name string
+
+	// Namespace is the resource namespace to watch.
+	Namespace string
+
+	// ReadyWhen is a krocodile CEL expression evaluated against the watched resource.
+	// The node variable placeholder is "healthNode". The translator must substitute
+	// "healthNode" with the actual Graph node ID before emitting the Graph spec.
+	//
+	// Example:
+	//   "healthNode.status.conditions.exists(c, c.type == 'Available' && c.status == 'True')"
+	ReadyWhen string
+
+	// HealthType is the adapter type that produced this spec.
+	// Preserved for debugging and documentation purposes.
+	HealthType string
+}
+
+// WatchNodeTemplate returns a krocodile ShapeWatch node spec for the given health type
+// and configuration. The translator calls this function to get the Watch node template
+// and readyWhen CEL expression for a Pipeline environment's health check.
+//
+// This function is pure and has no side effects. It is safe to call from any context.
+//
+// The ReadyWhen expression uses "healthNode" as the node variable placeholder. The
+// translator must replace "healthNode" with the actual Graph node ID (e.g. "health_prod")
+// before emitting the Graph spec.
+func WatchNodeTemplate(healthType string, opts CheckOptions) (WatchNodeSpec, error) {
+	switch healthType {
+	case "resource":
+		return watchNodeResource(opts.Resource), nil
+	case "argocd":
+		return watchNodeArgoCD(opts.ArgoCD), nil
+	case "flux":
+		return watchNodeFlux(opts.Flux), nil
+	case "argoRollouts":
+		return watchNodeArgoRollouts(opts.ArgoRollouts), nil
+	case "flagger":
+		return watchNodeFlagger(opts.Flagger), nil
+	case "":
+		return WatchNodeSpec{}, fmt.Errorf(
+			"health.type is required: set health.type to one of [resource, argocd, flux, argoRollouts, flagger]")
+	default:
+		return WatchNodeSpec{}, fmt.Errorf(
+			"unknown health.type %q: must be one of [resource, argocd, flux, argoRollouts, flagger]",
+			healthType)
+	}
+}
+
+// watchNodeResource builds a Watch node spec for a Kubernetes Deployment.
+//
+// readyWhen: the Available condition must be True.
+// HE-1 in docs/design/11-graph-purity-tech-debt.md.
+func watchNodeResource(cfg ResourceConfig) WatchNodeSpec {
+	condition := cfg.Condition
+	if condition == "" {
+		condition = "Available"
+	}
+	return WatchNodeSpec{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       cfg.Name,
+		Namespace:  cfg.Namespace,
+		ReadyWhen: fmt.Sprintf(
+			"healthNode.status.conditions.exists(c, c.type == %q && c.status == 'True')",
+			condition,
+		),
+		HealthType: "resource",
+	}
+}
+
+// watchNodeArgoCD builds a Watch node spec for an Argo CD Application.
+//
+// readyWhen: health=Healthy AND sync=Synced.
+// HE-2 in docs/design/11-graph-purity-tech-debt.md.
+func watchNodeArgoCD(cfg ArgoCDConfig) WatchNodeSpec {
+	ns := cfg.Namespace
+	if ns == "" {
+		ns = "argocd"
+	}
+	return WatchNodeSpec{
+		APIVersion: "argoproj.io/v1alpha1",
+		Kind:       "Application",
+		Name:       cfg.Name,
+		Namespace:  ns,
+		ReadyWhen: "healthNode.status.health.status == 'Healthy' && " +
+			"healthNode.status.sync.status == 'Synced'",
+		HealthType: "argocd",
+	}
+}
+
+// watchNodeFlux builds a Watch node spec for a Flux Kustomization.
+//
+// readyWhen: the Ready condition is True AND observedGeneration matches generation
+// (confirming the latest revision has been reconciled).
+// HE-3 in docs/design/11-graph-purity-tech-debt.md.
+func watchNodeFlux(cfg FluxConfig) WatchNodeSpec {
+	ns := cfg.Namespace
+	if ns == "" {
+		ns = "flux-system"
+	}
+	return WatchNodeSpec{
+		APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+		Kind:       "Kustomization",
+		Name:       cfg.Name,
+		Namespace:  ns,
+		ReadyWhen: "healthNode.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True') && " +
+			"healthNode.status.observedGeneration == healthNode.metadata.generation",
+		HealthType: "flux",
+	}
+}
+
+// watchNodeArgoRollouts builds a Watch node spec for an Argo Rollouts Rollout.
+//
+// readyWhen: status.phase == "Healthy".
+func watchNodeArgoRollouts(cfg ArgoRolloutsConfig) WatchNodeSpec {
+	ns := cfg.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	return WatchNodeSpec{
+		APIVersion: "argoproj.io/v1alpha1",
+		Kind:       "Rollout",
+		Name:       cfg.Name,
+		Namespace:  ns,
+		ReadyWhen:  "healthNode.status.phase == 'Healthy'",
+		HealthType: "argoRollouts",
+	}
+}
+
+// watchNodeFlagger builds a Watch node spec for a Flagger Canary.
+//
+// readyWhen: status.phase == "Succeeded".
+func watchNodeFlagger(cfg FlaggerConfig) WatchNodeSpec {
+	ns := cfg.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	return WatchNodeSpec{
+		APIVersion: "flagger.app/v1beta1",
+		Kind:       "Canary",
+		Name:       cfg.Name,
+		Namespace:  ns,
+		ReadyWhen:  "healthNode.status.phase == 'Succeeded'",
+		HealthType: "flagger",
+	}
+}

--- a/pkg/health/watch_node_test.go
+++ b/pkg/health/watch_node_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/health"
+)
+
+// TestWatchNodeTemplate_Resource verifies that health.type=resource produces
+// a Watch node spec for apps/v1 Deployment with the correct readyWhen expression.
+func TestWatchNodeTemplate_Resource(t *testing.T) {
+	spec, err := health.WatchNodeTemplate("resource", health.CheckOptions{
+		Resource: health.ResourceConfig{
+			Name:      "nginx",
+			Namespace: "prod",
+			Condition: "Available",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "apps/v1", spec.APIVersion)
+	assert.Equal(t, "Deployment", spec.Kind)
+	assert.Equal(t, "nginx", spec.Name)
+	assert.Equal(t, "prod", spec.Namespace)
+	assert.NotEmpty(t, spec.ReadyWhen, "ReadyWhen must be a non-empty CEL expression")
+	assert.Contains(t, spec.ReadyWhen, "Available")
+	assert.Equal(t, "resource", spec.HealthType)
+}
+
+// TestWatchNodeTemplate_ResourceDefaultCondition verifies that an empty Condition
+// defaults to "Available".
+func TestWatchNodeTemplate_ResourceDefaultCondition(t *testing.T) {
+	spec, err := health.WatchNodeTemplate("resource", health.CheckOptions{
+		Resource: health.ResourceConfig{
+			Name:      "nginx",
+			Namespace: "prod",
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, spec.ReadyWhen, "Available")
+}
+
+// TestWatchNodeTemplate_ArgoCD verifies that health.type=argocd produces
+// a Watch node spec for argoproj.io/v1alpha1 Application.
+func TestWatchNodeTemplate_ArgoCD(t *testing.T) {
+	spec, err := health.WatchNodeTemplate("argocd", health.CheckOptions{
+		ArgoCD: health.ArgoCDConfig{
+			Name:      "nginx-prod",
+			Namespace: "argocd",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "argoproj.io/v1alpha1", spec.APIVersion)
+	assert.Equal(t, "Application", spec.Kind)
+	assert.Equal(t, "nginx-prod", spec.Name)
+	assert.Equal(t, "argocd", spec.Namespace)
+	assert.Contains(t, spec.ReadyWhen, "Healthy")
+	assert.Contains(t, spec.ReadyWhen, "Synced")
+	assert.Equal(t, "argocd", spec.HealthType)
+}
+
+// TestWatchNodeTemplate_ArgoCDDefaultNamespace verifies that an empty Namespace
+// defaults to "argocd".
+func TestWatchNodeTemplate_ArgoCDDefaultNamespace(t *testing.T) {
+	spec, err := health.WatchNodeTemplate("argocd", health.CheckOptions{
+		ArgoCD: health.ArgoCDConfig{
+			Name: "nginx-prod",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "argocd", spec.Namespace)
+}
+
+// TestWatchNodeTemplate_Flux verifies that health.type=flux produces
+// a Watch node spec for kustomize.toolkit.fluxcd.io/v1 Kustomization.
+func TestWatchNodeTemplate_Flux(t *testing.T) {
+	spec, err := health.WatchNodeTemplate("flux", health.CheckOptions{
+		Flux: health.FluxConfig{
+			Name:      "nginx-prod",
+			Namespace: "flux-system",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "kustomize.toolkit.fluxcd.io/v1", spec.APIVersion)
+	assert.Equal(t, "Kustomization", spec.Kind)
+	assert.Equal(t, "nginx-prod", spec.Name)
+	assert.Equal(t, "flux-system", spec.Namespace)
+	assert.Contains(t, spec.ReadyWhen, "Ready")
+	assert.Equal(t, "flux", spec.HealthType)
+}
+
+// TestWatchNodeTemplate_FluxDefaultNamespace verifies that an empty Namespace
+// defaults to "flux-system".
+func TestWatchNodeTemplate_FluxDefaultNamespace(t *testing.T) {
+	spec, err := health.WatchNodeTemplate("flux", health.CheckOptions{
+		Flux: health.FluxConfig{Name: "nginx-prod"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "flux-system", spec.Namespace)
+}
+
+// TestWatchNodeTemplate_ArgoRollouts verifies that health.type=argoRollouts produces
+// a Watch node spec for argoproj.io/v1alpha1 Rollout.
+func TestWatchNodeTemplate_ArgoRollouts(t *testing.T) {
+	spec, err := health.WatchNodeTemplate("argoRollouts", health.CheckOptions{
+		ArgoRollouts: health.ArgoRolloutsConfig{
+			Name:      "my-app",
+			Namespace: "prod",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "argoproj.io/v1alpha1", spec.APIVersion)
+	assert.Equal(t, "Rollout", spec.Kind)
+	assert.Equal(t, "my-app", spec.Name)
+	assert.Equal(t, "prod", spec.Namespace)
+	assert.Contains(t, spec.ReadyWhen, "Healthy")
+	assert.Equal(t, "argoRollouts", spec.HealthType)
+}
+
+// TestWatchNodeTemplate_Flagger verifies that health.type=flagger produces
+// a Watch node spec for flagger.app/v1beta1 Canary.
+func TestWatchNodeTemplate_Flagger(t *testing.T) {
+	spec, err := health.WatchNodeTemplate("flagger", health.CheckOptions{
+		Flagger: health.FlaggerConfig{
+			Name:      "my-app",
+			Namespace: "prod",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "flagger.app/v1beta1", spec.APIVersion)
+	assert.Equal(t, "Canary", spec.Kind)
+	assert.Equal(t, "my-app", spec.Name)
+	assert.Equal(t, "prod", spec.Namespace)
+	assert.Contains(t, spec.ReadyWhen, "Succeeded")
+	assert.Equal(t, "flagger", spec.HealthType)
+}
+
+// TestWatchNodeTemplate_UnknownType verifies that an unknown health type returns an error.
+func TestWatchNodeTemplate_UnknownType(t *testing.T) {
+	_, err := health.WatchNodeTemplate("unknownType", health.CheckOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknownType")
+}
+
+// TestWatchNodeTemplate_EmptyType verifies that an empty health type returns an error.
+func TestWatchNodeTemplate_EmptyType(t *testing.T) {
+	_, err := health.WatchNodeTemplate("", health.CheckOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "health.type")
+}
+
+// TestWatchNodeTemplate_ReadyWhenIsValidCEL verifies that the ReadyWhen expressions
+// are non-trivial CEL expressions (contain a node reference for the respective adapter).
+func TestWatchNodeTemplate_ReadyWhenIsValidCEL(t *testing.T) {
+	cases := []struct {
+		healthType  string
+		opts        health.CheckOptions
+		wantNodeRef string // the node-id prefix used in the CEL expression
+	}{
+		{
+			"resource",
+			health.CheckOptions{Resource: health.ResourceConfig{Name: "app", Namespace: "ns", Condition: "Available"}},
+			"healthNode",
+		},
+		{
+			"argocd",
+			health.CheckOptions{ArgoCD: health.ArgoCDConfig{Name: "app", Namespace: "argocd"}},
+			"healthNode",
+		},
+		{
+			"flux",
+			health.CheckOptions{Flux: health.FluxConfig{Name: "app", Namespace: "flux-system"}},
+			"healthNode",
+		},
+		{
+			"argoRollouts",
+			health.CheckOptions{ArgoRollouts: health.ArgoRolloutsConfig{Name: "app", Namespace: "ns"}},
+			"healthNode",
+		},
+		{
+			"flagger",
+			health.CheckOptions{Flagger: health.FlaggerConfig{Name: "app", Namespace: "ns"}},
+			"healthNode",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.healthType, func(t *testing.T) {
+			spec, err := health.WatchNodeTemplate(tc.healthType, tc.opts)
+			require.NoError(t, err)
+			assert.NotEmpty(t, spec.ReadyWhen)
+			// The ReadyWhen expression must reference a node variable (not be a literal constant)
+			assert.Contains(t, spec.ReadyWhen, ".", "ReadyWhen must reference node fields via dot notation")
+		})
+	}
+}


### PR DESCRIPTION
Fixes part of #136

## Summary

Adds `WatchNodeTemplate()` to `pkg/health` — a pure, side-effect-free function
that returns a `WatchNodeSpec` containing the krocodile ShapeWatch node template
and `readyWhen` CEL expression for each supported health adapter type.

**Supported types**: `resource`, `argocd`, `flux`, `argoRollouts`, `flagger`

This is the `pkg/health` portion of the #136 refactor. It unblocks HE-1, HE-2,
HE-3 from `docs/design/11-graph-purity-tech-debt.md`.

## What this PR does

- Adds `WatchNodeSpec` struct describing the Watch node fields + `ReadyWhen` CEL
  expression. The translator calls `WatchNodeTemplate()` to get this spec and emits
  a `ShapeWatch` node in the Graph instead of polling health adapters at reconcile time.
- `ReadyWhen` uses `"healthNode"` as the node variable placeholder. The translator
  substitutes this with the actual Graph node ID (e.g. `"health_prod"`).
- Adds 15 table-driven tests covering all adapters, default namespace/condition
  fallbacks, unknown type errors, and CEL expression structure validation.

## krocodile status

Verified against krocodile HEAD: `ShapeWatch` is fully supported for external K8s
resources (read-only GET, identity-only template). The `blocked-on-krocodile` label
on #136 can be updated — the remaining work is the translator refactor (Core Agent scope).

## Boundary check

Only `pkg/health/watch_node.go` and `pkg/health/watch_node_test.go` added.
No changes to `pkg/translator`, `pkg/graph`, or any DENY_PACKAGES.

## Scope

**Scope**: Extension points — remaining v0.4.0 isolated work in scm/health/steps
**Packages changed**: `pkg/health` (within `ALLOWED_PACKAGES`)