### PR TITLE
fix(pipeline): derive Pipeline.status.phase from PromotionStep states

### DIFF
--- a/pkg/reconciler/pipeline/reconciler.go
+++ b/pkg/reconciler/pipeline/reconciler.go
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 
 // Package pipeline implements the PipelineReconciler which watches Pipeline
-// objects, validates their environment configuration, and sets status conditions.
+// objects, validates their environment configuration, and sets status conditions
+// and status.phase based on active PromotionStep states.
 package pipeline
 
 import (
@@ -14,17 +15,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 )
 
-// Reconciler watches Pipeline objects, validates them, and sets status.conditions.
+// Reconciler watches Pipeline objects, validates them, and sets status.conditions
+// and status.phase.
 type Reconciler struct {
 	client.Client
 }
 
-// Reconcile is called whenever a Pipeline is created, updated, or deleted.
-// It validates environment configuration and sets Ready condition accordingly.
+// Reconcile is called whenever a Pipeline or a PromotionStep in its namespace changes.
+// It validates environment configuration, derives status.phase from active PromotionSteps,
+// and sets the Ready condition.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := zerolog.Ctx(ctx).With().
 		Str("pipeline", req.Name).
@@ -40,21 +44,41 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, fmt.Errorf("get pipeline: %w", err)
 	}
 
-	// Determine the desired condition
+	// Determine the desired condition from pipeline spec validation.
 	desiredReason, desiredMsg := r.validate(&p)
 
