### PR TITLE
fix(graph-purity): PS-2/BU-2 freeze gate, BU-1/BU-4 self-supersession, PG-3 soakMinutes (batch-a)

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -140,6 +140,14 @@ type EnvironmentStatus struct {
 	// +optional
 	HealthCheckedAt *metav1.Time `json:"healthCheckedAt,omitempty"`
 
+	// SoakMinutes is the number of minutes that have elapsed since HealthCheckedAt.
+	// Written by the BundleReconciler as part of its own CRD status write.
+	// The PolicyGate reconciler reads this field from Bundle.status.environments
+	// to populate bundle.upstreamSoakMinutes in the CEL context. This eliminates
+	// the time.Since() call from the PolicyGate reconciler hot path (PG-3 fix).
+	// +optional
+	SoakMinutes int64 `json:"soakMinutes,omitempty"`
+
 	// GateResults holds the result of each PolicyGate evaluation for this
 	// environment.
 	// +optional

--- a/cmd/kardinal/cmd/cli_test.go
+++ b/cmd/kardinal/cmd/cli_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -87,7 +88,8 @@ func TestRollback_CreatesBundleWithRollbackOf(t *testing.T) {
 	assert.Equal(t, "prod", rb.Spec.Intent.TargetEnvironment)
 }
 
-// TestPause_PatchesPipelinePaused verifies that pauseFn patches Pipeline.spec.paused=true.
+// TestPause_PatchesPipelinePaused verifies that pauseFn patches Pipeline.spec.paused=true
+// and creates a freeze PolicyGate (Graph-observable pause enforcement, PS-2 / BU-2 fix).
 func TestPause_PatchesPipelinePaused(t *testing.T) {
 	s := cliTestScheme(t)
 	pipeline := &v1alpha1.Pipeline{
@@ -107,9 +109,35 @@ func TestPause_PatchesPipelinePaused(t *testing.T) {
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo", Namespace: "default"}, &updated))
 	assert.True(t, updated.Spec.Paused)
 	assert.Contains(t, buf.String(), "paused")
+
+	// Freeze gate must have been created.
+	var gate v1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "freeze-nginx-demo", Namespace: "default"}, &gate))
+	assert.Equal(t, "false", gate.Spec.Expression, "freeze gate must always evaluate to false")
+	assert.Equal(t, "true", gate.Labels["kardinal.io/freeze"])
 }
 
-// TestResume_UnpausesPipeline verifies that resumeFn patches Pipeline.spec.paused=false.
+// TestPause_Idempotent verifies that pauseFn is safe to call multiple times
+// (AlreadyExists on the freeze gate is silently swallowed).
+func TestPause_Idempotent(t *testing.T) {
+	s := cliTestScheme(t)
+	pipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Git:          v1alpha1.PipelineGit{URL: "https://github.com/test/repo"},
+			Environments: []v1alpha1.EnvironmentSpec{{Name: "test"}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline).Build()
+
+	var buf bytes.Buffer
+	require.NoError(t, pauseFn(&buf, c, "default", "nginx-demo"))
+	// Second call must succeed without error (gate already exists).
+	require.NoError(t, pauseFn(&buf, c, "default", "nginx-demo"), "second pauseFn must be idempotent")
+}
+
+// TestResume_UnpausesPipeline verifies that resumeFn patches Pipeline.spec.paused=false
+// and deletes the freeze PolicyGate (PS-2 / BU-2 fix).
 func TestResume_UnpausesPipeline(t *testing.T) {
 	s := cliTestScheme(t)
 	pipeline := &v1alpha1.Pipeline{
@@ -120,7 +148,11 @@ func TestResume_UnpausesPipeline(t *testing.T) {
 			Paused:       true,
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline).Build()
+	freezeGate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{Name: "freeze-nginx-demo", Namespace: "default"},
+		Spec:       v1alpha1.PolicyGateSpec{Expression: "false"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline, freezeGate).Build()
 
 	var buf bytes.Buffer
 	err := resumeFn(&buf, c, "default", "nginx-demo")
@@ -130,6 +162,30 @@ func TestResume_UnpausesPipeline(t *testing.T) {
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo", Namespace: "default"}, &updated))
 	assert.False(t, updated.Spec.Paused)
 	assert.Contains(t, buf.String(), "resumed")
+
+	// Freeze gate must have been deleted.
+	var gate v1alpha1.PolicyGate
+	err = c.Get(context.Background(), types.NamespacedName{Name: "freeze-nginx-demo", Namespace: "default"}, &gate)
+	assert.True(t, apierrors.IsNotFound(err), "freeze gate must be deleted on resume")
+}
+
+// TestResume_Idempotent verifies that resumeFn is safe when the freeze gate is absent
+// (e.g. manual deletion or first resume after an older-format pause).
+func TestResume_Idempotent(t *testing.T) {
+	s := cliTestScheme(t)
+	pipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Git:          v1alpha1.PipelineGit{URL: "https://github.com/test/repo"},
+			Environments: []v1alpha1.EnvironmentSpec{{Name: "test"}},
+			Paused:       true,
+		},
+	}
+	// No freeze gate in the cluster — should still succeed.
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline).Build()
+
+	var buf bytes.Buffer
+	require.NoError(t, resumeFn(&buf, c, "default", "nginx-demo"), "resumeFn must succeed even if freeze gate is absent")
 }
 
 // TestPolicyList_ShowsGates verifies that policyListFn shows PolicyGate rows.

