### PR TITLE
fix(cel): inline kro CEL library — remove broken local replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ toolchain go1.25.9
 
 require (
 	github.com/google/cel-go v0.28.0
-	github.com/kubernetes-sigs/kro v0.0.0  // CEL library extensions only — see replace directive
 	github.com/rs/zerolog v1.35.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -79,8 +78,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 )
-
-// Use kro-fork local copy for CEL library extensions.
-// IMPORTANT: only import github.com/kubernetes-sigs/kro/pkg/cel/library — never the controller packages.
-// See AGENTS.md anti-patterns for the distinction.
-replace github.com/kubernetes-sigs/kro => ../kro-fork

--- a/pkg/cel/conversion/conversion.go
+++ b/pkg/cel/conversion/conversion.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// This file is adapted from github.com/kubernetes-sigs/kro/pkg/cel/conversion.
+// Original copyright: The Kubernetes Authors, Apache 2.0.
+
+// Package conversion provides helpers for converting CEL ref.Val values
+// to Go native types suitable for JSON marshalling.
+package conversion
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/cel/sentinels"
+)
+
+// ErrUnsupportedType is returned when the type is not supported.
+var ErrUnsupportedType = errors.New("unsupported type")
+
+// GoNativeType transforms CEL output into corresponding Go types.
+func GoNativeType(v ref.Val) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch v.Type() {
+	case types.BoolType:
+		return v.Value().(bool), nil
+	case types.IntType:
+		return v.Value().(int64), nil
+	case types.UintType:
+		return v.Value().(uint64), nil
+	case types.DoubleType:
+		return v.Value().(float64), nil
+	case types.StringType:
+		return v.Value().(string), nil
+	case types.BytesType:
+		return v.Value().([]byte), nil
+	case types.DurationType:
+		return v1.Duration{Duration: v.Value().(time.Duration)}.ToUnstructured(), nil
+	case types.TimestampType:
+		return v1.Time{Time: v.Value().(time.Time)}.ToUnstructured(), nil
+	case types.ListType:
+		return convertList(v)
+	case types.MapType:
+		return convertMap(v)
+	case types.OptionalType:
+		opt := v.(*types.Optional)
+		if !opt.HasValue() {
+			return nil, nil
+		}
+		return GoNativeType(opt.GetValue())
+	case types.UnknownType:
+		return v.Value(), nil
+	case types.NullType:
+		return nil, nil
+	default:
+		if _, ok := v.Value().(sentinels.Omit); ok {
+			return sentinels.Omit{}, nil
+		}
+		return v.Value(), fmt.Errorf("%w: %v", ErrUnsupportedType, v.Type())
+	}
+}
+
+func convertList(v ref.Val) (interface{}, error) {
+	lister, ok := v.(traits.Lister)
+	if !ok {
+		return v.ConvertToNative(reflect.TypeOf([]interface{}{}))
+	}
+	result := make([]interface{}, 0)
+	it := lister.Iterator()
+	for it.HasNext() == types.True {
+		elem := it.Next()
+		native, err := GoNativeType(elem)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, native)
+	}
+	return result, nil
+}
+
+func convertMap(v ref.Val) (interface{}, error) {
+	mapper, ok := v.(traits.Mapper)
+	if !ok {
+		return v.ConvertToNative(reflect.TypeOf(map[string]any{}))
+	}
+	if rawMap, ok := v.Value().(map[string]interface{}); ok {
+		return runtime.DeepCopyJSON(rawMap), nil
+	}
+	result := make(map[string]interface{})
+	it := mapper.Iterator()
+	for it.HasNext() == types.True {
+		key := it.Next()
+		if key == nil {
+			continue
+		}
+		val := mapper.Get(key)
+		keyNative, err := GoNativeType(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert map key: %w", err)
+		}
+		keyStr, ok := keyNative.(string)
+		if !ok {
+			return nil, fmt.Errorf("map key must be string, got %T", keyNative)
+		}
+		valNative, err := GoNativeType(val)
+		if err != nil {
+			return nil, err
+		}
+		result[keyStr] = valNative
+	}
+	return result, nil
+}

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -19,7 +19,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
 
