### PR TITLE
[Extensions Agent] feat(translator): inject health Watch nodes (HE-1/HE-2/HE-3)

### DIFF
--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -6,12 +6,14 @@ package translator
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/rs/zerolog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	"github.com/kardinal-promoter/kardinal-promoter/pkg/graph"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/health"
 )
 
 // Translator handles the full pipeline-to-graph creation flow:
@@ -89,6 +91,26 @@ func (t *Translator) Translate(ctx context.Context,
 		Str("graph", result.Graph.Name).
 		Msg("graph spec built")
 
+	// Inject health Watch nodes for each environment that has health.type configured.
+	// HE-1, HE-2, HE-3 from docs/design/11-graph-purity-tech-debt.md:
+	// The translator emits krocodile ShapeWatch nodes (identity-only template:
+	// apiVersion+kind+metadata.name) for health verification so the Graph can
+	// observe real K8s resource health without the PromotionStep reconciler
+	// calling health adapters on the hot path.
+	//
+	// Each health Watch node:
+	//   - Has an identity-only template → krocodile auto-detects it as ShapeWatch
+	//   - Has a readyWhen expression evaluating the K8s resource's health status
+	//   - Updates the companion PromotionStep node's readyWhen to surface
+	//     real-resource health in the Graph's UI signal
+	if injected, injErr := injectHealthWatchNodes(pipeline, result.Graph); injErr != nil {
+		// Non-fatal: log and continue without Watch nodes rather than failing the promotion.
+		// The PromotionStep reconciler's Go adapter path remains as a fallback.
+		log.Warn().Err(injErr).Msg("health Watch node injection failed — continuing without Watch nodes")
+	} else if injected > 0 {
+		log.Debug().Int("healthNodes", injected).Msg("health Watch nodes injected into Graph")
+	}
+
 	// Create the Graph CR
 	if err := t.graphClient.Create(ctx, result.Graph); err != nil {
 		return "", fmt.Errorf("translator.Translate: create graph: %w", err)
@@ -100,6 +122,160 @@ func (t *Translator) Translate(ctx context.Context,
 		Msg("translation complete: graph created")
 
 	return result.Graph.Name, nil
+}
+
+// injectHealthWatchNodes post-processes the Graph spec to add krocodile ShapeWatch
+// nodes for each environment with a configured health.type.
+//
+// This is the translator-layer implementation of HE-1, HE-2, HE-3 from
+// docs/design/11-graph-purity-tech-debt.md. ShapeWatch nodes exist in krocodile
+// (confirmed HEAD commit 8ac56202) — they are auto-detected by krocodile when a
+// node template contains only apiVersion, kind, and metadata.name/namespace.
+//
+// For each environment env with health.type set:
+//  1. Build a WatchNodeSpec from pkg/health.WatchNodeTemplate
+//  2. Build the Graph node ID: "health_<envSlug>"
+//  3. Append a ShapeWatch node to the Graph spec
+//  4. Update the PromotionStep node's readyWhen to include the health condition
+//     (UI signal: the Graph shows the step as "ready" only when the K8s resource
+//     is also healthy — not just when the reconciler set state=Verified)
+//
+// Returns the count of injected Watch nodes.
+func injectHealthWatchNodes(
+	pipeline *kardinalv1alpha1.Pipeline,
+	g *graph.Graph,
+) (int, error) {
+	if pipeline == nil || g == nil {
+		return 0, nil
+	}
+
+	// Build a name→spec index for fast PromotionStep node lookup.
+	// Node IDs for PromotionStep nodes follow the celSafeSlug(envName) convention
+	// used by builder.go. We match them by ID prefix.
+	stepNodeByEnv := make(map[string]int, len(pipeline.Spec.Environments))
+	for i, node := range g.Spec.Nodes {
+		for _, env := range pipeline.Spec.Environments {
+			if node.ID == celSafeSlug(env.Name) {
+				stepNodeByEnv[env.Name] = i
+				break
+			}
+		}
+	}
+
+	injected := 0
+	for _, env := range pipeline.Spec.Environments {
+		if env.Health.Type == "" {
+			continue // no health check configured for this env
+		}
+
+		// Build the resource name. We use the same convention as the PromotionStep
+		// reconciler's handleHealthChecking: pipeline.Name + "-" + env.Name for
+		// argocd/flux, and pipeline.Name for resource/argoRollouts/flagger.
+		opts := healthOptsForEnv(pipeline.Name, env)
+
+		spec, err := health.WatchNodeTemplate(env.Health.Type, opts)
+		if err != nil {
+			// Unknown health type — skip this env rather than failing the whole promotion.
+			continue
+		}
+
+		nodeID := "health_" + celSafeSlug(env.Name)
+
+		// Substitute the "healthNode" placeholder in ReadyWhen with the actual node ID.
+		readyWhen := strings.ReplaceAll(spec.ReadyWhen, "healthNode", nodeID)
+
+		// Build an identity-only template so krocodile detects it as ShapeWatch.
+		// ShapeWatch detection (experimental/controller/types.go): only apiVersion,
+		// kind, metadata.name, optionally metadata.namespace.
+		watchNode := graph.GraphNode{
+			ID: nodeID,
+			Template: map[string]interface{}{
+				"apiVersion": spec.APIVersion,
+				"kind":       spec.Kind,
+				"metadata": map[string]interface{}{
+					"name":      spec.Name,
+					"namespace": spec.Namespace,
+				},
+			},
+			ReadyWhen: []string{readyWhen},
+		}
+		g.Spec.Nodes = append(g.Spec.Nodes, watchNode)
+
+		// Update the companion PromotionStep node's readyWhen to also include the
+		// health Watch node condition. This makes the Graph's UI signal reflect the
+		// real K8s resource health, not only the reconciler's state field.
+		//
+		// Note: propagateWhen is intentionally left unchanged — the PromotionStep
+		// reconciler still gates downstream via state==Verified. The Watch node
+		// readyWhen is a UI signal only (Graph UI shows amber vs green).
+		if idx, ok := stepNodeByEnv[env.Name]; ok {
+			g.Spec.Nodes[idx].ReadyWhen = append(
+				g.Spec.Nodes[idx].ReadyWhen,
+				readyWhen,
+			)
+		}
+
+		injected++
+	}
+	return injected, nil
+}
+
+// healthOptsForEnv builds the health.CheckOptions for a given environment using
+// the same name conventions as the PromotionStep reconciler's handleHealthChecking.
+//
+// Convention (matches promotionstep/reconciler.go handleHealthChecking):
+//   - resource: Deployment name = pipeline.Name, namespace = env.Name
+//   - argocd:   Application name = pipeline.Name + "-" + env.Name, namespace = "argocd"
+//   - flux:     Kustomization name = pipeline.Name + "-" + env.Name, namespace = "flux-system"
+//   - argoRollouts: Rollout name = pipeline.Name, namespace = env.Name
+//   - flagger:  Canary name = pipeline.Name, namespace = env.Name
+func healthOptsForEnv(pipelineName string, env kardinalv1alpha1.EnvironmentSpec) health.CheckOptions {
+	return health.CheckOptions{
+		Type: env.Health.Type,
+		Resource: health.ResourceConfig{
+			Name:      pipelineName,
+			Namespace: env.Name,
+			Condition: "Available",
+		},
+		ArgoCD: health.ArgoCDConfig{
+			Name:      pipelineName + "-" + env.Name,
+			Namespace: "argocd",
+		},
+		Flux: health.FluxConfig{
+			Name:      pipelineName + "-" + env.Name,
+			Namespace: "flux-system",
+		},
+		ArgoRollouts: health.ArgoRolloutsConfig{
+			Name:      pipelineName,
+			Namespace: env.Name,
+		},
+		Flagger: health.FlaggerConfig{
+			Name:      pipelineName,
+			Namespace: env.Name,
+		},
+	}
+}
+
+// celSafeSlug produces an identifier safe for use in CEL expressions.
+// Mirrors graph.celSafeSlug exactly — must be kept in sync.
+// Hyphens and other non-alphanumeric chars become underscores; uppercase → lowercase.
+// A leading digit gets a prefixed underscore.
+func celSafeSlug(s string) string {
+	var b strings.Builder
+	for i, c := range s {
+		switch {
+		case (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9' && i > 0) || c == '_':
+			b.WriteRune(c)
+		case c >= 'A' && c <= 'Z':
+			b.WriteRune(c - 'A' + 'a')
+		case c == '0' && i == 0:
+			b.WriteRune('_')
+			b.WriteRune(c)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
 }
 
 // collectGates lists PolicyGates from all policy namespaces and the pipeline's namespace.

--- a/pkg/translator/translator_health_test.go
+++ b/pkg/translator/translator_health_test.go
@@ -1,0 +1,441 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/graph"
+)
+
+// makeTestGraph builds a minimal Graph with one PromotionStep node per environment.
+// Mirrors the convention used by graph.Builder: node ID = celSafeSlug(envName).
+func makeTestGraph(envNames ...string) *graph.Graph {
+	g := &graph.Graph{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-graph", Namespace: "default"},
+	}
+	for _, name := range envNames {
+		g.Spec.Nodes = append(g.Spec.Nodes, graph.GraphNode{
+			ID: celSafeSlug(name),
+			Template: map[string]interface{}{
+				"apiVersion": "kardinal.io/v1alpha1",
+				"kind":       "PromotionStep",
+				"metadata":   map[string]interface{}{"name": "test-" + name},
+				"spec":       map[string]interface{}{"environment": name},
+			},
+			ReadyWhen: []string{
+				`${` + celSafeSlug(name) + `.status.state == "Verified"}`,
+			},
+			PropagateWhen: []string{
+				`${` + celSafeSlug(name) + `.status.state == "Verified"}`,
+			},
+		})
+	}
+	return g
+}
+
+// makePipeline builds a minimal Pipeline with the given environments.
+func makePipeline(name string, envs []kardinalv1alpha1.EnvironmentSpec) *kardinalv1alpha1.Pipeline {
+	return &kardinalv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       kardinalv1alpha1.PipelineSpec{Environments: envs},
+	}
+}
+
+// TestInjectHealthWatchNodes_NoHealthType verifies that environments without
+// health.type do not produce Watch nodes.
+func TestInjectHealthWatchNodes_NoHealthType(t *testing.T) {
+	pipeline := makePipeline("nginx", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "test"},
+		{Name: "prod"},
+	})
+	g := makeTestGraph("test", "prod")
+	originalCount := len(g.Spec.Nodes)
+
+	injected, err := injectHealthWatchNodes(pipeline, g)
+	require.NoError(t, err)
+	assert.Equal(t, 0, injected, "no Watch nodes should be injected when health.type is empty")
+	assert.Len(t, g.Spec.Nodes, originalCount, "node count must not change")
+}
+
+// TestInjectHealthWatchNodes_Resource verifies that health.type=resource injects
+// a ShapeWatch node for apps/v1 Deployment.
+func TestInjectHealthWatchNodes_Resource(t *testing.T) {
+	pipeline := makePipeline("nginx", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "prod", Health: kardinalv1alpha1.HealthConfig{Type: "resource"}},
+	})
+	g := makeTestGraph("prod")
+	originalStepCount := len(g.Spec.Nodes)
+
+	injected, err := injectHealthWatchNodes(pipeline, g)
+	require.NoError(t, err)
+	assert.Equal(t, 1, injected)
+	assert.Len(t, g.Spec.Nodes, originalStepCount+1, "one Watch node added")
+
+	// Find the health Watch node
+	var watchNode *graph.GraphNode
+	for i := range g.Spec.Nodes {
+		if strings.HasPrefix(g.Spec.Nodes[i].ID, "health_") {
+			watchNode = &g.Spec.Nodes[i]
+			break
+		}
+	}
+	require.NotNil(t, watchNode, "health Watch node must exist")
+
+	// Node ID follows "health_<envSlug>" pattern
+	assert.Equal(t, "health_prod", watchNode.ID)
+
+	// Template must be identity-only (ShapeWatch auto-detection):
+	// Only apiVersion, kind, metadata.name/namespace
+	tmpl := watchNode.Template
+	assert.Equal(t, "apps/v1", tmpl["apiVersion"])
+	assert.Equal(t, "Deployment", tmpl["kind"])
+	md := tmpl["metadata"].(map[string]interface{})
+	assert.Equal(t, "nginx", md["name"], "deployment name = pipeline name")
+	assert.Equal(t, "prod", md["namespace"], "deployment namespace = env name")
+
+	// Template must NOT have spec or other fields (would make it ShapeOwns/ShapeContribute)
+	_, hasSpec := tmpl["spec"]
+	assert.False(t, hasSpec, "identity-only template must not have spec field")
+	for k := range tmpl {
+		assert.Contains(t, []string{"apiVersion", "kind", "metadata"}, k,
+			"identity-only template must only have apiVersion/kind/metadata")
+	}
+	for k := range md {
+		assert.Contains(t, []string{"name", "namespace"}, k,
+			"metadata must only have name/namespace for ShapeWatch detection")
+	}
+
+	// ReadyWhen must reference the actual node ID (not the placeholder "healthNode")
+	require.NotEmpty(t, watchNode.ReadyWhen)
+	assert.Contains(t, watchNode.ReadyWhen[0], "health_prod", "readyWhen must reference node ID")
+	assert.NotContains(t, watchNode.ReadyWhen[0], "healthNode", "placeholder must be substituted")
+	assert.Contains(t, watchNode.ReadyWhen[0], "Available", "readyWhen checks Available condition")
+}
+
+// TestInjectHealthWatchNodes_ArgoCD verifies health.type=argocd Watch node.
+func TestInjectHealthWatchNodes_ArgoCD(t *testing.T) {
+	pipeline := makePipeline("myapp", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "prod", Health: kardinalv1alpha1.HealthConfig{Type: "argocd"}},
+	})
+	g := makeTestGraph("prod")
+
+	injected, err := injectHealthWatchNodes(pipeline, g)
+	require.NoError(t, err)
+	assert.Equal(t, 1, injected)
+
+	watchNode := findHealthNode(g, "prod")
+	require.NotNil(t, watchNode)
+
+	tmpl := watchNode.Template
+	assert.Equal(t, "argoproj.io/v1alpha1", tmpl["apiVersion"])
+	assert.Equal(t, "Application", tmpl["kind"])
+	md := tmpl["metadata"].(map[string]interface{})
+	assert.Equal(t, "myapp-prod", md["name"], "application name = pipeline + env")
+	assert.Equal(t, "argocd", md["namespace"])
+
+	require.NotEmpty(t, watchNode.ReadyWhen)
+	assert.Contains(t, watchNode.ReadyWhen[0], "Healthy")
+	assert.Contains(t, watchNode.ReadyWhen[0], "Synced")
+}
+
+// TestInjectHealthWatchNodes_Flux verifies health.type=flux Watch node.
+func TestInjectHealthWatchNodes_Flux(t *testing.T) {
+	pipeline := makePipeline("myapp", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "staging", Health: kardinalv1alpha1.HealthConfig{Type: "flux"}},
+	})
+	g := makeTestGraph("staging")
+
+	injected, err := injectHealthWatchNodes(pipeline, g)
+	require.NoError(t, err)
+	assert.Equal(t, 1, injected)
+
+	watchNode := findHealthNode(g, "staging")
+	require.NotNil(t, watchNode)
+
+	tmpl := watchNode.Template
+	assert.Equal(t, "kustomize.toolkit.fluxcd.io/v1", tmpl["apiVersion"])
+	assert.Equal(t, "Kustomization", tmpl["kind"])
+	md := tmpl["metadata"].(map[string]interface{})
+	assert.Equal(t, "myapp-staging", md["name"])
+	assert.Equal(t, "flux-system", md["namespace"])
+
+	require.NotEmpty(t, watchNode.ReadyWhen)
+	assert.Contains(t, watchNode.ReadyWhen[0], "Ready")
+}
+
+// TestInjectHealthWatchNodes_ArgoRollouts verifies health.type=argoRollouts Watch node.
+func TestInjectHealthWatchNodes_ArgoRollouts(t *testing.T) {
+	pipeline := makePipeline("rollouts-demo", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "prod-eu", Health: kardinalv1alpha1.HealthConfig{Type: "argoRollouts"}},
+	})
+	g := makeTestGraph("prod-eu")
+
+	injected, err := injectHealthWatchNodes(pipeline, g)
+	require.NoError(t, err)
+	assert.Equal(t, 1, injected)
+
+	watchNode := findHealthNode(g, "prod-eu")
+	require.NotNil(t, watchNode)
+	assert.Equal(t, "health_prod_eu", watchNode.ID, "hyphens in env name become underscores")
+
+	tmpl := watchNode.Template
+	assert.Equal(t, "argoproj.io/v1alpha1", tmpl["apiVersion"])
+	assert.Equal(t, "Rollout", tmpl["kind"])
+	md := tmpl["metadata"].(map[string]interface{})
+	assert.Equal(t, "rollouts-demo", md["name"])
+	assert.Equal(t, "prod-eu", md["namespace"])
+}
+
+// TestInjectHealthWatchNodes_Flagger verifies health.type=flagger Watch node.
+func TestInjectHealthWatchNodes_Flagger(t *testing.T) {
+	pipeline := makePipeline("myapp", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "prod", Health: kardinalv1alpha1.HealthConfig{Type: "flagger"}},
+	})
+	g := makeTestGraph("prod")
+
+	injected, err := injectHealthWatchNodes(pipeline, g)
+	require.NoError(t, err)
+	assert.Equal(t, 1, injected)
+
+	watchNode := findHealthNode(g, "prod")
+	require.NotNil(t, watchNode)
+
+	tmpl := watchNode.Template
+	assert.Equal(t, "flagger.app/v1beta1", tmpl["apiVersion"])
+	assert.Equal(t, "Canary", tmpl["kind"])
+	assert.Contains(t, watchNode.ReadyWhen[0], "Succeeded")
+}
+
+// TestInjectHealthWatchNodes_MultipleEnvs verifies multiple environments each get
+// their own Watch node.
+func TestInjectHealthWatchNodes_MultipleEnvs(t *testing.T) {
+	pipeline := makePipeline("nginx", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "test"}, // no health
+		{Name: "uat", Health: kardinalv1alpha1.HealthConfig{Type: "resource"}}, // has health
+		{Name: "prod", Health: kardinalv1alpha1.HealthConfig{Type: "argocd"}},  // has health
+	})
+	g := makeTestGraph("test", "uat", "prod")
+	originalCount := len(g.Spec.Nodes)
+
+	injected, err := injectHealthWatchNodes(pipeline, g)
+	require.NoError(t, err)
+	assert.Equal(t, 2, injected, "test has no health.type, uat and prod do")
+	assert.Len(t, g.Spec.Nodes, originalCount+2)
+
+	uatNode := findHealthNode(g, "uat")
+	require.NotNil(t, uatNode)
+	assert.Equal(t, "health_uat", uatNode.ID)
+
+	prodNode := findHealthNode(g, "prod")
+	require.NotNil(t, prodNode)
+	assert.Equal(t, "health_prod", prodNode.ID)
+}
+
+// TestInjectHealthWatchNodes_PromotionStepReadyWhenUpdated verifies that the
+// companion PromotionStep node's readyWhen gains the health Watch condition.
+func TestInjectHealthWatchNodes_PromotionStepReadyWhenUpdated(t *testing.T) {
+	pipeline := makePipeline("nginx", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "prod", Health: kardinalv1alpha1.HealthConfig{Type: "resource"}},
+	})
+	g := makeTestGraph("prod")
+
+	// Capture original readyWhen
+	var origReadyWhen []string
+	for _, node := range g.Spec.Nodes {
+		if node.ID == "prod" {
+			origReadyWhen = append(origReadyWhen, node.ReadyWhen...)
+			break
+		}
+	}
+
+	injected, err := injectHealthWatchNodes(pipeline, g)
+	require.NoError(t, err)
+	assert.Equal(t, 1, injected)
+
+	// Find the PromotionStep node
+	var stepNode *graph.GraphNode
+	for i := range g.Spec.Nodes {
+		if g.Spec.Nodes[i].ID == "prod" {
+			stepNode = &g.Spec.Nodes[i]
+			break
+		}
+	}
+	require.NotNil(t, stepNode)
+
+	// readyWhen must have grown by 1 (health condition appended)
+	assert.Len(t, stepNode.ReadyWhen, len(origReadyWhen)+1,
+		"PromotionStep readyWhen should gain one health condition")
+
+	// The new condition must reference the health Watch node ID
+	newCond := stepNode.ReadyWhen[len(stepNode.ReadyWhen)-1]
+	assert.Contains(t, newCond, "health_prod", "new readyWhen condition must reference health node ID")
+	assert.Contains(t, newCond, "Available", "resource readyWhen checks Available condition")
+}
+
+// TestInjectHealthWatchNodes_PropagateWhenUnchanged verifies that propagateWhen
+// is NOT modified — the PromotionStep reconciler still gates downstream.
+func TestInjectHealthWatchNodes_PropagateWhenUnchanged(t *testing.T) {
+	pipeline := makePipeline("nginx", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "prod", Health: kardinalv1alpha1.HealthConfig{Type: "resource"}},
+	})
+	g := makeTestGraph("prod")
+
+	var origPropagateWhen []string
+	for _, node := range g.Spec.Nodes {
+		if node.ID == "prod" {
+			origPropagateWhen = append(origPropagateWhen, node.PropagateWhen...)
+			break
+		}
+	}
+
+	_, err := injectHealthWatchNodes(pipeline, g)
+	require.NoError(t, err)
+
+	var stepNode *graph.GraphNode
+	for i := range g.Spec.Nodes {
+		if g.Spec.Nodes[i].ID == "prod" {
+			stepNode = &g.Spec.Nodes[i]
+			break
+		}
+	}
+	require.NotNil(t, stepNode)
+
+	assert.Equal(t, origPropagateWhen, stepNode.PropagateWhen,
+		"propagateWhen must NOT be modified — reconciler still gates downstream")
+}
+
+// TestInjectHealthWatchNodes_NilGraph handles nil input gracefully.
+func TestInjectHealthWatchNodes_NilGraph(t *testing.T) {
+	pipeline := makePipeline("nginx", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "prod", Health: kardinalv1alpha1.HealthConfig{Type: "resource"}},
+	})
+	injected, err := injectHealthWatchNodes(pipeline, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, injected, "nil graph must return 0 without error")
+}
+
+// TestInjectHealthWatchNodes_NilPipeline handles nil pipeline gracefully.
+func TestInjectHealthWatchNodes_NilPipeline(t *testing.T) {
+	g := makeTestGraph("prod")
+	injected, err := injectHealthWatchNodes(nil, g)
+	require.NoError(t, err)
+	assert.Equal(t, 0, injected, "nil pipeline must return 0 without error")
+}
+
+// TestInjectHealthWatchNodes_UnknownHealthType skips unknown types without error.
+func TestInjectHealthWatchNodes_UnknownHealthType(t *testing.T) {
+	pipeline := makePipeline("nginx", []kardinalv1alpha1.EnvironmentSpec{
+		{Name: "prod", Health: kardinalv1alpha1.HealthConfig{Type: "unknown-type"}},
+	})
+	g := makeTestGraph("prod")
+	originalCount := len(g.Spec.Nodes)
+
+	injected, err := injectHealthWatchNodes(pipeline, g)
+	require.NoError(t, err)
+	assert.Equal(t, 0, injected, "unknown health type is skipped silently")
+	assert.Len(t, g.Spec.Nodes, originalCount, "node count unchanged for unknown type")
+}
+
+// TestInjectHealthWatchNodes_WatchNodeIsIdentityOnly verifies that the emitted Watch
+// node template conforms to krocodile's ShapeWatch detection requirement:
+// only apiVersion, kind, metadata.name/namespace — no spec or other fields.
+func TestInjectHealthWatchNodes_WatchNodeIsIdentityOnly(t *testing.T) {
+	tests := []struct {
+		name       string
+		healthType string
+	}{
+		{"resource", "resource"},
+		{"argocd", "argocd"},
+		{"flux", "flux"},
+		{"argoRollouts", "argoRollouts"},
+		{"flagger", "flagger"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pipeline := makePipeline("myapp", []kardinalv1alpha1.EnvironmentSpec{
+				{Name: "prod", Health: kardinalv1alpha1.HealthConfig{Type: tc.healthType}},
+			})
+			g := makeTestGraph("prod")
+
+			_, err := injectHealthWatchNodes(pipeline, g)
+			require.NoError(t, err)
+
+			watchNode := findHealthNode(g, "prod")
+			require.NotNil(t, watchNode, "health Watch node must exist for type %s", tc.healthType)
+
+			tmpl := watchNode.Template
+
+			// Only allowed top-level keys: apiVersion, kind, metadata
+			for k := range tmpl {
+				assert.Contains(t, []string{"apiVersion", "kind", "metadata"}, k,
+					"ShapeWatch template must only have apiVersion/kind/metadata, got: %s", k)
+			}
+
+			// metadata must only have name/namespace
+			md, ok := tmpl["metadata"].(map[string]interface{})
+			require.True(t, ok, "metadata must be a map")
+			for k := range md {
+				assert.Contains(t, []string{"name", "namespace"}, k,
+					"metadata must only have name/namespace for ShapeWatch, got: %s", k)
+			}
+
+			// apiVersion and kind must be present
+			assert.NotEmpty(t, tmpl["apiVersion"])
+			assert.NotEmpty(t, tmpl["kind"])
+			assert.NotEmpty(t, md["name"])
+			assert.NotEmpty(t, md["namespace"])
+		})
+	}
+}
+
+// TestCelSafeSlug verifies celSafeSlug produces CEL-valid identifiers.
+func TestCelSafeSlug(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"prod", "prod"},
+		{"prod-eu", "prod_eu"},
+		{"prod-eu-2", "prod_eu_2"},
+		{"PROD", "prod"},
+		{"0prod", "_0prod"},
+		{"my.env", "my_env"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.want, celSafeSlug(tc.input))
+		})
+	}
+}
+
+// findHealthNode finds the health Watch node for a given environment in the graph.
+func findHealthNode(g *graph.Graph, envName string) *graph.GraphNode {
+	target := "health_" + celSafeSlug(envName)
+	for i := range g.Spec.Nodes {
+		if g.Spec.Nodes[i].ID == target {
+			return &g.Spec.Nodes[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #136

## Summary

- The translator post-processes the Graph after `builder.Build()` to inject krocodile **ShapeWatch** nodes for each environment with a configured `health.type`
- ShapeWatch confirmed in krocodile HEAD (commit `8ac56202`) — auto-detected when template has only `apiVersion`, `kind`, `metadata.name/namespace`
- Removed `blocked-on-krocodile` label from #136 (blocker is gone)

## What changed

**`pkg/translator/translator.go`** — new `injectHealthWatchNodes()` function:
- Called after `builder.Build()`, before `graphClient.Create()`
- For each env with `health.type` set: appends a ShapeWatch node `health_<envSlug>` to the Graph
- Updates the companion PromotionStep node's `readyWhen` with the health condition (UI signal)
- `propagateWhen` intentionally unchanged — reconciler still gates downstream via `state==Verified`

**`pkg/translator/translator_health_test.go`** — 12 new tests:
- One test per health adapter type (resource, argocd, flux, argoRollouts, flagger)
- Identity-only template validation (ShapeWatch auto-detection compliance)
- Multiple environments, nil guards, unknown types, readyWhen/propagateWhen invariants

## Graph-first compliance

- No new logic leaks introduced
- No `pkg/cel` references outside `pkg/reconciler/policygate`
- No `time.Now()`, no external HTTP, no cross-CRD mutation
- Watch nodes are pure Graph-layer infrastructure — HE-1/HE-2/HE-3 graph-first migration

## Scope

**Boundary**: `pkg/translator`, `pkg/health` (both in `ALLOWED_PACKAGES`)
**Not touched**: `pkg/reconciler/promotionstep`, `pkg/graph`, `api/v1alpha1`, `cmd/kardinal`

The PromotionStep reconciler migration (using `healthWatchRef` to skip Go adapter calls) is a follow-up issue for the Core Agent scope.