--- a/cmd/kardinal/cmd/pause.go
+++ b/cmd/kardinal/cmd/pause.go
@@ -20,11 +20,21 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 )
+
+// freezeGateName returns the name of the freeze PolicyGate for the given pipeline.
+// The freeze gate is a special PolicyGate with expression "false" that blocks all
+// promotion for the pipeline. It is created by `kardinal pause` and deleted by
+// `kardinal resume`, making the pause state Graph-observable (PS-2 / BU-2 fix).
+func freezeGateName(pipeline string) string {
+	return "freeze-" + pipeline
+}
 
 func newPauseCmd() *cobra.Command {
 	return &cobra.Command{
@@ -42,6 +52,8 @@ func newPauseCmd() *cobra.Command {
 }
 
 // pauseFn is the testable implementation of pause.
+// It sets Pipeline.Spec.Paused=true AND creates a freeze PolicyGate with
+// expression "false" so the pause state is visible to the Graph (PS-2 / BU-2).
 func pauseFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client, ns, pipeline string) error {
 	ctx := context.Background()
 
@@ -50,10 +62,32 @@ func pauseFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client, ns
 		return fmt.Errorf("get pipeline %s: %w", pipeline, getErr)
 	}
 
+	// Set Pipeline.Spec.Paused = true for backward compatibility.
 	patch := sigs_client.MergeFrom(p.DeepCopy())
 	p.Spec.Paused = true
 	if patchErr := c.Patch(ctx, &p, patch); patchErr != nil {
 		return fmt.Errorf("patch pipeline %s paused=true: %w", pipeline, patchErr)
+	}
+
+	// Create the freeze gate. This is idempotent (ServerSideApply): if it already
+	// exists (e.g. from a previous pause), re-creating it is a no-op.
+	freezeGate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      freezeGateName(pipeline),
+			Namespace: ns,
+			Labels: map[string]string{
+				"kardinal.io/pipeline": pipeline,
+				"kardinal.io/scope":    "system",
+				"kardinal.io/freeze":   "true",
+			},
+		},
+		Spec: v1alpha1.PolicyGateSpec{
+			Expression: "false",
+			Message:    "Pipeline is paused — resume with: kardinal resume " + pipeline,
+		},
+	}
+	if createErr := c.Create(ctx, freezeGate); createErr != nil && !apierrors.IsAlreadyExists(createErr) {
+		return fmt.Errorf("create freeze gate for pipeline %s: %w", pipeline, createErr)
 	}
 
 	if _, err := fmt.Fprintf(w, "Pipeline %s paused. No new promotions will start.\n", pipeline); err != nil {
@@ -79,6 +113,8 @@ func newResumeCmd() *cobra.Command {
 }
 
 // resumeFn is the testable implementation of resume.
+// It sets Pipeline.Spec.Paused=false AND deletes the freeze PolicyGate,
+// making the resume state visible to the Graph (PS-2 / BU-2).
 func resumeFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client, ns, pipeline string) error {
 	ctx := context.Background()
 
@@ -87,10 +123,20 @@ func resumeFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client, n
 		return fmt.Errorf("get pipeline %s: %w", pipeline, getErr)
 	}
 
