### PR TITLE
feat(cli): add kardinal diff command (#199)

### DIFF
--- a/.maqa/state.json
+++ b/.maqa/state.json
@@ -446,6 +446,20 @@
       "dependency_mode": "merged",
       "pr_number": 196,
       "pr_merged": false
+    },
+    "200-cli-history-format": {
+      "state": "done",
+      "assigned_to": "STANDALONE-CLI-UI",
+      "pr_number": 207,
+      "pr_merged": true,
+      "dependency_mode": "merged"
+    },
+    "201-cli-version-graph": {
+      "state": "done",
+      "assigned_to": "STANDALONE-CLI-UI",
+      "pr_number": 206,
+      "pr_merged": true,
+      "dependency_mode": "merged"
     }
   },
   "session_heartbeats": {

--- a/cmd/kardinal/cmd/diff.go
+++ b/cmd/kardinal/cmd/diff.go
@@ -1,0 +1,210 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+func newDiffCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "diff <bundle-a> <bundle-b>",
+		Short: "Show artifact differences between two Bundles",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, ns, err := buildClient()
+			if err != nil {
+				return fmt.Errorf("diff: %w", err)
+			}
+			return diffFn(cmd.OutOrStdout(), c, ns, args[0], args[1])
+		},
+	}
+}
+
+// diffFn is the testable implementation of the diff command.
+// It compares images and provenance between two Bundle CRDs.
+func diffFn(w io.Writer, c sigs_client.Client, ns, nameA, nameB string) error {
+	ctx := context.Background()
+
+	var bA v1alpha1.Bundle
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: nameA}, &bA); err != nil {
+		return fmt.Errorf("get bundle %q: %w", nameA, err)
+	}
+
+	var bB v1alpha1.Bundle
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: nameB}, &bB); err != nil {
+		return fmt.Errorf("get bundle %q: %w", nameB, err)
+	}
+
+	return FormatDiffTable(w, &bA, &bB)
+}
+
+// FormatDiffTable writes a tabwriter-formatted artifact diff table comparing
+// two Bundles. The format matches docs/cli-reference.md.
+//
+// Example output:
+//
+//	ARTIFACT                     BUNDLE-A (v1.28.0)    BUNDLE-B (v1.29.0)
+//	ghcr.io/myorg/my-app         1.28.0                1.29.0
+//	  digest                     sha256:def456...       sha256:abc123...
+//	  commit                     def456                 abc123
+//	  author                     dependabot[bot]        engineer-name
+func FormatDiffTable(w io.Writer, a, b *v1alpha1.Bundle) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+
+	// Print header with bundle names.
+	if _, err := fmt.Fprintf(tw, "ARTIFACT\tBUNDLE-A (%s)\tBUNDLE-B (%s)\n", a.Name, b.Name); err != nil {
+		return fmt.Errorf("write diff header: %w", err)
+	}
+
+	// Build image maps keyed by repository.
+	aImages := make(map[string]v1alpha1.ImageRef)
+	for _, img := range a.Spec.Images {
+		aImages[img.Repository] = img
+	}
+	bImages := make(map[string]v1alpha1.ImageRef)
+	for _, img := range b.Spec.Images {
+		bImages[img.Repository] = img
+	}
+
+	// Collect all repositories in deterministic order:
+	// images in A first (in spec order), then images only in B.
+	seen := make(map[string]bool)
+	var repos []string
+	for _, img := range a.Spec.Images {
+		if !seen[img.Repository] {
+			repos = append(repos, img.Repository)
+			seen[img.Repository] = true
+		}
+	}
+	for _, img := range b.Spec.Images {
+		if !seen[img.Repository] {
+			repos = append(repos, img.Repository)
+			seen[img.Repository] = true
+		}
+	}
+
+	for _, repo := range repos {
+		aImg := aImages[repo] // zero value if absent
+		bImg := bImages[repo] // zero value if absent
+
+		aTag := aImg.Tag
+		if aTag == "" {
+			aTag = "(absent)"
+		}
+		bTag := bImg.Tag
+		if bTag == "" {
+			bTag = "(absent)"
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", repo, aTag, bTag); err != nil {
+			return fmt.Errorf("write diff row: %w", err)
+		}
+
+		// Sub-rows for digest.
+		aDigest := truncDigest(aImg.Digest)
+		bDigest := truncDigest(bImg.Digest)
+		if aDigest != "" || bDigest != "" {
+			if aDigest == "" {
+				aDigest = "--"
+			}
+			if bDigest == "" {
+				bDigest = "--"
+			}
+			if _, err := fmt.Fprintf(tw, "  digest\t%s\t%s\n", aDigest, bDigest); err != nil {
+				return fmt.Errorf("write diff digest row: %w", err)
+			}
+		}
+	}
+
+	// Provenance diff (commit + author).
+	aCommit := commitSHA(a)
+	bCommit := commitSHA(b)
+	if aCommit != "" || bCommit != "" {
+		if aCommit == "" {
+			aCommit = "--"
+		}
+		if bCommit == "" {
+			bCommit = "--"
+		}
+		if _, err := fmt.Fprintf(tw, "  commit\t%s\t%s\n", aCommit, bCommit); err != nil {
+			return fmt.Errorf("write diff commit row: %w", err)
+		}
+	}
+
+	aAuthor := author(a)
+	bAuthor := author(b)
+	if aAuthor != "" || bAuthor != "" {
+		if aAuthor == "" {
+			aAuthor = "--"
+		}
+		if bAuthor == "" {
+			bAuthor = "--"
+		}
+		if _, err := fmt.Fprintf(tw, "  author\t%s\t%s\n", aAuthor, bAuthor); err != nil {
+			return fmt.Errorf("write diff author row: %w", err)
+		}
+	}
+
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("flush diff table: %w", err)
+	}
+	return nil
+}
+
+// truncDigest returns the first 15 chars of a digest with trailing ellipsis,
+// or the full digest if shorter. Returns "" for an empty input.
+func truncDigest(d string) string {
+	if d == "" {
+		return ""
+	}
+	if len(d) > 15 {
+		return d[:15] + "..."
+	}
+	return d
+}
+
+// commitSHA returns the source commit SHA from the bundle's provenance (if any).
+func commitSHA(b *v1alpha1.Bundle) string {
+	if b.Spec.ConfigRef != nil && b.Spec.ConfigRef.CommitSHA != "" {
+		return b.Spec.ConfigRef.CommitSHA[:min(8, len(b.Spec.ConfigRef.CommitSHA))]
+	}
+	if b.Spec.Provenance != nil && b.Spec.Provenance.CommitSHA != "" {
+		return b.Spec.Provenance.CommitSHA[:min(8, len(b.Spec.Provenance.CommitSHA))]
+	}
+	return ""
+}
+
+// author returns the bundle author from provenance (if any).
+func author(b *v1alpha1.Bundle) string {
+	if b.Spec.Provenance != nil {
+		return b.Spec.Provenance.Author
+	}
+	return ""
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cmd/kardinal/cmd/diff_test.go
+++ b/cmd/kardinal/cmd/diff_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+// TestDiff_ShowsImageDifferences verifies that diffFn outputs image tag differences.
+func TestDiff_ShowsImageDifferences(t *testing.T) {
+	s := cliTestScheme(t)
+	bA := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "bundle-v1", Namespace: "default"},
+		Spec: v1alpha1.BundleSpec{
+			Type:     "image",
+			Pipeline: "nginx-demo",
+			Images: []v1alpha1.ImageRef{
+				{Repository: "ghcr.io/myorg/my-app", Tag: "1.28.0", Digest: "sha256:def456abcdef456"},
+			},
+			Provenance: &v1alpha1.BundleProvenance{
+				CommitSHA: "def456abcdef456",
+				Author:    "dependabot[bot]",
+			},
+		},
+	}
+	bB := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "bundle-v2", Namespace: "default"},
+		Spec: v1alpha1.BundleSpec{
+			Type:     "image",
+			Pipeline: "nginx-demo",
+			Images: []v1alpha1.ImageRef{
+				{Repository: "ghcr.io/myorg/my-app", Tag: "1.29.0", Digest: "sha256:abc123xyz789abc"},
+			},
+			Provenance: &v1alpha1.BundleProvenance{
+				CommitSHA: "abc123xyz789abc",
+				Author:    "engineer-name",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(bA, bB).Build()
+
+	var buf bytes.Buffer
+	err := diffFn(&buf, c, "default", "bundle-v1", "bundle-v2")
+	require.NoError(t, err)
+
+	out := buf.String()
+	// Headers
+	assert.Contains(t, out, "ARTIFACT")
+	assert.Contains(t, out, "bundle-v1")
+	assert.Contains(t, out, "bundle-v2")
+	// Image row
+	assert.Contains(t, out, "ghcr.io/myorg/my-app")
+	assert.Contains(t, out, "1.28.0")
+	assert.Contains(t, out, "1.29.0")
+	// Digest sub-row (truncated)
+	assert.Contains(t, out, "digest")
+	assert.Contains(t, out, "sha256:def456ab...")
+	assert.Contains(t, out, "sha256:abc123xy...")
+	// Commit + author
+	assert.Contains(t, out, "commit")
+	assert.Contains(t, out, "author")
+	assert.Contains(t, out, "dependabot[bot]")
+	assert.Contains(t, out, "engineer-name")
+}
+
+// TestDiff_NoBundleReturnsError verifies that diffFn returns an error for missing bundles.
+func TestDiff_NoBundleReturnsError(t *testing.T) {
+	s := cliTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	var buf bytes.Buffer
+	err := diffFn(&buf, c, "default", "missing-a", "missing-b")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-a")
+}
+
+// TestFormatDiffTable_SameImagesShowsNoChanges verifies diff output when both bundles
+// have the same image (no change to highlight, but table should still render).
+func TestFormatDiffTable_SameImages(t *testing.T) {
+	bA := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "bundle-a"},
+		Spec: v1alpha1.BundleSpec{
+			Images: []v1alpha1.ImageRef{
+				{Repository: "nginx", Tag: "1.25"},
+			},
+		},
+	}
+	bB := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "bundle-b"},
+		Spec: v1alpha1.BundleSpec{
+			Images: []v1alpha1.ImageRef{
+				{Repository: "nginx", Tag: "1.25"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, FormatDiffTable(&buf, bA, bB))
+
+	out := buf.String()
+	assert.Contains(t, out, "nginx")
+	assert.Contains(t, out, "1.25")
+}
+
+// TestFormatDiffTable_ImageAbsentInB verifies that an image absent in bundle-b shows "(absent)".
+func TestFormatDiffTable_ImageAbsentInB(t *testing.T) {
+	bA := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "bundle-a"},
+		Spec: v1alpha1.BundleSpec{
+			Images: []v1alpha1.ImageRef{
+				{Repository: "ghcr.io/removed/svc", Tag: "1.0.0"},
+			},
+		},
+	}
+	bB := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "bundle-b"},
+		Spec:       v1alpha1.BundleSpec{},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, FormatDiffTable(&buf, bA, bB))
+
+	out := buf.String()
+	assert.Contains(t, out, "ghcr.io/removed/svc")
+	assert.Contains(t, out, "1.0.0")
+	assert.Contains(t, out, "(absent)")
+}
+
+// TestTruncDigest verifies digest truncation.
+func TestTruncDigest(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"sha256:abc123456789012345", "sha256:abc12345..."},
+		{"sha256:abc", "sha256:abc"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := truncDigest(tc.input)
+		assert.Equal(t, tc.expected, got, "input: %q", tc.input)
+	}
+}

