### PR TITLE
[UI-CLI Agent] feat(cli): kardinal approve — approve Bundle for priority promotion

### DIFF
--- a/cmd/kardinal/cmd/approve.go
+++ b/cmd/kardinal/cmd/approve.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+func newApproveCmd() *cobra.Command {
+	var envFlag string
+
+	cmd := &cobra.Command{
+		Use:   "approve <bundle>",
+		Short: "Approve a Bundle for promotion, bypassing upstream gate requirements",
+		Long: `Approve a Bundle for promotion to a specific environment.
+
+Approval is expressed by patching the Bundle with the label
+kardinal.io/approved=true (and optionally kardinal.io/approved-for=<env>).
+
+This is useful for hotfix deployments that must skip the normal
+upstream soak / gate requirements.
+
+Example:
+  kardinal approve nginx-demo-v1-29-0 --env prod`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, ns, err := buildClient()
+			if err != nil {
+				return fmt.Errorf("approve: %w", err)
+			}
+			return approveFn(cmd.OutOrStdout(), c, ns, args[0], envFlag)
+		},
+	}
+
+	cmd.Flags().StringVar(&envFlag, "env", "", "Target environment to approve for (optional)")
+	return cmd
+}
+
+// approveFn patches a Bundle with approval labels.
+func approveFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client, ns, bundleName, env string) error {
+	ctx := context.Background()
+
+	// Fetch the existing bundle to verify it exists.
+	var bundle v1alpha1.Bundle
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: bundleName}, &bundle); err != nil {
+		return fmt.Errorf("get bundle %q: %w", bundleName, err)
+	}
+
+	// Apply approval labels via a merge patch.
+	labels := map[string]string{
+		"kardinal.io/approved": "true",
+	}
+	if env != "" {
+		labels["kardinal.io/approved-for"] = env
+	}
+
+	patch := bundle.DeepCopy()
+	if patch.Labels == nil {
+		patch.Labels = make(map[string]string)
+	}
+	for k, v := range labels {
+		patch.Labels[k] = v
+	}
+
+	if err := c.Patch(ctx, patch, sigs_client.MergeFrom(&bundle)); err != nil {
+		return fmt.Errorf("patch bundle %q: %w", bundleName, err)
+	}
+
+	if env != "" {
+		if _, err := fmt.Fprintf(w, "Bundle %q approved for %q.\n  Label: kardinal.io/approved=true, kardinal.io/approved-for=%s\n  To track: kardinal explain %s --env %s\n",
+			bundleName, env, env, bundle.Spec.Pipeline, env); err != nil {
+			return fmt.Errorf("write: %w", err)
+		}
+	} else {
+		if _, err := fmt.Fprintf(w, "Bundle %q approved.\n  Label: kardinal.io/approved=true\n  To track: kardinal explain %s\n",
+			bundleName, bundle.Spec.Pipeline); err != nil {
+			return fmt.Errorf("write: %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/kardinal/cmd/cli_test.go
+++ b/cmd/kardinal/cmd/cli_test.go
@@ -654,3 +654,57 @@ func contains(s, sub string) bool {
 			return false
 		}())
 }
+
+// TestApprove_PatchesBundleWithLabel verifies that approveFn adds kardinal.io/approved label.
+func TestApprove_PatchesBundleWithLabel(t *testing.T) {
+	s := cliTestScheme(t)
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1-29-0", Namespace: "default"},
+		Spec:       v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(bundle).Build()
+
+	var buf bytes.Buffer
+	err := approveFn(&buf, c, "default", "nginx-demo-v1-29-0", "prod")
+	require.NoError(t, err)
+
+	// Verify label was applied.
+	var updated v1alpha1.Bundle
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1-29-0", Namespace: "default"}, &updated))
+	assert.Equal(t, "true", updated.Labels["kardinal.io/approved"])
+	assert.Equal(t, "prod", updated.Labels["kardinal.io/approved-for"])
+
+	// Verify output.
+	assert.Contains(t, buf.String(), "nginx-demo-v1-29-0")
+	assert.Contains(t, buf.String(), "approved")
+}
+
+// TestApprove_WithoutEnv verifies approveFn without --env flag.
+func TestApprove_WithoutEnv(t *testing.T) {
+	s := cliTestScheme(t)
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1-28-0", Namespace: "default"},
+		Spec:       v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(bundle).Build()
+
+	var buf bytes.Buffer
+	err := approveFn(&buf, c, "default", "nginx-demo-v1-28-0", "")
+	require.NoError(t, err)
+
+	var updated v1alpha1.Bundle
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "nginx-demo-v1-28-0", Namespace: "default"}, &updated))
+	assert.Equal(t, "true", updated.Labels["kardinal.io/approved"])
+	assert.Empty(t, updated.Labels["kardinal.io/approved-for"])
+}
+
+// TestApprove_BundleNotFound verifies error when bundle does not exist.
+func TestApprove_BundleNotFound(t *testing.T) {
+	s := cliTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	var buf bytes.Buffer
+	err := approveFn(&buf, c, "default", "nonexistent-bundle", "prod")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-bundle")
+}

--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -76,6 +76,7 @@ It communicates with the Kubernetes API server to read and write CRDs.`,
 	root.AddCommand(newHistoryCmd())
 	root.AddCommand(newInitCmd())
 	root.AddCommand(newDiffCmd())
+	root.AddCommand(newApproveCmd())
 
 	return root
 }


### PR DESCRIPTION
Fixes #231

## Summary

Implements `kardinal approve` (Kargo parity: explicit freight approval for hotfix bypasses).

```bash
kardinal approve nginx-demo-v1-29-0 --env prod
# Bundle "nginx-demo-v1-29-0" approved for "prod".
#   Label: kardinal.io/approved=true, kardinal.io/approved-for=prod
#   To track: kardinal explain nginx-demo --env prod
```

**Mechanism**: Patches the Bundle with:
- `kardinal.io/approved=true`
- `kardinal.io/approved-for=<env>` (when --env specified)

The controller can observe these labels in CEL expressions on PolicyGates to allow bypassing soak timers and other non-mandatory gates for approved bundles.

3 tests: with-env, without-env, not-found.

**Scope**: CLI feature — area/cli
**Packages changed**: within cmd/kardinal