-	krolibrary "github.com/kubernetes-sigs/kro/pkg/cel/library"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/cel/library"
 )
 
 // NewCELEnvironment creates a shared CEL environment for PolicyGate expression
@@ -63,12 +63,12 @@ func NewCELEnvironment() (*cel.Env, error) {
 		// kro CEL library extensions — same set used by kro Graph controller
 		// for readyWhen/propagateWhen evaluation. This ensures PolicyGate
 		// expressions can use the same functions as native kro CEL expressions.
-		// Source: github.com/kubernetes-sigs/kro/pkg/cel/library
-		krolibrary.JSON(),
-		krolibrary.Maps(),
-		krolibrary.Lists(),
-		krolibrary.Random(),
-		krolibrary.Omit(),
+		// Inlined from github.com/kubernetes-sigs/kro/pkg/cel/library (Apache 2.0).
+		library.JSON(),
+		library.Maps(),
+		library.Lists(),
+		library.Random(),
+		library.Omit(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cel.NewEnv: %w", err)

--- a/pkg/cel/library/json.go
+++ b/pkg/cel/library/json.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// This file is adapted from github.com/kubernetes-sigs/kro/pkg/cel/library/json.go.
+// Original copyright: The Kubernetes Authors, Apache 2.0.
+
+package library
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/cel/conversion"
+)
+
+// JSON returns a CEL library that provides JSON parsing functions.
+//
+// Functions:
+//   - json.unmarshal(jsonString string) → dyn  — parses JSON string into CEL value
+//   - json.marshal(value dyn) → string         — converts CEL value to JSON string
+func JSON(options ...JSONOption) cel.EnvOption {
+	lib := &jsonLibrary{version: math.MaxUint32}
+	for _, o := range options {
+		lib = o(lib)
+	}
+	return cel.Lib(lib)
+}
+
+// JSONOption is a functional option for configuring the json library.
+type JSONOption func(*jsonLibrary) *jsonLibrary
+
+// JSONVersion configures the version of the json library.
+func JSONVersion(version uint32) JSONOption {
+	return func(lib *jsonLibrary) *jsonLibrary {
+		lib.version = version
+		return lib
+	}
+}
+
+type jsonLibrary struct {
+	version uint32
+}
+
+func (l *jsonLibrary) LibraryName() string {
+	return "json"
+}
+
+func (l *jsonLibrary) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Function("json.unmarshal",
+			cel.Overload("json.unmarshal_string",
+				[]*cel.Type{cel.StringType},
+				cel.DynType,
+				cel.UnaryBinding(unmarshalJSON),
+			),
+		),
+		cel.Function("json.marshal",
+			cel.Overload("json.marshal_dyn",
+				[]*cel.Type{cel.DynType},
+				cel.StringType,
+				cel.UnaryBinding(marshalJSON),
+			),
+		),
+	}
+}
+
+func (l *jsonLibrary) ProgramOptions() []cel.ProgramOption {
+	return nil
+}
+
+func unmarshalJSON(jsonString ref.Val) ref.Val {
+	native, err := jsonString.ConvertToNative(reflect.TypeOf(""))
+	if err != nil {
+		return types.NewErr("json.unmarshal argument must be a string")
+	}
+	str, ok := native.(string)
+	if !ok {
+		return types.NewErr("json.unmarshal argument must be a string")
+	}
+	var result interface{}
+	if err := json.Unmarshal([]byte(str), &result); err != nil {
+		return types.NewErr("json.unmarshal failed to parse JSON: %s", err.Error())
+	}
+	return types.DefaultTypeAdapter.NativeToValue(result)
+}
+
+func marshalJSON(value ref.Val) ref.Val {
+	native, err := conversion.GoNativeType(value)
+	if err != nil {
+		return types.NewErr("json.marshal failed to convert value: %s", err.Error())
+	}
+	jsonBytes, err := json.Marshal(native)
+	if err != nil {
+		return types.NewErr("json.marshal failed to encode value: %s", err.Error())
+	}
+	return types.String(string(jsonBytes))
+}