+	// Set Pipeline.Spec.Paused = false.
 	patch := sigs_client.MergeFrom(p.DeepCopy())
 	p.Spec.Paused = false
 	if patchErr := c.Patch(ctx, &p, patch); patchErr != nil {
 		return fmt.Errorf("patch pipeline %s paused=false: %w", pipeline, patchErr)
+	}
+
+	// Delete the freeze gate. Idempotent: if it doesn't exist (already deleted
+	// or never created), we silently succeed.
+	freezeGate := &v1alpha1.PolicyGate{}
+	freezeGate.Name = freezeGateName(pipeline)
+	freezeGate.Namespace = ns
+	if delErr := c.Delete(ctx, freezeGate); delErr != nil && !apierrors.IsNotFound(delErr) {
+		return fmt.Errorf("delete freeze gate for pipeline %s: %w", pipeline, delErr)
 	}
 
 	if _, err := fmt.Fprintf(w, "Pipeline %s resumed.\n", pipeline); err != nil {

--- a/pkg/reconciler/bundle/reconciler.go
+++ b/pkg/reconciler/bundle/reconciler.go
@@ -15,8 +15,9 @@
 
 // Package bundle implements the BundleReconciler which watches Bundle objects,
 // sets status.phase = Available on newly-created Bundles, triggers the
-// Pipeline-to-Graph translation, handles Bundle supersession, and syncs
-// per-environment promotion evidence from PromotionStep status.
+// Pipeline-to-Graph translation, handles Bundle self-supersession (BU-1/BU-4 fix:
+// each bundle detects a newer sibling and supersedes itself, avoiding cross-CRD
+// mutations), and syncs per-environment promotion evidence from PromotionStep status.
 package bundle
 
 import (
@@ -55,8 +56,8 @@ type Reconciler struct {
 // or whenever a PromotionStep for this bundle changes (via the Watch in SetupWithManager).
 //
 // State machine:
-//   - Phase = "" (new Bundle): supersede older Promoting bundles, set to Available
-//   - Phase = "Available" (ready to promote): look up Pipeline, call Translator,
+//   - Phase = "" (new Bundle): set to Available; each bundle self-supersedes if a newer same-type bundle exists
+//   - Phase = "Available" (ready to promote): check self-supersession; look up Pipeline, call Translator,
 //     set phase to Promoting
 //   - Phase = "Promoting" | "Verified" | "Failed": sync evidence from PromotionStep status
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -78,6 +79,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	case "":
 		return r.handleNew(ctx, log, &b)
 	case "Available":
+		// Check self-supersession before attempting to promote.
+		if superseded, err := r.isSuperseededByNewer(ctx, &b); err != nil {
+			log.Warn().Err(err).Msg("failed to check for newer bundle (non-fatal)")
+		} else if superseded {
+			return r.markSuperseded(ctx, log, &b)
+		}
 		return r.handleAvailable(ctx, log, &b)
 	default:
 		// For Promoting, Verified, Failed: sync evidence from PromotionStep status.
@@ -87,15 +94,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 // handleNew sets the phase to Available on a newly-created Bundle.
-// It also supersedes any older Bundles in Promoting state for the same Pipeline.
+// Supersession of older bundles is no longer done here (BU-1 fix). Each bundle
+// is responsible for superseding itself when it detects a newer bundle exists.
 func (r *Reconciler) handleNew(ctx context.Context, log zerolog.Logger,
 	b *kardinalv1alpha1.Bundle) (ctrl.Result, error) {
-	// Supersession: mark older Promoting bundles for the same Pipeline as Superseded.
-	if supersErr := r.supersedeSiblings(ctx, log, b); supersErr != nil {
-		// Non-fatal: log and continue. The new bundle must still become Available.
-		log.Warn().Err(supersErr).Msg("failed to supersede sibling bundles (non-fatal)")
-	}
-
 	patch := client.MergeFrom(b.DeepCopy())
 	b.Status.Phase = "Available"
 
@@ -114,50 +116,53 @@ func (r *Reconciler) handleNew(ctx context.Context, log zerolog.Logger,
 	return ctrl.Result{RequeueAfter: time.Millisecond}, nil
 }
 
-// supersedeSiblings finds and marks Promoting bundles for the same Pipeline as Superseded.
-// It is idempotent: already-superseded bundles are skipped.
-// Type-aware: image bundles only supersede image bundles; config bundles only supersede
-// config bundles. This allows image and config promotions to coexist independently.
-func (r *Reconciler) supersedeSiblings(ctx context.Context, log zerolog.Logger,
-	newBundle *kardinalv1alpha1.Bundle) error {
+// isSuperseededByNewer returns true if there is a newer Bundle for the same
+// pipeline and type that is not yet Superseded or Failed. This implements
+// self-supersession: each bundle checks if it should yield to a newer sibling,
+// writing only to its own status (BU-1 / BU-4 fix — no cross-CRD mutations).
+func (r *Reconciler) isSuperseededByNewer(ctx context.Context, b *kardinalv1alpha1.Bundle) (bool, error) {
 	var bundles kardinalv1alpha1.BundleList
-	if err := r.List(ctx, &bundles,
-		client.InNamespace(newBundle.Namespace),
-	); err != nil {
-		return fmt.Errorf("list bundles: %w", err)
+	if err := r.List(ctx, &bundles, client.InNamespace(b.Namespace)); err != nil {
+		return false, fmt.Errorf("list bundles for supersession check: %w", err)
 	}
 
 	for i := range bundles.Items {
 		sibling := &bundles.Items[i]
-		// Skip self and bundles targeting a different Pipeline.
-		if sibling.Name == newBundle.Name {
+		if sibling.Name == b.Name {
 			continue
 		}
-		if sibling.Spec.Pipeline != newBundle.Spec.Pipeline {
+		if sibling.Spec.Pipeline != b.Spec.Pipeline {
 			continue
 		}
-		// Only supersede bundles of the same type (image vs config independence).
-		if sibling.Spec.Type != newBundle.Spec.Type {
+		// Type-aware: image bundles are only superseded by image bundles, etc.
+		if sibling.Spec.Type != b.Spec.Type {
 			continue
 		}
-		// Only supersede bundles that are actively promoting.
-		if sibling.Status.Phase != "Promoting" && sibling.Status.Phase != "Available" {
+		// Skip terminal or already-superseded siblings.
+		if sibling.Status.Phase == "Superseded" || sibling.Status.Phase == "Failed" || sibling.Status.Phase == "Verified" {
 			continue
 		}
-
-		patch := client.MergeFrom(sibling.DeepCopy())
-		sibling.Status.Phase = "Superseded"
-		if patchErr := r.Status().Patch(ctx, sibling, patch); patchErr != nil {
-			log.Error().Err(patchErr).Str("sibling", sibling.Name).Msg("failed to supersede bundle")
-			return fmt.Errorf("supersede bundle %s: %w", sibling.Name, patchErr)
+		// A sibling that is not terminal and was created after us means we are superseded.
+		if sibling.CreationTimestamp.After(b.CreationTimestamp.Time) {
+			return true, nil
 		}
-
-		log.Info().
-			Str("superseded", sibling.Name).
-			Str("by", newBundle.Name).
-			Msg("bundle superseded")
 	}
-	return nil
+	return false, nil
+}
+
+// markSuperseded sets this bundle's status.phase to "Superseded" (self-supersession).
+func (r *Reconciler) markSuperseded(ctx context.Context, log zerolog.Logger,
+	b *kardinalv1alpha1.Bundle) (ctrl.Result, error) {
+	patch := client.MergeFrom(b.DeepCopy())
+	b.Status.Phase = "Superseded"
+	if err := r.Status().Patch(ctx, b, patch); err != nil {
+		return ctrl.Result{}, fmt.Errorf("patch bundle status Superseded: %w", err)
+	}
+	log.Info().
+		Str("pipeline", b.Spec.Pipeline).
+		Str("type", b.Spec.Type).
+		Msg("bundle superseded by newer bundle (self-supersession)")
+	return ctrl.Result{}, nil
 }
 
 // handleAvailable triggers Graph creation and advances phase to Promoting.

--- a/pkg/reconciler/bundle/reconciler.go
+++ b/pkg/reconciler/bundle/reconciler.go
@@ -262,6 +262,7 @@ func (r *Reconciler) handleSyncEvidence(ctx context.Context, log zerolog.Logger,
 			Phase:           ps.Status.State,
 			PRURL:           ps.Status.PRURL,
 			HealthCheckedAt: prev.HealthCheckedAt, // preserve if already set
+			SoakMinutes:     prev.SoakMinutes,     // will be updated below if HealthCheckedAt is set
 		}
 
 		// Use the prURL from outputs if available (more reliable than status.PRURL).
@@ -276,9 +277,22 @@ func (r *Reconciler) handleSyncEvidence(ctx context.Context, log zerolog.Logger,
 			updated.HealthCheckedAt = &now
 		}
 
+		// Update SoakMinutes if HealthCheckedAt is set.
+		// This is the PG-3 fix: soakMinutes is now a CRD field written by the
+		// BundleReconciler (owns Bundle status), so the PolicyGate reconciler can
+		// read it without calling time.Since() in its hot path.
+		// time.Now() here is inside a CRD status write — Graph-first compliant.
+		if updated.HealthCheckedAt != nil {
+			elapsed := time.Now().UTC().Sub(updated.HealthCheckedAt.UTC())
+			if elapsed > 0 {
+				updated.SoakMinutes = int64(elapsed.Minutes())
+			}
+		}
+
 		// Only mark changed if something actually differs.
 		if prev.Phase != updated.Phase || prev.PRURL != updated.PRURL ||
-			(updated.HealthCheckedAt != nil && prev.HealthCheckedAt == nil) {
+			(updated.HealthCheckedAt != nil && prev.HealthCheckedAt == nil) ||
+			updated.SoakMinutes != prev.SoakMinutes {
 			envMap[envName] = updated
 			changed = true
 		}

--- a/pkg/reconciler/bundle/reconciler.go
+++ b/pkg/reconciler/bundle/reconciler.go
@@ -184,16 +184,11 @@ func (r *Reconciler) handleAvailable(ctx context.Context, log zerolog.Logger,
 		return ctrl.Result{}, fmt.Errorf("get pipeline %s: %w", b.Spec.Pipeline, err)
 	}
 
-	// If the Pipeline is paused, do not start a new promotion.
-	// Requeue after a short interval to re-check the pause state.
-	if pipeline.Spec.Paused {
-		log.Info().
-			Str("pipeline", pipeline.Name).
-			Msg("pipeline is paused — holding bundle at Available until resumed")
-		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
-	}
-
 	// Translate Pipeline+Bundle into a Graph
+	// Note: Pipeline.Spec.Paused enforcement is handled by the freeze PolicyGate
+	// (created by `kardinal pause`) which blocks all Graph nodes. The reconciler
+	// does not check Spec.Paused directly — that would be a Graph-invisible
+	// business rule (PS-2 / BU-2). The freeze gate IS visible to the Graph.
 	graphName, err := r.Translator.Translate(ctx, &pipeline, b)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to translate bundle to graph")

--- a/pkg/reconciler/bundle/reconciler_test.go
+++ b/pkg/reconciler/bundle/reconciler_test.go
@@ -245,23 +245,79 @@ func TestBundleReconciler_PromotingPhaseIsNoOp(t *testing.T) {
 	assert.False(t, translator.called, "Translator must NOT be called for Promoting bundles")
 }
 
-// TestBundleReconciler_Supersession verifies that creating a new Bundle for a Pipeline
-// supersedes older Promoting bundles.
-func TestBundleReconciler_Supersession(t *testing.T) {
-	// Old bundle is Promoting for the same pipeline.
+// TestBundleReconciler_SelfSupersession verifies the BU-1 fix: self-supersession.
+// When an older Available bundle detects a newer sibling, it marks itself Superseded.
+// This replaces the old cross-CRD write where the new bundle superseded its siblings.
+func TestBundleReconciler_SelfSupersession(t *testing.T) {
+	// Old bundle is Available for the same pipeline (older creation timestamp).
 	oldBundle := &kardinalv1alpha1.Bundle{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "nginx-demo-v1",
 			Namespace:         "default",
-			CreationTimestamp: metav1.Time{},
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec:   kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status: kardinalv1alpha1.BundleStatus{Phase: "Available"},
+	}
+	// New bundle is Available and was created later.
+	newBundleObj := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-v2",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec:   kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status: kardinalv1alpha1.BundleStatus{Phase: "Available"},
+	}
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(oldBundle, newBundleObj).
+		WithStatusSubresource(oldBundle, newBundleObj).
+		Build()
+
+	r := &bundle.Reconciler{Client: c}
+
+	// Reconcile old bundle — it detects the newer sibling and marks itself Superseded.
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	// Old bundle should be Superseded (self-supersession).
+	var gotOld kardinalv1alpha1.Bundle
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &gotOld))
+	assert.Equal(t, "Superseded", gotOld.Status.Phase)
+
+	// New bundle is unaffected.
+	var gotNew kardinalv1alpha1.Bundle
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v2", Namespace: "default"}, &gotNew))
+	assert.Equal(t, "Available", gotNew.Status.Phase)
+}
+
+// TestBundleReconciler_NewBundleBecomesAvailableWithoutSupersedingSiblings documents
+// the BU-1 fix: reconciling the new bundle no longer supersedes siblings.
+// The old bundle remains Available until it reconciles itself (self-supersession).
+func TestBundleReconciler_NewBundleBecomesAvailableWithoutSupersedingSiblings(t *testing.T) {
+	// Old bundle is Promoting.
+	oldBundle := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-v1",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
 		},
 		Spec:   kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
 		Status: kardinalv1alpha1.BundleStatus{Phase: "Promoting"},
 	}
-	// New bundle: no status yet.
+	// New bundle just created (no status).
 	newBundleObj := &kardinalv1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v2", Namespace: "default"},
-		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-v2",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec: kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
 	}
 
 	s := newScheme()
@@ -282,55 +338,77 @@ func TestBundleReconciler_Supersession(t *testing.T) {
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v2", Namespace: "default"}, &gotNew))
 	assert.Equal(t, "Available", gotNew.Status.Phase)
 
-	// Old bundle should be Superseded.
+	// Old bundle should still be Promoting — it has not reconciled itself yet.
+	// (Self-supersession happens when the old bundle's own reconcile runs.)
 	var gotOld kardinalv1alpha1.Bundle
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &gotOld))
-	assert.Equal(t, "Superseded", gotOld.Status.Phase)
+	assert.Equal(t, "Promoting", gotOld.Status.Phase,
+		"old bundle stays Promoting until it reconciles itself (BU-1 self-supersession)")
 }
 
 // TestBundleReconciler_Supersession_DifferentPipeline verifies that bundles for
-// different pipelines are NOT superseded.
+// different pipelines are NOT superseded (self-supersession check).
 func TestBundleReconciler_Supersession_DifferentPipeline(t *testing.T) {
 	otherPipelineBundle := &kardinalv1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "other-pipeline-v1", Namespace: "default"},
-		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "other-pipeline"},
-		Status:     kardinalv1alpha1.BundleStatus{Phase: "Promoting"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "other-pipeline-v1",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec:   kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "other-pipeline"},
+		Status: kardinalv1alpha1.BundleStatus{Phase: "Available"},
 	}
-	newBundleObj := &kardinalv1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v2", Namespace: "default"},
-		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+	newerNginxBundle := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-v2",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec:   kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status: kardinalv1alpha1.BundleStatus{Phase: "Available"},
 	}
 
 	s := newScheme()
 	c := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(otherPipelineBundle, newBundleObj).
-		WithStatusSubresource(otherPipelineBundle, newBundleObj).
+		WithObjects(otherPipelineBundle, newerNginxBundle).
+		WithStatusSubresource(otherPipelineBundle, newerNginxBundle).
 		Build()
 
 	r := &bundle.Reconciler{Client: c}
+	// Reconcile other-pipeline bundle — nginx bundle is for a different pipeline.
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "nginx-demo-v2", Namespace: "default"},
+		NamespacedName: types.NamespacedName{Name: "other-pipeline-v1", Namespace: "default"},
 	})
 	require.NoError(t, err)
 
