### PR TITLE
[UI-CLI Agent] fix(cli): kardinal version outputs CLI/Controller/Graph lines

### DIFF
--- a/cmd/kardinal/cmd/cli_test.go
+++ b/cmd/kardinal/cmd/cli_test.go
@@ -450,3 +450,44 @@ func TestPolicyList_ShowsPendingState(t *testing.T) {
 
 	assert.Contains(t, buf.String(), "Pending", "unevaluated gate must show Pending")
 }
+
+// TestVersionOutput_ThreeLines verifies that versionFn outputs CLI, Controller, and Graph lines.
+func TestVersionOutput_ThreeLines(t *testing.T) {
+	tests := []struct {
+		name        string
+		controllerV string
+		graphV      string
+		wantLines   []string
+	}{
+		{
+			name:        "all versions known",
+			controllerV: "v0.2.0",
+			graphV:      "v0.9.1",
+			wantLines:   []string{"CLI:", "Controller: v0.2.0", "Graph:      v0.9.1"},
+		},
+		{
+			name:        "graph version unknown",
+			controllerV: "v0.2.0",
+			graphV:      "",
+			wantLines:   []string{"CLI:", "Controller: v0.2.0", "Graph:      (unknown)"},
+		},
+		{
+			name:        "controller version unknown",
+			controllerV: "",
+			graphV:      "",
+			wantLines:   []string{"CLI:", "Controller: unknown", "Graph:      (unknown)"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := versionFn(&buf, tc.controllerV, tc.graphV)
+			require.NoError(t, err)
+			out := buf.String()
+			for _, want := range tc.wantLines {
+				assert.Contains(t, out, want, "output should contain %q", want)
+			}
+		})
+	}
+}

--- a/cmd/kardinal/cmd/version.go
+++ b/cmd/kardinal/cmd/version.go
@@ -29,35 +29,59 @@ var CLIVersion = "v0.1.0-dev"
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Print the CLI and controller versions",
+		Short: "Print the CLI, controller, and graph versions",
 		RunE:  runVersion,
 	}
 }
 
 func runVersion(cmd *cobra.Command, _ []string) error {
-	cliVer := buildInfoVersion()
 	controllerVer := "unknown"
+	graphVer := ""
 
 	// Best-effort: try to read from the kardinal-version ConfigMap.
 	client, _, err := buildClient()
 	if err == nil {
 		var cm corev1.ConfigMap
-		if err := client.Get(context.Background(),
+		if cmErr := client.Get(context.Background(),
 			types.NamespacedName{
 				Namespace: "kardinal-system",
 				Name:      "kardinal-version",
-			}, &cm); err == nil {
+			}, &cm); cmErr == nil {
 			if v, ok := cm.Data["version"]; ok && v != "" {
 				controllerVer = v
+			}
+			if v, ok := cm.Data["graph"]; ok && v != "" {
+				graphVer = v
 			}
 		}
 	}
 
-	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "CLI:        %s\n", cliVer); err != nil {
-		return fmt.Errorf("write version: %w", err)
+	return versionFn(cmd.OutOrStdout(), controllerVer, graphVer)
+}
+
+// versionFn is the testable implementation of the version command.
+// It writes CLI, Controller, and Graph version lines to w.
+// controllerVer is the controller version resolved from the ConfigMap ("unknown" if absent).
+// graphVer is the graph engine version from the ConfigMap (empty string when unavailable).
+func versionFn(w interface{ Write([]byte) (int, error) }, controllerVer, graphVer string) error {
+	cliVer := buildInfoVersion()
+
+	if controllerVer == "" {
+		controllerVer = "unknown"
 	}
-	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Controller: %s\n", controllerVer); err != nil {
-		return fmt.Errorf("write version: %w", err)
+	graphDisplay := graphVer
+	if graphDisplay == "" {
+		graphDisplay = "(unknown)"
+	}
+
+	if _, err := fmt.Fprintf(w, "CLI:        %s\n", cliVer); err != nil {
+		return fmt.Errorf("write version cli: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "Controller: %s\n", controllerVer); err != nil {
+		return fmt.Errorf("write version controller: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "Graph:      %s\n", graphDisplay); err != nil {
+		return fmt.Errorf("write version graph: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #201

## Summary

- Added `Graph:` line to `kardinal version` output, matching `docs/cli-reference.md`
- Reads graph version from `kardinal-version` ConfigMap `graph` key
- Falls back to `(unknown)` when key is absent or ConfigMap unavailable
- Extracted `versionFn()` for unit testing

**Scope**: CLI output gap closure — area/cli
**Packages changed**: within cmd/kardinal