--- a/pkg/cel/library/lists.go
+++ b/pkg/cel/library/lists.go
@@ -1,0 +1,157 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// This file is adapted from github.com/kubernetes-sigs/kro/pkg/cel/library/lists.go.
+// Original copyright: The Kubernetes Authors, Apache 2.0.
+
+package library
+
+import (
+	"math"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+)
+
+// Lists returns a CEL library that provides index-mutation functions for lists.
+// All functions are pure — they return a new list and do not modify the input.
+//
+//   - lists.setAtIndex(list(T), int, T) -> list(T)
+//   - lists.insertAtIndex(list(T), int, T) -> list(T)
+//   - lists.removeAtIndex(list(T), int) -> list(T)
+func Lists(options ...ListsOption) cel.EnvOption {
+	l := &listsLibrary{version: math.MaxUint32}
+	for _, o := range options {
+		l = o(l)
+	}
+	return cel.Lib(l)
+}
+
+// ListsOption is a functional option for configuring the lists library.
+type ListsOption func(*listsLibrary) *listsLibrary
+
+// ListsVersion configures the version of the lists library.
+func ListsVersion(version uint32) ListsOption {
+	return func(lib *listsLibrary) *listsLibrary {
+		lib.version = version
+		return lib
+	}
+}
+
+type listsLibrary struct {
+	version uint32
+}
+
+func (l *listsLibrary) LibraryName() string {
+	return "kro.lists"
+}
+
+func (l *listsLibrary) CompileOptions() []cel.EnvOption {
+	listType := cel.ListType(cel.TypeParamType("T"))
+	return []cel.EnvOption{
+		cel.Function("lists.setAtIndex",
+			cel.Overload("lists.setAtIndex_list_int_T",
+				[]*cel.Type{listType, cel.IntType, cel.TypeParamType("T")},
+				listType,
+				cel.FunctionBinding(listsSetAtIndex),
+			),
+		),
+		cel.Function("lists.insertAtIndex",
+			cel.Overload("lists.insertAtIndex_list_int_T",
+				[]*cel.Type{listType, cel.IntType, cel.TypeParamType("T")},
+				listType,
+				cel.FunctionBinding(listsInsertAtIndex),
+			),
+		),
+		cel.Function("lists.removeAtIndex",
+			cel.Overload("lists.removeAtIndex_list_int",
+				[]*cel.Type{listType, cel.IntType},
+				listType,
+				cel.BinaryBinding(listsRemoveAtIndex),
+			),
+		),
+	}
+}
+
+func (l *listsLibrary) ProgramOptions() []cel.ProgramOption {
+	return nil
+}
+
+func listsSetAtIndex(args ...ref.Val) ref.Val {
+	if len(args) != 3 {
+		return types.NewErr("lists.setAtIndex: expected 3 arguments (arr, index, value)")
+	}
+	lister, ok := args[0].(traits.Lister)
+	if !ok {
+		return types.NewErr("lists.setAtIndex: first argument must be a list")
+	}
+	if args[1].Type() != types.IntType {
+		return types.NewErr("lists.setAtIndex: index must be an integer")
+	}
+	idx := int64(args[1].(types.Int))
+	size := int64(lister.Size().(types.Int))
+	if idx < 0 || idx >= size {
+		return types.NewErr("lists.setAtIndex: index %d out of bounds [0, %d)", idx, size)
+	}
+	elems := make([]ref.Val, size)
+	for i := int64(0); i < size; i++ {
+		if i == idx {
+			elems[i] = args[2]
+		} else {
+			elems[i] = lister.Get(types.Int(i))
+		}
+	}
+	return types.NewRefValList(types.DefaultTypeAdapter, elems)
+}
+
+func listsInsertAtIndex(args ...ref.Val) ref.Val {
+	if len(args) != 3 {
+		return types.NewErr("lists.insertAtIndex: expected 3 arguments (arr, index, value)")
+	}
+	lister, ok := args[0].(traits.Lister)
+	if !ok {
+		return types.NewErr("lists.insertAtIndex: first argument must be a list")
+	}
+	if args[1].Type() != types.IntType {
+		return types.NewErr("lists.insertAtIndex: index must be an integer")
+	}
+	idx := int64(args[1].(types.Int))
+	size := int64(lister.Size().(types.Int))
+	if idx < 0 || idx > size {
+		return types.NewErr("lists.insertAtIndex: index %d out of bounds [0, %d]", idx, size)
+	}
+	elems := make([]ref.Val, size+1)
+	for i := int64(0); i < idx; i++ {
+		elems[i] = lister.Get(types.Int(i))
+	}
+	elems[idx] = args[2]
+	for i := idx; i < size; i++ {
+		elems[i+1] = lister.Get(types.Int(i))
+	}
+	return types.NewRefValList(types.DefaultTypeAdapter, elems)
+}
+
+func listsRemoveAtIndex(arrVal, idxVal ref.Val) ref.Val {
+	lister, ok := arrVal.(traits.Lister)
+	if !ok {
+		return types.NewErr("lists.removeAtIndex: first argument must be a list")
+	}
+	if idxVal.Type() != types.IntType {
+		return types.NewErr("lists.removeAtIndex: index must be an integer")
+	}
+	idx := int64(idxVal.(types.Int))
+	size := int64(lister.Size().(types.Int))
+	if idx < 0 || idx >= size {
+		return types.NewErr("lists.removeAtIndex: index %d out of bounds [0, %d)", idx, size)
+	}
+	elems := make([]ref.Val, size-1)
+	for i := int64(0); i < idx; i++ {
+		elems[i] = lister.Get(types.Int(i))
+	}
+	for i := idx + 1; i < size; i++ {
+		elems[i-1] = lister.Get(types.Int(i))
+	}
+	return types.NewRefValList(types.DefaultTypeAdapter, elems)
+}