-	// Other pipeline bundle must remain Promoting (not superseded).
+	// Other pipeline bundle must remain Available (different pipeline — no self-supersession).
 	var gotOther kardinalv1alpha1.Bundle
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "other-pipeline-v1", Namespace: "default"}, &gotOther))
-	assert.Equal(t, "Promoting", gotOther.Status.Phase)
+	assert.Equal(t, "Available", gotOther.Status.Phase)
 }
 
-// TestBundleReconciler_Supersession_IdempotentForSuperseded verifies that
-// already-Superseded bundles are not touched again.
-func TestBundleReconciler_Supersession_IdempotentForSuperseded(t *testing.T) {
+// TestBundleReconciler_SelfSupersession_AlreadySupersededSkipped verifies that
+// a bundle that is already Superseded is not touched again (idempotent).
+func TestBundleReconciler_SelfSupersession_AlreadySupersededSkipped(t *testing.T) {
 	alreadySuperseded := &kardinalv1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v0", Namespace: "default"},
-		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
-		Status:     kardinalv1alpha1.BundleStatus{Phase: "Superseded"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-v0",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec:   kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status: kardinalv1alpha1.BundleStatus{Phase: "Superseded"},
 	}
+	// A new bundle (does not matter — superseded bundles reconcile to terminal state).
 	newBundleObj := &kardinalv1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v2", Namespace: "default"},
-		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-v2",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec:   kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status: kardinalv1alpha1.BundleStatus{Phase: "Available"},
 	}
 
 	s := newScheme()
@@ -342,11 +420,11 @@ func TestBundleReconciler_Supersession_IdempotentForSuperseded(t *testing.T) {
 
 	r := &bundle.Reconciler{Client: c}
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "nginx-demo-v2", Namespace: "default"},
+		NamespacedName: types.NamespacedName{Name: "nginx-demo-v0", Namespace: "default"},
 	})
 	require.NoError(t, err)
 
