### PR TITLE
fix(pdca): PAUSED badge + active bundle display + bundle.upstreamSoakMinutes

### DIFF
--- a/cmd/kardinal/cmd/format.go
+++ b/cmd/kardinal/cmd/format.go
@@ -47,10 +47,35 @@ func HumanAge(t time.Time) string {
 // derive per-environment status and the active bundle version for each pipeline.
 // If steps is nil or empty the environment columns will show "-".
 func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1alpha1.PromotionStep) error {
-	// Build a lookup: pipeline → environment → (state, bundleName)
+	// stepStatePriority assigns a priority to each PromotionStep state so we can
+	// prefer the most-active step when multiple bundles have steps for the same
+	// pipeline+environment. Higher priority = displayed first.
+	// Active states (Promoting/Pending/WaitingForMerge/HealthChecking) take precedence
+	// over terminal states (Verified/Failed/Superseded).
+	stepStatePriority := func(state string) int {
+		switch state {
+		case "Promoting", "WaitingForMerge", "HealthChecking":
+			return 4
+		case "Pending":
+			return 3
+		case "Failed":
+			return 2
+		case "Verified":
+			return 1
+		default:
+			return 0
+		}
+	}
+
+	// Build a lookup: pipeline → environment → (state, bundleName, createdAt)
+	// When multiple PromotionSteps exist for the same pipeline+env (from different
+	// bundles), prefer the one with the highest state priority, then most recently
+	// created.
 	type envState struct {
 		state      string
 		bundleName string
+		priority   int
+		createdAt  time.Time
 	}
 	// pipelineEnvMap[pipelineName][envName] = envState
 	pipelineEnvMap := make(map[string]map[string]envState)
@@ -67,9 +92,18 @@ func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1a
 		if state == "" {
 			state = "Pending"
 		}
-		pipelineEnvMap[pipe][env] = envState{
-			state:      state,
-			bundleName: s.Spec.BundleName,
+		priority := stepStatePriority(state)
+		existing, hasExisting := pipelineEnvMap[pipe][env]
+		// Replace if: higher priority, or same priority + more recent step.
+		if !hasExisting ||
+			priority > existing.priority ||
+			(priority == existing.priority && s.CreationTimestamp.After(existing.createdAt)) {
+			pipelineEnvMap[pipe][env] = envState{
+				state:      state,
+				bundleName: s.Spec.BundleName,
+				priority:   priority,
+				createdAt:  s.CreationTimestamp.Time,
+			}
 		}
 	}
 
@@ -101,23 +135,34 @@ func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1a
 
 	for _, p := range pipelines {
 		// Determine active bundle version.
-		// Use the bundle name from any PromotionStep for this pipeline, preferring
-		// the most-advanced (Verified) environment's bundle name.
+		// Pick the bundle name from the highest-priority step across all environments.
+		// This ensures the most-active bundle (Promoting > Verified > Failed) is shown,
+		// not an older superseded bundle that happens to be Verified.
 		bundleDisplay := "-"
+		var bestPriority int
+		var bestCreatedAt time.Time
 		if envMap, ok := pipelineEnvMap[p.Name]; ok {
-			// Prefer Verified env bundle, else take any non-empty bundle name.
 			for _, est := range envMap {
-				if est.bundleName != "" && bundleDisplay == "-" {
-					bundleDisplay = est.bundleName
+				if est.bundleName == "" {
+					continue
 				}
-				if est.state == "Verified" && est.bundleName != "" {
+				if bundleDisplay == "-" ||
+					est.priority > bestPriority ||
+					(est.priority == bestPriority && est.createdAt.After(bestCreatedAt)) {
 					bundleDisplay = est.bundleName
+					bestPriority = est.priority
+					bestCreatedAt = est.createdAt
 				}
 			}
 		}
 
-		// Build the row.
-		row := fmt.Sprintf("%s\t%s", p.Name, bundleDisplay)
+		// Build the row. Append [PAUSED] to the pipeline name when the pipeline
+		// has spec.paused=true so operators immediately see the frozen state.
+		pipelineDisplay := p.Name
+		if p.Spec.Paused {
+			pipelineDisplay = p.Name + " [PAUSED]"
+		}
+		row := fmt.Sprintf("%s\t%s", pipelineDisplay, bundleDisplay)
 		for _, env := range envOrder {
 			state := "-"
 			if envMap, ok := pipelineEnvMap[p.Name]; ok {

--- a/cmd/kardinal/cmd/format_test.go
+++ b/cmd/kardinal/cmd/format_test.go
@@ -378,3 +378,127 @@ func TestOutputFormat_DefaultIsTable(t *testing.T) {
 	// Default global output is "", which means table.
 	assert.Equal(t, "", cmd.OutputFormat())
 }
+
+// TestFormatPipelineTable_PausedBadge verifies that a paused pipeline shows [PAUSED] in the name.
+func TestFormatPipelineTable_PausedBadge(t *testing.T) {
+	now := time.Now()
+	pipelines := []v1alpha1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "my-pipeline",
+				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
+			},
+			Spec: v1alpha1.PipelineSpec{
+				Paused: true,
+				Environments: []v1alpha1.EnvironmentSpec{
+					{Name: "test"},
+					{Name: "prod"},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cmd.FormatPipelineTable(&buf, pipelines, nil))
+	out := buf.String()
+
+	assert.Contains(t, out, "my-pipeline [PAUSED]", "paused pipeline must show [PAUSED] badge in name")
+}
+
+// TestFormatPipelineTable_NonPausedNoBadge verifies that a non-paused pipeline does NOT show [PAUSED].
+func TestFormatPipelineTable_NonPausedNoBadge(t *testing.T) {
+	now := time.Now()
+	pipelines := []v1alpha1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "my-pipeline",
+				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
+			},
+			Spec: v1alpha1.PipelineSpec{
+				Paused: false,
+				Environments: []v1alpha1.EnvironmentSpec{
+					{Name: "test"},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cmd.FormatPipelineTable(&buf, pipelines, nil))
+	out := buf.String()
+
+	assert.NotContains(t, out, "[PAUSED]", "non-paused pipeline must not show [PAUSED] badge")
+}
+
+// TestFormatPipelineTable_ActiveBundlePrefersPromoting verifies that when both a Verified
+// step (old bundle) and a Promoting step (new bundle) exist, the Promoting bundle is shown.
+func TestFormatPipelineTable_ActiveBundlePrefersPromoting(t *testing.T) {
+	now := time.Now()
+	pipelines := []v1alpha1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "my-app",
+				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
+			},
+			Spec: v1alpha1.PipelineSpec{
+				Environments: []v1alpha1.EnvironmentSpec{
+					{Name: "test"},
+					{Name: "prod"},
+				},
+			},
+		},
+	}
+	// Old bundle: Verified in test, prod; created 1 hour ago.
+	oldTime := metav1.NewTime(now.Add(-1 * time.Hour))
+	// New bundle: Promoting in test; created 30s ago.
+	newTime := metav1.NewTime(now.Add(-30 * time.Second))
+
+	steps := []v1alpha1.PromotionStep{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "my-app-old-test",
+				CreationTimestamp: oldTime,
+			},
+			Spec: v1alpha1.PromotionStepSpec{
+				PipelineName: "my-app",
+				Environment:  "test",
+				BundleName:   "my-app-old",
+			},
+			Status: v1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "my-app-old-prod",
+				CreationTimestamp: oldTime,
+			},
+			Spec: v1alpha1.PromotionStepSpec{
+				PipelineName: "my-app",
+				Environment:  "prod",
+				BundleName:   "my-app-old",
+			},
+			Status: v1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "my-app-new-test",
+				CreationTimestamp: newTime,
+			},
+			Spec: v1alpha1.PromotionStepSpec{
+				PipelineName: "my-app",
+				Environment:  "test",
+				BundleName:   "my-app-new",
+			},
+			Status: v1alpha1.PromotionStepStatus{State: "Promoting"},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cmd.FormatPipelineTable(&buf, pipelines, steps))
+	out := buf.String()
+
+	// The table MUST show the new (Promoting) bundle, not the old (Verified) bundle.
+	assert.Contains(t, out, "my-app-new",
+		"table must show the active Promoting bundle, not the old Verified one")
+	assert.NotContains(t, out, "my-app-old",
+		"the old Verified bundle should not appear when a newer Promoting bundle exists")
+}