--- a/pkg/cel/library/maps.go
+++ b/pkg/cel/library/maps.go
@@ -1,0 +1,96 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// This file is adapted from github.com/kubernetes-sigs/kro/pkg/cel/library/maps.go.
+// Original copyright: Google LLC, Apache 2.0.
+
+package library
+
+import (
+	"math"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+)
+
+// Maps returns a cel.EnvOption to configure extended functions for map manipulation.
+//
+// # Merge
+//
+//	map(string, T).merge(map(string, T)) -> map(string, T)
+//
+// Merges two maps. Keys from the second map overwrite keys in the first map.
+func Maps(options ...MapsOption) cel.EnvOption {
+	l := &mapsLib{version: math.MaxUint32}
+	for _, o := range options {
+		l = o(l)
+	}
+	return cel.Lib(l)
+}
+
+// MapsOption is a functional option for configuring the maps library.
+type MapsOption func(*mapsLib) *mapsLib
+
+// MapsVersion configures the version of the maps library.
+func MapsVersion(version uint32) MapsOption {
+	return func(lib *mapsLib) *mapsLib {
+		lib.version = version
+		return lib
+	}
+}
+
+type mapsLib struct {
+	version uint32
+}
+
+func (mapsLib) LibraryName() string {
+	return "cel.lib.ext.maps"
+}
+
+func (lib mapsLib) CompileOptions() []cel.EnvOption {
+	mapType := cel.MapType(cel.TypeParamType("K"), cel.TypeParamType("V"))
+	return []cel.EnvOption{
+		cel.Function("merge",
+			cel.MemberOverload("map_merge",
+				[]*cel.Type{mapType, mapType},
+				mapType,
+				cel.BinaryBinding(mergeVals),
+			),
+		),
+	}
+}
+
+func (lib mapsLib) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}
+
+func mergeVals(lhs, rhs ref.Val) ref.Val {
+	left, lok := lhs.(traits.Mapper)
+	right, rok := rhs.(traits.Mapper)
+	if !lok || !rok {
+		return types.ValOrErr(lhs, "no such overload: %v.merge(%v)", lhs.Type(), rhs.Type())
+	}
+	return mergeMaps(left, right)
+}
+
+func mergeMaps(self, other traits.Mapper) traits.Mapper {
+	result := mapperToMutable(other)
+	for i := self.Iterator(); i.HasNext().(types.Bool); {
+		k := i.Next()
+		if !result.Contains(k).(types.Bool) {
+			result.Insert(k, self.Get(k))
+		}
+	}
+	return result.ToImmutableMap()
+}
+
+func mapperToMutable(m traits.Mapper) traits.MutableMapper {
+	vals := make(map[ref.Val]ref.Val, m.Size().(types.Int))
+	for it := m.Iterator(); it.HasNext().(types.Bool); {
+		k := it.Next()
+		vals[k] = m.Get(k)
+	}
+	return types.NewMutableMap(types.DefaultTypeAdapter, vals)
+}