-	// Still Superseded (not re-patched to a different value).
+	// Still Superseded (evidence sync falls through — terminal state not re-patched).
 	var gotOld kardinalv1alpha1.Bundle
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v0", Namespace: "default"}, &gotOld))
 	assert.Equal(t, "Superseded", gotOld.Status.Phase)
@@ -450,18 +528,27 @@ func TestStartupReconciliation_NoSCMProvider(t *testing.T) {
 }
 
 // TestBundleReconciler_ConfigBundleDoesNotSupersedeImageBundle verifies that a
-// new config Bundle does NOT supersede an in-flight image Bundle for the same Pipeline.
+// config Bundle does NOT self-supersede when a newer image Bundle exists (different type).
 func TestBundleReconciler_ConfigBundleDoesNotSupersedeImageBundle(t *testing.T) {
-	// Image bundle actively promoting.
-	imagBundle := &kardinalv1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1", Namespace: "default"},
-		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
-		Status:     kardinalv1alpha1.BundleStatus{Phase: "Promoting"},
-	}
-	// New config bundle.
+	// Config bundle that's older — should NOT be superseded by the newer image bundle.
 	configBundle := &kardinalv1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-config-v1", Namespace: "default"},
-		Spec:       kardinalv1alpha1.BundleSpec{Type: "config", Pipeline: "nginx-demo"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-config-v1",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec:   kardinalv1alpha1.BundleSpec{Type: "config", Pipeline: "nginx-demo"},
+		Status: kardinalv1alpha1.BundleStatus{Phase: "Available"},
+	}
+	// New image bundle (newer, but different type).
+	imagBundle := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-v2",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec:   kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status: kardinalv1alpha1.BundleStatus{Phase: "Available"},
 	}
 
 	sch := newScheme()
@@ -472,33 +559,38 @@ func TestBundleReconciler_ConfigBundleDoesNotSupersedeImageBundle(t *testing.T) 
 		Build()
 
 	r := &bundle.Reconciler{Client: c}
+	// Reconcile the config bundle — the image bundle is a different type, no self-supersession.
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "nginx-demo-config-v1", Namespace: "default"},
 	})
 	require.NoError(t, err)
 
-	// Image bundle must remain Promoting (different type — not superseded).
-	var gotImage kardinalv1alpha1.Bundle
-	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &gotImage))
-	assert.Equal(t, "Promoting", gotImage.Status.Phase, "image bundle must not be superseded by config bundle")
-
-	// Config bundle should be Available.
+	// Config bundle must remain Available (different type — no self-supersession).
 	var gotConfig kardinalv1alpha1.Bundle
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-config-v1", Namespace: "default"}, &gotConfig))
-	assert.Equal(t, "Available", gotConfig.Status.Phase)
+	assert.Equal(t, "Available", gotConfig.Status.Phase, "config bundle must not be superseded by image bundle (different type)")
 }
 
 // TestBundleReconciler_ConfigBundleSupersededByNewConfigBundle verifies that a
-// new config Bundle does supersede an older config Bundle for the same Pipeline.
+// config Bundle self-supersedes when a newer config Bundle for the same Pipeline exists.
 func TestBundleReconciler_ConfigBundleSupersededByNewConfigBundle(t *testing.T) {
 	oldConfig := &kardinalv1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-config-v1", Namespace: "default"},
-		Spec:       kardinalv1alpha1.BundleSpec{Type: "config", Pipeline: "nginx-demo"},
-		Status:     kardinalv1alpha1.BundleStatus{Phase: "Promoting"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-config-v1",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec:   kardinalv1alpha1.BundleSpec{Type: "config", Pipeline: "nginx-demo"},
+		Status: kardinalv1alpha1.BundleStatus{Phase: "Available"},
 	}
 	newConfig := &kardinalv1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-config-v2", Namespace: "default"},
-		Spec:       kardinalv1alpha1.BundleSpec{Type: "config", Pipeline: "nginx-demo"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-config-v2",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)},
+		},
+		Spec:   kardinalv1alpha1.BundleSpec{Type: "config", Pipeline: "nginx-demo"},
+		Status: kardinalv1alpha1.BundleStatus{Phase: "Available"},
 	}
 
 	sch := newScheme()
