### PR TITLE
[UI-CLI Agent] feat(cli): add kardinal diff command

### DIFF
--- a/cmd/kardinal/cmd/cli_test.go
+++ b/cmd/kardinal/cmd/cli_test.go
@@ -559,3 +559,86 @@ func TestVersionOutput_ThreeLines(t *testing.T) {
 		})
 	}
 }
+
+// TestDiff_ShowsImageTagDifference verifies that diffFn shows tag differences.
+func TestDiff_ShowsImageTagDifference(t *testing.T) {
+	s := cliTestScheme(t)
+	b1 := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1-28-0", Namespace: "default"},
+		Spec: v1alpha1.BundleSpec{
+			Type:     "image",
+			Pipeline: "nginx-demo",
+			Images: []v1alpha1.ImageRef{
+				{Repository: "ghcr.io/myorg/my-app", Tag: "1.28.0", Digest: "sha256:def456"},
+			},
+			Provenance: &v1alpha1.BundleProvenance{
+				CommitSHA: "def456abc",
+				Author:    "dependabot[bot]",
+			},
+		},
+	}
+	b2 := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1-29-0", Namespace: "default"},
+		Spec: v1alpha1.BundleSpec{
+			Type:     "image",
+			Pipeline: "nginx-demo",
+			Images: []v1alpha1.ImageRef{
+				{Repository: "ghcr.io/myorg/my-app", Tag: "1.29.0", Digest: "sha256:abc123"},
+			},
+			Provenance: &v1alpha1.BundleProvenance{
+				CommitSHA: "abc123def",
+				Author:    "engineer-name",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(b1, b2).Build()
+
+	var buf bytes.Buffer
+	err := diffFn(&buf, c, "default", "nginx-demo-v1-28-0", "nginx-demo-v1-29-0")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ghcr.io/myorg/my-app", "should show image repository")
+	assert.Contains(t, out, "1.28.0", "should show bundle-a tag")
+	assert.Contains(t, out, "1.29.0", "should show bundle-b tag")
+	assert.Contains(t, out, "engineer-name", "should show author difference")
+	assert.Contains(t, out, "ARTIFACT", "should have ARTIFACT header column")
+}
+
+// TestDiff_NoDifferences verifies diff output when bundles have no images (empty diff).
+func TestDiff_NoDifferences(t *testing.T) {
+	s := cliTestScheme(t)
+	b1 := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-config-a", Namespace: "default"},
+		Spec: v1alpha1.BundleSpec{
+			Type:     "config",
+			Pipeline: "nginx-demo",
+			// No images — pure config bundle
+			Provenance: &v1alpha1.BundleProvenance{
+				CommitSHA: "abc123",
+				Author:    "bot",
+			},
+		},
+	}
+	b2 := b1.DeepCopy()
+	b2.Name = "nginx-demo-config-b"
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(b1, b2).Build()
+
+	var buf bytes.Buffer
+	err := diffFn(&buf, c, "default", "nginx-demo-config-a", "nginx-demo-config-b")
+	require.NoError(t, err)
+
+	// Identical config bundles with same commit/author produce no diff rows.
+	assert.Contains(t, buf.String(), "no differences", "identical config bundles should show no diff")
+}
+
+// TestDiff_BundleNotFound verifies error on missing bundle.
+func TestDiff_BundleNotFound(t *testing.T) {
+	s := cliTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	var buf bytes.Buffer
+	err := diffFn(&buf, c, "default", "nonexistent-a", "nonexistent-b")
+	assert.Error(t, err, "should return error for missing bundle")
+	assert.Contains(t, err.Error(), "nonexistent-a", "error should mention the missing bundle")
+}