--- a/pkg/cel/library/omit.go
+++ b/pkg/cel/library/omit.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// This file is adapted from github.com/kubernetes-sigs/kro/pkg/cel/library/omit.go.
+// Original copyright: The Kubernetes Authors, Apache 2.0.
+
+package library
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/cel/sentinels"
+)
+
+// omitVal is the CEL ref.Val wrapper for the omit sentinel.
+type omitVal struct{}
+
+var omitInstance = &omitVal{}
+
+func (v *omitVal) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	if typeDesc == reflect.TypeOf(sentinels.Omit{}) {
+		return sentinels.Omit{}, nil
+	}
+	if typeDesc.Kind() == reflect.Interface {
+		return sentinels.Omit{}, nil
+	}
+	return nil, fmt.Errorf("unsupported native conversion from omit to %v", typeDesc)
+}
+
+func (v *omitVal) ConvertToType(typeVal ref.Type) ref.Val {
+	if typeVal == types.TypeType {
+		return types.NewObjectType("kro.omit")
+	}
+	return types.NewErr("unsupported conversion from omit to %v", typeVal)
+}
+
+func (v *omitVal) Equal(other ref.Val) ref.Val {
+	return types.NewErr("omit() is a field-removal sentinel and cannot be compared")
+}
+
+func (v *omitVal) Type() ref.Type {
+	return types.NewObjectType("kro.omit")
+}
+
+func (v *omitVal) Value() any {
+	return sentinels.Omit{}
+}
+
+// Omit returns a cel.EnvOption that registers the omit() function.
+// omit() is a zero-argument function that returns a sentinel value causing
+// field omission in Graph templates.
+func Omit() cel.EnvOption {
+	return cel.Lib(&omitLib{})
+}
+
+type omitLib struct{}
+
+func (l *omitLib) LibraryName() string {
+	return "kro.omit"
+}
+
+func (l *omitLib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Function("omit",
+			cel.Overload("omit_void",
+				[]*cel.Type{},
+				cel.DynType,
+				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+					return omitInstance
+				}),
+			),
+		),
+	}
+}
+
+func (l *omitLib) ProgramOptions() []cel.ProgramOption {
+	return nil
+}