--- a/pkg/reconciler/policygate/reconciler.go
+++ b/pkg/reconciler/policygate/reconciler.go
@@ -172,6 +172,19 @@ func (r *Reconciler) buildContext(ctx context.Context, gate *kardinalv1alpha1.Po
 	// SoakMinutes is read from Bundle.status.environments[*].soakMinutes (PG-3 fix).
 	upstreamCtx := buildUpstreamContext(&bundle)
 
+	// bundle.upstreamSoakMinutes is the maximum soak minutes across all verified
+	// upstream environments. It is a convenience shorthand so expressions can write
+	//   bundle.upstreamSoakMinutes >= 30
+	// instead of requiring knowledge of the specific upstream environment name.
+	// Documented in docs/policy-gates.md §CEL context variables.
+	var maxSoakMinutes int64
+	for _, env := range bundle.Status.Environments {
+		if env.SoakMinutes > maxSoakMinutes {
+			maxSoakMinutes = env.SoakMinutes
+		}
+	}
+	bundleCtx["upstreamSoakMinutes"] = maxSoakMinutes
+
 	return map[string]interface{}{
 		"bundle": bundleCtx,
 		"schedule": map[string]interface{}{

--- a/pkg/reconciler/policygate/reconciler_test.go
+++ b/pkg/reconciler/policygate/reconciler_test.go
@@ -577,6 +577,90 @@ func makeBundleWithImage(name, ns, repo, tag string) *kardinalv1alpha1.Bundle {
 	return b
 }
 
+// TestPolicyGateReconciler_BundleUpstreamSoakMinutes_Passes verifies that
+// bundle.upstreamSoakMinutes is the max SoakMinutes across all upstream envs.
+// This is the convenience shorthand documented in docs/policy-gates.md and used
+// in examples/quickstart/policy-gates.yaml.
+func TestPolicyGateReconciler_BundleUpstreamSoakMinutes_Passes(t *testing.T) {
+	now := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
+	healthCheckedAt := metav1.NewTime(now.Add(-50 * time.Minute))
+
+	bundle := makeBundleWithEnvironments("nginx-demo-v1", "default", []kardinalv1alpha1.EnvironmentStatus{
+		{Name: "test", Phase: "Verified", HealthCheckedAt: &healthCheckedAt, SoakMinutes: 50},
+		{Name: "uat", Phase: "Verified", HealthCheckedAt: &healthCheckedAt, SoakMinutes: 45},
+	})
+	gate := makeGateInstance("soak-gate", "default", "nginx-demo-v1",
+		`bundle.upstreamSoakMinutes >= 30`, "1m")
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gate, bundle).
+		WithStatusSubresource(gate, bundle).
+		Build()
+
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return now },
+	}
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "soak-gate", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "soak-gate", Namespace: "default"}, &got))
+	assert.True(t, got.Status.Ready,
+		"gate must pass: bundle.upstreamSoakMinutes = max(50,45) = 50 >= 30")
+}
+
+// TestPolicyGateReconciler_BundleUpstreamSoakMinutes_Blocks verifies that
+// bundle.upstreamSoakMinutes blocks when all upstream envs have soak < threshold.
+func TestPolicyGateReconciler_BundleUpstreamSoakMinutes_Blocks(t *testing.T) {
+	now := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
+	healthCheckedAt := metav1.NewTime(now.Add(-10 * time.Minute))
+
+	bundle := makeBundleWithEnvironments("nginx-demo-v1", "default", []kardinalv1alpha1.EnvironmentStatus{
+		{Name: "test", Phase: "Verified", HealthCheckedAt: &healthCheckedAt, SoakMinutes: 5},
+		{Name: "uat", Phase: "Verified", HealthCheckedAt: &healthCheckedAt, SoakMinutes: 10},
+	})
+	gate := makeGateInstance("soak-gate", "default", "nginx-demo-v1",
+		`bundle.upstreamSoakMinutes >= 30`, "1m")
+
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+	eval := celpkg.NewEvaluator(env)
+
+	s := newScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(gate, bundle).
+		WithStatusSubresource(gate, bundle).
+		Build()
+
+	r := &policygate.Reconciler{
+		Client:    c,
+		Evaluator: eval,
+		NowFn:     func() time.Time { return now },
+	}
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "soak-gate", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "soak-gate", Namespace: "default"}, &got))
+	assert.False(t, got.Status.Ready,
+		"gate must block: bundle.upstreamSoakMinutes = max(5,10) = 10 < 30")
+}
+
 // TestPolicyGateReconciler_StatusReasonContainsVersion verifies that when a bundle
 // has an image tag, the evaluated status.reason includes the bundle version.
 // This makes the routing info (bundle version used for evaluation) CRD-observable