--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -72,6 +72,7 @@ It communicates with the Kubernetes API server to read and write CRDs.`,
 	root.AddCommand(newPolicyCmd())
 	root.AddCommand(newHistoryCmd())
 	root.AddCommand(newInitCmd())
+	root.AddCommand(newDiffCmd())
 
 	return root
 }


### PR DESCRIPTION
## [🔨 ENG] Issue #199 — kardinal diff command

### Closes
Closes #199

### Problem
`kardinal diff <bundle-a> <bundle-b>` is documented in `docs/cli-reference.md` but not implemented.

### Solution

New `cmd/kardinal/cmd/diff.go`:
- `diffFn(w, client, ns, nameA, nameB)` — testable implementation
- `FormatDiffTable(w, bundleA, bundleB)` — tabwriter-formatted output matching docs
- Per-repository rows: tag comparison across both bundles
- Sub-rows: digest (truncated to 15 chars + `...`), commit SHA (first 8 chars), author
- Handles images absent in either bundle (shows `(absent)`)
- Provenance from `Bundle.Spec.Provenance` and `Bundle.Spec.ConfigRef`
- Deterministic ordering: repos from bundle-A first, then B-only repos

Root command registration in `root.go`.

### Tests
`cmd/kardinal/cmd/diff_test.go` — 5 tests:
- `TestDiff_ShowsImageDifferences` — end-to-end output with image/digest/commit/author
- `TestDiff_NoBundleReturnsError` — missing bundle error handling
- `TestFormatDiffTable_SameImages` — same-tag output renders correctly
- `TestFormatDiffTable_ImageAbsentInB` — removed images show `(absent)`
- `TestTruncDigest` — digest truncation edge cases

### Self-validation
```
go test ./cmd/kardinal/... -count=1  # PASS (includes 5 new diff tests)
go test ./... -count=1               # ALL PASS
go vet ./...                         # CLEAN
go build ./...                       # CLEAN
```

Docs updated: No changes needed (format matches existing `docs/cli-reference.md` spec).
Examples verified: No example changes needed.