--- a/cmd/kardinal/cmd/diff.go
+++ b/cmd/kardinal/cmd/diff.go
@@ -1,0 +1,205 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+func newDiffCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "diff <bundle-a> <bundle-b>",
+		Short: "Show artifact differences between two Bundles",
+		Long: `Show artifact differences between two Bundles.
+
+Compares images, digests, commits, and authors between two Bundle CRDs.
+
+Example:
+  kardinal diff nginx-demo-v1-28-0 nginx-demo-v1-29-0`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, ns, err := buildClient()
+			if err != nil {
+				return fmt.Errorf("diff: %w", err)
+			}
+			return diffFn(cmd.OutOrStdout(), c, ns, args[0], args[1])
+		},
+	}
+}
+
+// diffFn is the testable implementation of kardinal diff.
+func diffFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client, ns, bundleA, bundleB string) error {
+	ctx := context.Background()
+
+	var a, b v1alpha1.Bundle
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: bundleA}, &a); err != nil {
+		return fmt.Errorf("get bundle %q: %w", bundleA, err)
+	}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: bundleB}, &b); err != nil {
+		return fmt.Errorf("get bundle %q: %w", bundleB, err)
+	}
+
+	rows := buildDiffRows(a, b)
+	return formatDiffTable(w, bundleA, bundleB, rows)
+}
+
+// DiffRow represents one row in the diff output.
+type DiffRow struct {
+	Artifact string
+	A        string
+	B        string
+}
+
+// buildDiffRows builds a list of diff rows from two Bundles.
+func buildDiffRows(a, b v1alpha1.Bundle) []DiffRow {
+	var rows []DiffRow
+
+	// Compare images.
+	// Build a lookup of repository → ImageRef for each bundle.
+	aImages := make(map[string]v1alpha1.ImageRef)
+	for _, img := range a.Spec.Images {
+		aImages[img.Repository] = img
+	}
+	bImages := make(map[string]v1alpha1.ImageRef)
+	for _, img := range b.Spec.Images {
+		bImages[img.Repository] = img
+	}
+
+	// Collect all repositories seen in either bundle, preserving order.
+	repos := make([]string, 0)
+	seen := make(map[string]bool)
+	for _, img := range a.Spec.Images {
+		if !seen[img.Repository] {
+			repos = append(repos, img.Repository)
+			seen[img.Repository] = true
+		}
+	}
+	for _, img := range b.Spec.Images {
+		if !seen[img.Repository] {
+			repos = append(repos, img.Repository)
+			seen[img.Repository] = true
+		}
+	}
+
+	for _, repo := range repos {
+		ai := aImages[repo]
+		bi := bImages[repo]
+
+		// Image row: show repository with tag.
+		aTag := ai.Tag
+		if aTag == "" {
+			aTag = "(absent)"
+		}
+		bTag := bi.Tag
+		if bTag == "" {
+			bTag = "(absent)"
+		}
+		rows = append(rows, DiffRow{Artifact: repo, A: aTag, B: bTag})
+
+		// Sub-rows: digest, commit (from provenance of the bundle, approximated per-image via tag).
+		aDigest := ai.Digest
+		if aDigest == "" {
+			aDigest = "--"
+		}
+		bDigest := bi.Digest
+		if bDigest == "" {
+			bDigest = "--"
+		}
+		if aDigest != bDigest {
+			rows = append(rows, DiffRow{
+				Artifact: "  digest",
+				A:        shortenDigest(aDigest),
+				B:        shortenDigest(bDigest),
+			})
+		}
+	}
+
+	// Provenance diff rows.
+	aP := provenance(a)
+	bP := provenance(b)
+
+	if aP.commit != bP.commit {
+		rows = append(rows, DiffRow{Artifact: "  commit", A: aP.commit, B: bP.commit})
+	}
+	if aP.author != bP.author {
+		rows = append(rows, DiffRow{Artifact: "  author", A: aP.author, B: bP.author})
+	}
+	if aP.ciRunURL != bP.ciRunURL && (aP.ciRunURL != "" || bP.ciRunURL != "") {
+		rows = append(rows, DiffRow{Artifact: "  ci-run", A: aP.ciRunURL, B: bP.ciRunURL})
+	}
+
+	return rows
+}
+
+type provenanceData struct {
+	commit   string
+	author   string
+	ciRunURL string
+}
+
+func provenance(b v1alpha1.Bundle) provenanceData {
+	if b.Spec.Provenance == nil {
+		return provenanceData{commit: "--", author: "--"}
+	}
+	p := b.Spec.Provenance
+	commit := p.CommitSHA
+	if commit == "" {
+		commit = "--"
+	}
+	author := p.Author
+	if author == "" {
+		author = "--"
+	}
+	return provenanceData{commit: commit, author: author, ciRunURL: p.CIRunURL}
+}
+
+// shortenDigest truncates a sha256 digest to sha256:abc123... for display.
+func shortenDigest(d string) string {
+	if len(d) > 19 {
+		return d[:19] + "..."
+	}
+	return d
+}
+
+// formatDiffTable writes the diff table to w.
+func formatDiffTable(w io.Writer, bundleA, bundleB string, rows []DiffRow) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 4, ' ', 0)
+	header := fmt.Sprintf("ARTIFACT\t%s\t%s", bundleA, bundleB)
+	if _, err := fmt.Fprintln(tw, header); err != nil {
+		return fmt.Errorf("write diff header: %w", err)
+	}
+
+	if len(rows) == 0 {
+		if _, err := fmt.Fprintln(tw, "(no differences)"); err != nil {
+			return fmt.Errorf("write diff empty: %w", err)
+		}
+		return tw.Flush()
+	}
+
+	for _, r := range rows {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", r.Artifact, r.A, r.B); err != nil {
+			return fmt.Errorf("write diff row: %w", err)
+		}
+	}
+	return tw.Flush()
+}

--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -72,6 +72,7 @@ It communicates with the Kubernetes API server to read and write CRDs.`,
 	root.AddCommand(newPolicyCmd())
 	root.AddCommand(newHistoryCmd())
 	root.AddCommand(newInitCmd())
+	root.AddCommand(newDiffCmd())
 
 	return root
 }


### PR DESCRIPTION
Fixes #199

## Summary

Implements `kardinal diff <bundle-a> <bundle-b>` as documented in `docs/cli-reference.md`.

- Shows image tag, digest, commit SHA, and author differences between two Bundle CRDs
- Only shows sub-rows (digest, commit, author) when they differ
- Shows `(no differences)` when bundles are identical or have no differing fields
- Registered in root command next to history/rollback
- 3 tests: image diff, no-diff (config bundles), bundle-not-found

**Scope**: CLI feature implementation — area/cli
**Packages changed**: within cmd/kardinal (diff.go, root.go, cli_test.go)