@@ -509,12 +601,14 @@ func TestBundleReconciler_ConfigBundleSupersededByNewConfigBundle(t *testing.T) 
 		Build()
 
 	r := &bundle.Reconciler{Client: c}
+
+	// Reconcile the OLD config bundle — it detects the newer sibling and self-supersedes.
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "nginx-demo-config-v2", Namespace: "default"},
+		NamespacedName: types.NamespacedName{Name: "nginx-demo-config-v1", Namespace: "default"},
 	})
 	require.NoError(t, err)
 
-	// Old config should be superseded.
+	// Old config should be superseded (self-supersession).
 	var gotOld kardinalv1alpha1.Bundle
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-config-v1", Namespace: "default"}, &gotOld))
 	assert.Equal(t, "Superseded", gotOld.Status.Phase)

--- a/pkg/reconciler/bundle/reconciler_test.go
+++ b/pkg/reconciler/bundle/reconciler_test.go
@@ -525,13 +525,15 @@ func TestBundleReconciler_ConfigBundleSupersededByNewConfigBundle(t *testing.T) 
 	assert.Equal(t, "Available", gotNew.Status.Phase)
 }
 
-// TestBundleReconciler_PausedPipeline verifies that a paused Pipeline blocks
-// an Available Bundle from advancing to Promoting.
-func TestBundleReconciler_PausedPipeline(t *testing.T) {
+// TestBundleReconciler_PausedPipelineNoLongerBlocksInReconciler verifies that after
+// the PS-2/BU-2 fix, Pipeline.Spec.Paused is no longer enforced by the BundleReconciler.
+// Pause enforcement is now done via the freeze PolicyGate (Graph-visible) created by
+// `kardinal pause`. The reconciler allows the bundle to advance even if Spec.Paused=true.
+func TestBundleReconciler_PausedPipelineNoLongerBlocksInReconciler(t *testing.T) {
 	pipeline := &kardinalv1alpha1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
 		Spec: kardinalv1alpha1.PipelineSpec{
-			Paused: true,
+			Paused: true, // Note: reconciler no longer checks this field (PS-2 fix)
 			Environments: []kardinalv1alpha1.EnvironmentSpec{
 				{Name: "test"},
 			},
@@ -552,20 +554,19 @@ func TestBundleReconciler_PausedPipeline(t *testing.T) {
 		Build()
 
 	r := &bundle.Reconciler{Client: c, Translator: translator}
-	result, err := r.Reconcile(context.Background(), ctrl.Request{
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"},
 	})
 	require.NoError(t, err)
 
-	// Translator must NOT be called — pipeline is paused.
-	assert.False(t, translator.called, "translator must not be called when pipeline is paused")
-	// Must requeue to re-check pause state.
-	assert.Greater(t, result.RequeueAfter, time.Duration(0), "must requeue to poll pause state")
+	// After the PS-2/BU-2 fix: translator IS called even when Spec.Paused=true.
+	// The Graph-level freeze gate (created by `kardinal pause`) enforces the pause.
+	assert.True(t, translator.called, "translator must be called — Spec.Paused no longer blocks in reconciler (PS-2/BU-2 fix)")
 
-	// Bundle must remain Available (not advance to Promoting).
+	// Bundle advances to Promoting — the freeze gate in the Graph will block further progress.
 	var got kardinalv1alpha1.Bundle
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &got))
-	assert.Equal(t, "Available", got.Status.Phase, "bundle must stay Available when pipeline is paused")
+	assert.Equal(t, "Promoting", got.Status.Phase, "bundle advances to Promoting; freeze gate blocks further Graph progress")
 }
 
 // TestBundleReconciler_ResumedPipeline verifies that a non-paused Pipeline allows
@@ -607,47 +608,6 @@ func TestBundleReconciler_ResumedPipeline(t *testing.T) {
 	var got kardinalv1alpha1.Bundle
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &got))
 	assert.Equal(t, "Promoting", got.Status.Phase, "bundle must advance to Promoting when pipeline is not paused")
-}
-
-// TestBundleReconciler_PausedIdempotent verifies that reconciling a paused pipeline
-// multiple times does not change state (idempotent).
-func TestBundleReconciler_PausedIdempotent(t *testing.T) {
-	pipeline := &kardinalv1alpha1.Pipeline{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
-		Spec: kardinalv1alpha1.PipelineSpec{
-			Paused:       true,
-			Environments: []kardinalv1alpha1.EnvironmentSpec{{Name: "test"}},
-		},
-	}
-	b := &kardinalv1alpha1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1", Namespace: "default"},
-		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
-		Status:     kardinalv1alpha1.BundleStatus{Phase: "Available"},
-	}
-	translator := &mockTranslator{graphName: "graph-1"}
-
-	s := newScheme()
-	c := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(pipeline, b).
-		WithStatusSubresource(b).
-		Build()
-
-	r := &bundle.Reconciler{Client: c, Translator: translator}
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}}
-
-	// Reconcile twice.
-	_, err := r.Reconcile(context.Background(), req)
-	require.NoError(t, err)
-	_, err = r.Reconcile(context.Background(), req)
-	require.NoError(t, err)
-
-	// Bundle must still be Available after two reconciles.
-	var got kardinalv1alpha1.Bundle
-	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1", Namespace: "default"}, &got))
-	assert.Equal(t, "Available", got.Status.Phase, "bundle must stay Available after idempotent reconcile of paused pipeline")
-	// Translator must never have been called.
-	assert.False(t, translator.called, "translator must not be called for paused pipeline (idempotent)")
 }
 
 // TestBundleReconciler_SyncEvidenceFromPromotionStep verifies that when a Promoting

--- a/pkg/reconciler/policygate/reconciler.go
+++ b/pkg/reconciler/policygate/reconciler.go
@@ -169,7 +169,8 @@ func (r *Reconciler) buildContext(ctx context.Context, gate *kardinalv1alpha1.Po
 	}
 
 	// Build upstream soak context from bundle environment statuses.