--- a/pkg/cel/library/random.go
+++ b/pkg/cel/library/random.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// This file is adapted from github.com/kubernetes-sigs/kro/pkg/cel/library/random.go.
+// Original copyright: The Kubernetes Authors, Apache 2.0.
+
+package library
+
+import (
+	"crypto/sha256"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+const alphanumericChars = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+// Random returns a CEL library that provides deterministic random generation.
+//
+//   - random.seededInt(min int, max int, seed string) → int
+//   - random.seededString(length int, seed string) → string
+func Random() cel.EnvOption {
+	return cel.Lib(&randomLibrary{})
+}
+
+type randomLibrary struct{}
+
+func (l *randomLibrary) LibraryName() string {
+	return "random"
+}
+
+func (l *randomLibrary) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Function("random.seededString",
+			cel.Overload("random.seededString_int_string",
+				[]*cel.Type{cel.IntType, cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(generateDeterministicString),
+			),
+		),
+		cel.Function("random.seededInt",
+			cel.Overload("random.seededInt_int_int_string",
+				[]*cel.Type{cel.IntType, cel.IntType, cel.StringType},
+				cel.IntType,
+				cel.FunctionBinding(generateDeterministicInt),
+			),
+		),
+	}
+}
+
+func (l *randomLibrary) ProgramOptions() []cel.ProgramOption {
+	return nil
+}
+
+func generateDeterministicInt(args ...ref.Val) ref.Val {
+	if len(args) != 3 {
+		return types.NewErr("random.seededInt requires exactly 3 arguments")
+	}
+	minVal, maxVal, seed := args[0], args[1], args[2]
+	if minVal.Type() != types.IntType {
+		return types.NewErr("random.seededInt min must be an integer")
+	}
+	if maxVal.Type() != types.IntType {
+		return types.NewErr("random.seededInt max must be an integer")
+	}
+	if seed.Type() != types.StringType {
+		return types.NewErr("random.seededInt seed must be a string")
+	}
+	minInt := minVal.(types.Int).Value().(int64)
+	maxInt := maxVal.(types.Int).Value().(int64)
+	if minInt >= maxInt {
+		return types.NewErr("random.seededInt min must be less than max")
+	}
+	seedStr := seed.(types.String).Value().(string)
+	hash := sha256.Sum256([]byte(seedStr))
+	v := uint64(hash[0])<<56 | uint64(hash[1])<<48 | uint64(hash[2])<<40 | uint64(hash[3])<<32 |
+		uint64(hash[4])<<24 | uint64(hash[5])<<16 | uint64(hash[6])<<8 | uint64(hash[7])
+	rangeSize := uint64(maxInt - minInt)
+	result := minInt + int64(v%rangeSize)
+	return types.Int(result)
+}
+
+func generateDeterministicString(length ref.Val, seed ref.Val) ref.Val {
+	if length.Type() != types.IntType {
+		return types.NewErr("random.seededString length must be an integer")
+	}
+	if length.(types.Int) <= 0 {
+		return types.NewErr("random.seededString length must be positive")
+	}
+	if seed.Type() != types.StringType {
+		return types.NewErr("random.seededString seed must be a string")
+	}
+	n := int(length.(types.Int).Value().(int64))
+	seedStr := seed.(types.String).Value().(string)
+	hash := sha256.Sum256([]byte(seedStr))
+	result := make([]byte, n)
+	charsLen := len(alphanumericChars)
+	for i := 0; i < n; i++ {
+		start := (i * 4) % len(hash)
+		end := start + 4
+		if end > len(hash) {
+			newHash := sha256.Sum256(append(hash[:], result[:i]...))
+			hash = newHash
+			start = 0
+		}
+		idx := uint32(hash[start])<<24 | uint32(hash[start+1])<<16 | uint32(hash[start+2])<<8 | uint32(hash[start+3])
+		result[i] = alphanumericChars[idx%uint32(charsLen)]
+	}
+	return types.String(string(result))
+}

--- a/pkg/cel/sentinels/sentinels.go
+++ b/pkg/cel/sentinels/sentinels.go
@@ -1,0 +1,19 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// This file is adapted from github.com/kubernetes-sigs/kro/pkg/cel/sentinels.
+// Original copyright: The Kubernetes Authors, Apache 2.0.
+
+// Package sentinels provides marker types for CEL template field omission.
+package sentinels
+
+// Omit is a marker value that signals the resolver to remove the
+// containing field or array element from the rendered object instead
+// of writing a value.
+type Omit struct{}
+
+// IsOmit returns true if the value is an Omit sentinel.
+func IsOmit(v interface{}) bool {
+	_, ok := v.(Omit)
+	return ok
+}


### PR DESCRIPTION
## Summary

Fixes CI-breaking failure introduced when the kro CEL library integration was merged.

**Root cause**: `go.mod` contained a `replace` directive pointing to `../kro-fork` (a local directory). In CI, this path does not exist, causing every build, lint, and test step to fail with:
```
replacement directory ../kro-fork does not exist
```

**Fix**: Inline the five kro CEL library functions into our own `pkg/cel/library/` package:
- `JSON()` — json.marshal / json.unmarshal
- `Maps()` — map.merge
- `Lists()` — lists.setAtIndex / insertAtIndex / removeAtIndex
- `Random()` — random.seededInt / seededString
- `Omit()` — omit() sentinel for Graph templates

Also inline supporting packages `pkg/cel/conversion` and `pkg/cel/sentinels` that json.go depends on.

All files adapted from `github.com/kubernetes-sigs/kro/pkg/cel/library` (Apache 2.0, attributed in file headers). Behavior is identical — same CEL function names, same signatures, same library names for CEL registration.

Remove the `github.com/kubernetes-sigs/kro` dependency and `replace` directive from go.mod entirely.

## Verification

- `go build ./...` ✅
- `go test ./... -race` ✅ (all 18 packages pass)
- `go vet ./...` ✅
- `go mod tidy` (no diff) ✅

## Docs updated: no docs change needed (internal implementation)
## Examples verified: CEL evaluator tests pass identically