-	// Idempotency: if condition already matches desired state, skip patching
-	if conditionMatches(p.Status.Conditions, desiredReason) {
-		log.Debug().Str("reason", desiredReason).Msg("pipeline condition already correct, skipping")
+	// Derive status.phase from active PromotionStep states.
+	// List all PromotionSteps in the pipeline's namespace that belong to this pipeline.
+	// This is a Watch-node pattern: we read PromotionStep CRD status (written by the
+	// PromotionStep reconciler) and write only our own CRD status (Pipeline.status.phase).
+	var stepList kardinalv1alpha1.PromotionStepList
+	if err := r.List(ctx, &stepList,
+		client.InNamespace(p.Namespace),
+		client.MatchingFields{"spec.pipelineName": p.Name},
+	); err != nil {
+		// Non-fatal: if list fails, use Unknown phase.
+		log.Warn().Err(err).Msg("failed to list PromotionSteps for phase derivation, using Unknown")
+	}
+
+	desiredPhase := DerivePhase(stepList.Items)
+
+	// Idempotency: only patch if something changed.
+	condMatch := conditionMatches(p.Status.Conditions, desiredReason)
+	phaseMatch := p.Status.Phase == desiredPhase
+	if condMatch && phaseMatch {
+		log.Debug().
+			Str("reason", desiredReason).
+			Str("phase", desiredPhase).
+			Msg("pipeline status already correct, skipping")
 		return ctrl.Result{}, nil
 	}
 
-	status := metav1.ConditionFalse
 	patch := client.MergeFrom(p.DeepCopy())
+	p.Status.Phase = desiredPhase
 	p.Status.Conditions = []metav1.Condition{
 		{
 			Type:               "Ready",
-			Status:             status,
+			Status:             metav1.ConditionFalse,
 			Reason:             desiredReason,
 			Message:            desiredMsg,
 			LastTransitionTime: metav1.Now(),
@@ -67,10 +91,57 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	log.Info().
 		Str("reason", desiredReason).
+		Str("phase", desiredPhase).
 		Int("environments", len(p.Spec.Environments)).
 		Msg("pipeline status updated")
 
 	return ctrl.Result{}, nil
+}
+
+// DerivePhase computes the Pipeline.status.phase from the given PromotionStep list:
+//   - "Unknown"  — no PromotionSteps exist yet (pipeline initializing or no bundles)
+//   - "Degraded" — at least one PromotionStep is in Failed state
+//   - "Ready"    — all PromotionSteps are in Verified state (at least one step)
+//
+// Phase derivation is based on the MOST RECENT step per environment: if multiple
+// bundles have steps for the same env, only the newest one is used.
+func DerivePhase(steps []kardinalv1alpha1.PromotionStep) string {
+	if len(steps) == 0 {
+		return "Unknown"
+	}
+
+	// Track the most recent step per pipeline+env (same logic as FormatPipelineTable).
+	type envKey struct{ pipeline, env string }
+	bestStep := make(map[envKey]*kardinalv1alpha1.PromotionStep)
+	for i := range steps {
+		s := &steps[i]
+		key := envKey{s.Spec.PipelineName, s.Spec.Environment}
+		existing, ok := bestStep[key]
+		if !ok || s.CreationTimestamp.After(existing.CreationTimestamp.Time) {
+			bestStep[key] = s
+		}
+	}
+
+	hasFailed := false
+	allVerified := true
+	for _, s := range bestStep {
+		state := s.Status.State
+		if state == "Failed" {
+			hasFailed = true
+		}
+		if state != "Verified" {
+			allVerified = false
+		}
+	}
+
+	switch {
+	case hasFailed:
+		return "Degraded"
+	case allVerified:
+		return "Ready"
+	default:
+		return "Unknown"
+	}
 }
 
 // validate checks pipeline invariants and returns (reason, message).
@@ -111,8 +182,42 @@ func conditionMatches(conditions []metav1.Condition, reason string) bool {
 }
 
 // SetupWithManager registers the PipelineReconciler with the controller-runtime Manager.
+// It watches Pipeline objects AND PromotionSteps (to update pipeline phase when step
+// states change). The PromotionStep watch maps each step to its pipeline via
+// spec.pipelineName, triggering a reconcile of the pipeline.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Index PromotionSteps by spec.pipelineName for efficient lookup in Reconcile.
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&kardinalv1alpha1.PromotionStep{},
+		"spec.pipelineName",
+		func(obj client.Object) []string {
+			s, ok := obj.(*kardinalv1alpha1.PromotionStep)
+			if !ok || s.Spec.PipelineName == "" {
+				return nil
+			}
+			return []string{s.Spec.PipelineName}
+		},
+	); err != nil {
+		return fmt.Errorf("index PromotionStep by spec.pipelineName: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kardinalv1alpha1.Pipeline{}).
+		// Enqueue the pipeline named by spec.pipelineName whenever a PromotionStep changes.
+		Watches(&kardinalv1alpha1.PromotionStep{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+				s, ok := obj.(*kardinalv1alpha1.PromotionStep)
+				if !ok || s.Spec.PipelineName == "" {
+					return nil
+				}
+				return []ctrl.Request{{
+					NamespacedName: client.ObjectKey{
+						Name:      s.Spec.PipelineName,
+						Namespace: s.Namespace,
+					},
+				}}
+			}),
+		).
 		Complete(r)
 }

--- a/pkg/reconciler/pipeline/reconciler_test.go
+++ b/pkg/reconciler/pipeline/reconciler_test.go
@@ -201,3 +201,86 @@ func TestPipelineReconciler_NotFound(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
 }
+
+// TestDerivePhase_NoSteps verifies that an empty step list yields Unknown.
+func TestDerivePhase_NoSteps(t *testing.T) {
+	assert.Equal(t, "Unknown", pipeline.DerivePhase(nil))
+	assert.Equal(t, "Unknown", pipeline.DerivePhase([]kardinalv1alpha1.PromotionStep{}))
+}
+
+// TestDerivePhase_AllVerified verifies that all-Verified steps yield Ready.
+func TestDerivePhase_AllVerified(t *testing.T) {
+	now := metav1.Now()
+	steps := []kardinalv1alpha1.PromotionStep{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "s-test", Namespace: "default", CreationTimestamp: now},
+			Spec:       kardinalv1alpha1.PromotionStepSpec{PipelineName: "app", Environment: "test"},
+			Status:     kardinalv1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "s-prod", Namespace: "default", CreationTimestamp: now},
+			Spec:       kardinalv1alpha1.PromotionStepSpec{PipelineName: "app", Environment: "prod"},
+			Status:     kardinalv1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+	}
+	assert.Equal(t, "Ready", pipeline.DerivePhase(steps))
+}
+
+// TestDerivePhase_OneFailed verifies that a Failed step yields Degraded.
+func TestDerivePhase_OneFailed(t *testing.T) {
+	now := metav1.Now()
+	steps := []kardinalv1alpha1.PromotionStep{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "s-test", Namespace: "default", CreationTimestamp: now},
+			Spec:       kardinalv1alpha1.PromotionStepSpec{PipelineName: "app", Environment: "test"},
+			Status:     kardinalv1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "s-prod", Namespace: "default", CreationTimestamp: now},
+			Spec:       kardinalv1alpha1.PromotionStepSpec{PipelineName: "app", Environment: "prod"},
+			Status:     kardinalv1alpha1.PromotionStepStatus{State: "Failed"},
+		},
+	}
+	assert.Equal(t, "Degraded", pipeline.DerivePhase(steps))
+}
+
+// TestDerivePhase_Promoting verifies that Promoting steps yield Unknown (not yet done).
+func TestDerivePhase_Promoting(t *testing.T) {
+	now := metav1.Now()
+	steps := []kardinalv1alpha1.PromotionStep{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "s-test", Namespace: "default", CreationTimestamp: now},
+			Spec:       kardinalv1alpha1.PromotionStepSpec{PipelineName: "app", Environment: "test"},
+			Status:     kardinalv1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "s-prod", Namespace: "default", CreationTimestamp: now},
+			Spec:       kardinalv1alpha1.PromotionStepSpec{PipelineName: "app", Environment: "prod"},
+			Status:     kardinalv1alpha1.PromotionStepStatus{State: "Promoting"},
+		},
+	}
+	assert.Equal(t, "Unknown", pipeline.DerivePhase(steps))
+}
+
+// TestDerivePhase_MultiBundle_NewFailed_OldVerified verifies that when a new bundle
+// has a Failed step, Degraded is shown (not Ready from the old Verified step).
+func TestDerivePhase_MultiBundle_NewFailed_OldVerified(t *testing.T) {
+	old := metav1.NewTime(metav1.Now().Add(-1 * 3600 * 1e9)) // 1 hour ago
+	now := metav1.Now()
+	steps := []kardinalv1alpha1.PromotionStep{
+		// Old bundle — Verified in prod
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "old-prod", Namespace: "default", CreationTimestamp: old},
+			Spec:       kardinalv1alpha1.PromotionStepSpec{PipelineName: "app", Environment: "prod"},
+			Status:     kardinalv1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+		// New bundle — Failed in prod
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "new-prod", Namespace: "default", CreationTimestamp: now},
+			Spec:       kardinalv1alpha1.PromotionStepSpec{PipelineName: "app", Environment: "prod"},
+			Status:     kardinalv1alpha1.PromotionStepStatus{State: "Failed"},
+		},
+	}
+	// Most recent step per env wins: new-prod is Failed → Degraded
+	assert.Equal(t, "Degraded", pipeline.DerivePhase(steps))
+}