### PR DESCRIPTION
## Summary

Batch fix for 3 product gaps found in PDCA Cycle 5 validation on live kind cluster.

### Fix 1 — #253: PAUSED badge in `kardinal get pipelines`

`FormatPipelineTable` now appends `[PAUSED]` to the pipeline name when `spec.paused=true`.

**Before**: `nginx-demo   v1.29.0   Verified   ...`
**After**: `nginx-demo [PAUSED]   v1.29.0   Verified   ...`

### Fix 2 — #254: Active bundle shown instead of old verified bundle

When multiple bundles have PromotionSteps (e.g., after rapid successive deploys),
`FormatPipelineTable` previously showed the first Verified bundle it encountered —
usually an old superseded one.

**Fix**: Steps are now ranked by state priority (Promoting=4 > Pending=3 > Failed=2 > Verified=1).
Within same priority, most recently created step wins. The highest-priority bundle is shown.

**Before**: `nginx-demo   nginx-demo-old   Verified   ...`  (old bundle shown even with new one Promoting)
**After**: `nginx-demo   nginx-demo-new   Promoting   ...`  (active promoting bundle shown)

### Fix 3 — #250: `bundle.upstreamSoakMinutes` not populated in live CEL evaluation

The documentation and `examples/quickstart/policy-gates.yaml` use:
```yaml
expression: "bundle.upstreamSoakMinutes >= 30"
```

But the PolicyGate reconciler's `buildContext()` never set `bundle.upstreamSoakMinutes`.
Live evaluation showed: `CEL evaluation error: no such key: upstreamSoakMinutes`.

**Fix**: `buildContext()` computes `max(SoakMinutes)` across all `bundle.status.environments`
and sets `bundleCtx["upstreamSoakMinutes"]`. The upstream map `upstream["uat"].soakMinutes`
also continues to work.

## Tests

- `TestFormatPipelineTable_PausedBadge` — PAUSED badge appears when paused=true
- `TestFormatPipelineTable_NonPausedNoBadge` — no badge when paused=false
- `TestFormatPipelineTable_ActiveBundlePrefersPromoting` — Promoting bundle takes priority over old Verified
- `TestPolicyGateReconciler_BundleUpstreamSoakMinutes_Passes` — max(50,45)=50 >= 30 → PASS
- `TestPolicyGateReconciler_BundleUpstreamSoakMinutes_Blocks` — max(5,10)=10 < 30 → BLOCK

All 18 test packages pass with `-race`.

## Docs updated: behavior documented in docs/policy-gates.md was already correct (no change needed)
## Examples verified: examples/quickstart/policy-gates.yaml now works as documented