### PR TITLE
[UI-CLI Agent] feat(cli): -o json/yaml output format flag for get commands

### DIFF
--- a/cmd/kardinal/cmd/format.go
+++ b/cmd/kardinal/cmd/format.go
@@ -22,8 +22,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	sigsyaml "sigs.k8s.io/yaml"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 )
 
 // HumanAge returns a human-readable age string for the given creation time.

--- a/cmd/kardinal/cmd/format.go
+++ b/cmd/kardinal/cmd/format.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -22,6 +23,7 @@ import (
 	"time"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
 // HumanAge returns a human-readable age string for the given creation time.
@@ -206,6 +208,36 @@ func FormatStepsTable(w io.Writer, steps []v1alpha1.PromotionStep) error {
 	}
 	if err := tw.Flush(); err != nil {
 		return fmt.Errorf("flush steps table: %w", err)
+	}
+	return nil
+}
+
+// ─── Output format helpers ────────────────────────────────────────────────────
+
+// OutputFormat returns the global output format flag value, normalised to lower-case.
+// Valid values: "" (table), "json", "yaml".
+func OutputFormat() string {
+	return strings.ToLower(globalOutput)
+}
+
+// WriteJSON serialises v as indented JSON to w.
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("write json: %w", err)
+	}
+	return nil
+}
+
+// WriteYAML serialises v as YAML to w.
+func WriteYAML(w io.Writer, v any) error {
+	data, err := sigsyaml.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal yaml: %w", err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("write yaml: %w", err)
 	}
 	return nil
 }

--- a/cmd/kardinal/cmd/format_test.go
+++ b/cmd/kardinal/cmd/format_test.go
@@ -343,3 +343,38 @@ func TestHumanAge(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteJSON_ProducesValidJSON(t *testing.T) {
+	data := []struct {
+		Name  string `json:"name"`
+		Phase string `json:"phase"`
+	}{
+		{Name: "my-app", Phase: "Promoting"},
+	}
+	var buf bytes.Buffer
+	err := cmd.WriteJSON(&buf, data)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, `"name": "my-app"`)
+	assert.Contains(t, out, `"phase": "Promoting"`)
+}
+
+func TestWriteYAML_ProducesValidYAML(t *testing.T) {
+	data := []struct {
+		Name  string `json:"name" yaml:"name"`
+		Phase string `json:"phase" yaml:"phase"`
+	}{
+		{Name: "my-app", Phase: "Verified"},
+	}
+	var buf bytes.Buffer
+	err := cmd.WriteYAML(&buf, data)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "name: my-app")
+	assert.Contains(t, out, "phase: Verified")
+}
+
+func TestOutputFormat_DefaultIsTable(t *testing.T) {
+	// Default global output is "", which means table.
+	assert.Equal(t, "", cmd.OutputFormat())
+}

--- a/cmd/kardinal/cmd/get_bundles.go
+++ b/cmd/kardinal/cmd/get_bundles.go
@@ -64,5 +64,13 @@ func runGetBundles(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return FormatBundleTable(cmd.OutOrStdout(), bundles.Items)
+	out := cmd.OutOrStdout()
+	switch OutputFormat() {
+	case "json":
+		return WriteJSON(out, bundles.Items)
+	case "yaml":
+		return WriteYAML(out, bundles.Items)
+	default:
+		return FormatBundleTable(out, bundles.Items)
+	}
 }

--- a/cmd/kardinal/cmd/get_pipelines.go
+++ b/cmd/kardinal/cmd/get_pipelines.go
@@ -67,5 +67,13 @@ func runGetPipelines(cmd *cobra.Command, args []string) error {
 		items = filtered
 	}
 
-	return FormatPipelineTable(cmd.OutOrStdout(), items, promotionSteps.Items)
+	out := cmd.OutOrStdout()
+	switch OutputFormat() {
+	case "json":
+		return WriteJSON(out, items)
+	case "yaml":
+		return WriteYAML(out, items)
+	default:
+		return FormatPipelineTable(out, items, promotionSteps.Items)
+	}
 }

--- a/cmd/kardinal/cmd/get_steps.go
+++ b/cmd/kardinal/cmd/get_steps.go
@@ -49,5 +49,13 @@ func runGetSteps(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("list promotion steps: %w", err)
 	}
 
-	return FormatStepsTable(cmd.OutOrStdout(), steps.Items)
+		out := cmd.OutOrStdout()
+	switch OutputFormat() {
+	case "json":
+		return WriteJSON(out, steps.Items)
+	case "yaml":
+		return WriteYAML(out, steps.Items)
+	default:
+		return FormatStepsTable(out, steps.Items)
+	}
 }

--- a/cmd/kardinal/cmd/get_steps.go
+++ b/cmd/kardinal/cmd/get_steps.go
@@ -49,7 +49,7 @@ func runGetSteps(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("list promotion steps: %w", err)
 	}
 
-		out := cmd.OutOrStdout()
+	out := cmd.OutOrStdout()
 	switch OutputFormat() {
 	case "json":
 		return WriteJSON(out, steps.Items)

--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -35,6 +35,7 @@ var (
 	globalNamespace  string
 	globalKubeconfig string
 	globalContext    string
+	globalOutput     string // output format: "" (table), "json", "yaml"
 )
 
 func init() {
@@ -60,6 +61,8 @@ It communicates with the Kubernetes API server to read and write CRDs.`,
 		"Path to kubeconfig file")
 	root.PersistentFlags().StringVar(&globalContext, "context", "",
 		"Kubeconfig context override")
+	root.PersistentFlags().StringVarP(&globalOutput, "output", "o", "",
+		"Output format: table (default), json, yaml")
 
 	root.AddCommand(newVersionCmd())
 	root.AddCommand(newGetCmd())


### PR DESCRIPTION
Fixes #226

## Summary

Adds `-o` / `--output` flag to all `get` subcommands, enabling JSON/YAML output for scripting and CI pipelines (Kargo parity).

```bash
kardinal get pipelines -o json
kardinal get bundles nginx-demo -o yaml
kardinal get steps nginx-demo -o json
```

Default (no flag) still outputs the human-readable table.

### Files changed
- `root.go`: global `--output/-o` persistent flag
- `format.go`: `WriteJSON()`, `WriteYAML()`, `OutputFormat()` helpers
- `get_pipelines.go`, `get_bundles.go`, `get_steps.go`: output switch

3 new tests: TestWriteJSON, TestWriteYAML, TestOutputFormat

**Scope**: CLI feature — area/cli
**Packages changed**: within cmd/kardinal