### PR DESCRIPTION
## Summary

Fixes #247 — Pipeline.status.phase always showing Unknown after successful bundle promotions.

### Root Cause

The PipelineReconciler only watched Pipeline objects and only set a condition
(Ready=False/Initializing) — it never updated `status.phase`.

### Fix

1. **DerivePhase**: New exported function that computes phase from PromotionSteps:
   - `Ready` — all per-env most-recent steps are Verified
   - `Degraded` — any per-env most-recent step is Failed
   - `Unknown` — no steps exist (no bundles yet)

2. **PromotionStep watch**: SetupWithManager now adds a `Watches` on PromotionStep
   objects that maps each step to its pipeline via `spec.pipelineName`. A field
   index is registered to enable efficient listing.

3. **Idempotent**: Only patches status when both condition reason AND phase differ.

### Graph-First Compliance

- Reads: `PromotionStep.status.state` (written by PromotionStep reconciler — a different CRD's reconciler)
- Writes: `Pipeline.status.phase` (our own CRD status)
- No cross-CRD status mutation. No time.Now() outside CRD write. No external HTTP.

### Tests

- `TestDerivePhase_NoSteps` → Unknown
- `TestDerivePhase_AllVerified` → Ready
- `TestDerivePhase_OneFailed` → Degraded
- `TestDerivePhase_Promoting` → Unknown (in-progress)
- `TestDerivePhase_MultiBundle_NewFailed_OldVerified` → Degraded (new bundle wins)

All 18 test packages pass with -race.

## Docs updated: behavior is now consistent with CRD schema comment
## Examples verified: existing Journey 1 test continues to pass