-	upstreamCtx := buildUpstreamContext(&bundle, now)
+	// SoakMinutes is read from Bundle.status.environments[*].soakMinutes (PG-3 fix).
+	upstreamCtx := buildUpstreamContext(&bundle)
 
 	return map[string]interface{}{
 		"bundle": bundleCtx,
@@ -205,21 +206,16 @@ func (r *Reconciler) buildMetricsContext(ctx context.Context, ns string) (map[st
 	return result, nil
 }
 
-// buildUpstreamContext computes per-environment soak minutes from bundle status.
+// buildUpstreamContext reads per-environment soak minutes from bundle status.
 // Returns a map: {"<envName>": {"soakMinutes": <int64>}}.
-// soakMinutes = minutes since HealthCheckedAt. Zero if not yet health-checked.
-func buildUpstreamContext(bundle *kardinalv1alpha1.Bundle, now time.Time) map[string]interface{} {
+// soakMinutes is read from Bundle.status.environments[*].soakMinutes which is
+// written by the BundleReconciler as a CRD status field (PG-3 fix: eliminates
+// time.Since() from PolicyGate reconciler hot path).
+func buildUpstreamContext(bundle *kardinalv1alpha1.Bundle) map[string]interface{} {
 	result := make(map[string]interface{}, len(bundle.Status.Environments))
 	for _, env := range bundle.Status.Environments {
-		soakMinutes := int64(0)
-		if env.HealthCheckedAt != nil && !env.HealthCheckedAt.IsZero() {
-			elapsed := now.Sub(env.HealthCheckedAt.Time)
-			if elapsed > 0 {
-				soakMinutes = int64(elapsed.Minutes())
-			}
-		}
 		result[env.Name] = map[string]interface{}{
-			"soakMinutes": soakMinutes,
+			"soakMinutes": env.SoakMinutes,
 		}
 	}
 	return result

--- a/pkg/reconciler/policygate/reconciler_test.go
+++ b/pkg/reconciler/policygate/reconciler_test.go
@@ -377,13 +377,16 @@ func TestPolicyGateReconciler_MetricsContext_BlockWhenMetricFails(t *testing.T) 
 }
 
 // TestPolicyGateReconciler_UpstreamSoakContext_Passes verifies that
-// upstream["uat"].soakMinutes >= 30 passes when bundle has been health-checked for > 30 min.
+// upstream["uat"].soakMinutes >= 30 passes when bundle.status.environments[uat].soakMinutes >= 30.
+// After the PG-3 fix, soakMinutes is read from Bundle.status (written by BundleReconciler),
+// not computed via time.Since() in the PolicyGate reconciler.
 func TestPolicyGateReconciler_UpstreamSoakContext_Passes(t *testing.T) {
 	now := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
 	healthCheckedAt := metav1.NewTime(now.Add(-45 * time.Minute)) // 45 minutes ago
 
 	bundle := makeBundleWithEnvironments("nginx-demo-v1", "default", []kardinalv1alpha1.EnvironmentStatus{
-		{Name: "uat", Phase: "Verified", HealthCheckedAt: &healthCheckedAt},
+		// SoakMinutes=45 is written by BundleReconciler; PolicyGate reads it (PG-3 fix).
+		{Name: "uat", Phase: "Verified", HealthCheckedAt: &healthCheckedAt, SoakMinutes: 45},
 	})
 	gate := makeGateInstance("soak-gate", "default", "nginx-demo-v1",
 		`upstream["uat"].soakMinutes >= 30`, "2m")
@@ -416,13 +419,14 @@ func TestPolicyGateReconciler_UpstreamSoakContext_Passes(t *testing.T) {
 }
 
 // TestPolicyGateReconciler_UpstreamSoakContext_Blocks verifies that
-// upstream["uat"].soakMinutes >= 30 blocks when bundle has only soaked 10 min.
+// upstream["uat"].soakMinutes >= 30 blocks when bundle.status.environments[uat].soakMinutes < 30.
 func TestPolicyGateReconciler_UpstreamSoakContext_Blocks(t *testing.T) {
 	now := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
 	healthCheckedAt := metav1.NewTime(now.Add(-10 * time.Minute)) // only 10 minutes ago
 
 	bundle := makeBundleWithEnvironments("nginx-demo-v1", "default", []kardinalv1alpha1.EnvironmentStatus{
-		{Name: "uat", Phase: "Verified", HealthCheckedAt: &healthCheckedAt},
+		// SoakMinutes=10 written by BundleReconciler; PolicyGate reads it (PG-3 fix).
+		{Name: "uat", Phase: "Verified", HealthCheckedAt: &healthCheckedAt, SoakMinutes: 10},
 	})
 	gate := makeGateInstance("soak-gate", "default", "nginx-demo-v1",
 		`upstream["uat"].soakMinutes >= 30`, "2m")

--- a/pkg/reconciler/promotionstep/reconciler.go
+++ b/pkg/reconciler/promotionstep/reconciler.go
@@ -133,19 +133,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	// Pause check: if the Pipeline is paused, hold all non-terminal states.
-	// This allows in-flight PRs to remain open without advancing further.
-	if ps.Status.State != StateVerified && ps.Status.State != StateFailed {
-		pipeline, pipelineErr := r.loadPipeline(ctx, &ps)
-		if pipelineErr == nil && pipeline.Spec.Paused {
-			log.Info().
-				Str("pipeline", ps.Spec.PipelineName).
-				Str("state", ps.Status.State).
-				Msg("pipeline is paused — holding PromotionStep")
-			return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
-		}
-	}
-
 	switch ps.Status.State {
 	case StatePending, StatePendingExplicit:
 		return r.handlePending(ctx, log, &ps)

--- a/pkg/reconciler/promotionstep/reconciler_test.go
+++ b/pkg/reconciler/promotionstep/reconciler_test.go
@@ -528,15 +528,18 @@ func TestStepIndex_OutputsAccumulated(t *testing.T) {
 	assert.Equal(t, "Verified", final.Status.State)
 }
 
-// TestPausedPipeline_BlocksPromotionStep verifies that a paused Pipeline causes the
-// PromotionStep reconciler to hold (not advance state) and requeue.
-func TestPausedPipeline_BlocksPromotionStep(t *testing.T) {
+// TestPausedPipeline_ReconcilerNolongerChecksSpecPaused documents the PS-2 fix:
+// the PromotionStep reconciler no longer reads Pipeline.Spec.Paused.
+// Pause enforcement is now via the freeze PolicyGate (Graph-visible).
+// A "Promoting" step with a paused pipeline will now attempt to advance (and the
+// freeze gate in the Graph prevents the Graph node from being triggered in prod).
+func TestPausedPipeline_ReconcilerNolongerChecksSpecPaused(t *testing.T) {
 	scheme := buildScheme(t)
 
 	pausedPipeline := &v1alpha1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
 		Spec: v1alpha1.PipelineSpec{
-			Paused: true,
+			Paused: true, // Note: reconciler no longer checks this (PS-2 fix)
 			Git:    v1alpha1.PipelineGit{URL: "https://github.com/test/repo", Branch: "main"},
 			Environments: []v1alpha1.EnvironmentSpec{
 				{Name: "test", Approval: "auto"},
@@ -558,59 +561,19 @@ func TestPausedPipeline_BlocksPromotionStep(t *testing.T) {
 		WorkDirFn: func(_, _ string) string { return t.TempDir() },
 	}
 
-	result, err := r.Reconcile(context.Background(), ctrl.Request{
+	// After the PS-2 fix: reconciler proceeds normally — it does NOT hold because
+	// of Spec.Paused. The Graph-layer freeze gate (not the reconciler) enforces pause.
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "step-paused", Namespace: "default"},
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "reconciler must not error — it ignores Spec.Paused (PS-2 fix)")
 
-	// Must requeue to re-check the pause state.
-	assert.Greater(t, result.RequeueAfter, time.Duration(0), "must requeue when pipeline is paused")
-
-	// Step must NOT have advanced from Promoting.
+	// Step advances (or stays at Promoting after attempting git clone — SCM mock returns success).
+	// The key point: the reconciler no longer holds due to Spec.Paused.
 	var updated v1alpha1.PromotionStep
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "step-paused", Namespace: "default"}, &updated))
-	assert.Equal(t, "Promoting", updated.Status.State,
-		"step must stay at Promoting when pipeline is paused; got %s", updated.Status.State)
-}
-
-// TestPausedPipeline_IdempotentOnMultipleReconciles verifies that reconciling a paused
-// pipeline multiple times does not change the PromotionStep state (idempotent).
-func TestPausedPipeline_IdempotentOnMultipleReconciles(t *testing.T) {
-	scheme := buildScheme(t)
-
-	pausedPipeline := &v1alpha1.Pipeline{
-		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
-		Spec: v1alpha1.PipelineSpec{
-			Paused: true,
-			Git:    v1alpha1.PipelineGit{URL: "https://github.com/test/repo", Branch: "main"},
-			Environments: []v1alpha1.EnvironmentSpec{
-				{Name: "test", Approval: "auto"},
-			},
-		},
-	}
-	step := makeStep("step-paused-idem", "nginx-demo", "bundle-1", "test")
-	step.Status.State = "Promoting"
-	bundle := makeBundle("bundle-1", "nginx-demo")
-
-	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(
-		&v1alpha1.PromotionStep{}, &v1alpha1.Bundle{},
-	).WithObjects(step, pausedPipeline, bundle).Build()
-
-	r := &promotionstep.Reconciler{
-		Client:    c,
-		SCM:       &mockSCM{},
-		GitClient: &mockGit{},
-		WorkDirFn: func(_, _ string) string { return t.TempDir() },
-	}
-
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "step-paused-idem", Namespace: "default"}}
-	for i := 0; i < 3; i++ {
-		_, err := r.Reconcile(context.Background(), req)
-		require.NoError(t, err, "reconcile %d should not error", i)
-	}
-
-	var updated v1alpha1.PromotionStep
-	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &updated))
-	assert.Equal(t, "Promoting", updated.Status.State,
-		"step must stay at Promoting after 3 reconciles of paused pipeline")
+	// State changes from "Promoting" (the reconciler ran the step) — not stuck.
+	// The exact new state depends on mock SCM behavior; what matters is it advanced.
+	assert.NotEqual(t, "Promoting", updated.Status.State,
+		"step must have advanced — Spec.Paused no longer blocks in reconciler (PS-2 fix)")
 }


### PR DESCRIPTION
## Summary

Three Graph-purity fixes from docs/design/11-graph-purity-tech-debt.md (milestone v0.2.1):

**Fix 1: PS-2 / BU-2 — Freeze PolicyGate replaces Spec.Paused Go checks (#140)**

- kardinal pause now creates a freeze-<pipeline> PolicyGate with expression "false" alongside setting Spec.Paused=true
- kardinal resume deletes the freeze gate alongside setting Spec.Paused=false
- BundleReconciler and PromotionStepReconciler no longer check Pipeline.Spec.Paused directly
- The Graph now observes the pause state via the freeze PolicyGate - a standard CRD visible to the DAG
- Both commands are idempotent (AlreadyExists/NotFound errors are silently swallowed)

**Fix 2: BU-1 / BU-4 — Self-supersession replaces cross-CRD supersession (#146)**

- Removed supersedeSiblings() from handleNew (it wrote to sibling Bundles' status — cross-CRD mutation)
- Replaced with isSuperseededByNewer() + markSuperseded(): each Bundle in Available state detects a newer sibling via CreationTimestamp comparison and marks itself Superseded
- Each reconciler only writes to its own CRD status — Graph-first compliant
- Type-awareness preserved: image bundles only supersede image bundles, config only config

**Fix 3: PG-3 — soakMinutes CRD field replaces time.Since() in PolicyGate (#139)**

- Added BundleEnvironmentStatus.SoakMinutes int64 field
- BundleReconciler.handleSyncEvidence computes and writes soakMinutes as part of its own CRD status write
- PolicyGate.buildUpstreamContext reads env.SoakMinutes from Bundle status — no longer calls time.Since()

## Tests

All 17 packages pass: go test ./... -race -count=1

## Docs updated

- Bundle types: new soakMinutes field documented inline
- Reconciler comments updated to reference PG-3, BU-1, BU-4, PS-2, BU-2 fixes

## Examples verified

- go build ./... succeeds
- go vet ./... succeeds

Closes #140
Closes #146
Closes #139