### PR TITLE
fix(promotionstep): self-delete orphaned steps when parent Bundle is gone

### DIFF
--- a/pkg/reconciler/promotionstep/reconciler.go
+++ b/pkg/reconciler/promotionstep/reconciler.go
@@ -134,6 +134,31 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	// Orphan guard: if the parent Bundle no longer exists, self-delete this
+	// PromotionStep to stop the infinite reconcile error loop (#248).
+	// This handles the case where a Bundle was deleted manually (e.g. during
+	// development or testing) while its PromotionSteps are still present.
+	// Graph-first: we delete our OWN resource (PromotionStep), not anyone else's.
+	if ps.Spec.BundleName != "" {
+		var parentBundle v1alpha1.Bundle
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      ps.Spec.BundleName,
+			Namespace: ps.Namespace,
+		}, &parentBundle); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info().
+					Str("bundle", ps.Spec.BundleName).
+					Msg("parent bundle not found — self-deleting orphaned PromotionStep")
+				if delErr := r.Delete(ctx, &ps); delErr != nil && !apierrors.IsNotFound(delErr) {
+					return ctrl.Result{}, fmt.Errorf("delete orphaned promotionstep: %w", delErr)
+				}
+				return ctrl.Result{}, nil
+			}
+			// Transient error — requeue to retry later.
+			return ctrl.Result{}, fmt.Errorf("check parent bundle %s: %w", ps.Spec.BundleName, err)
+		}
+	}
+
 	switch ps.Status.State {
 	case StatePending, StatePendingExplicit:
 		return r.handlePending(ctx, log, &ps)

--- a/pkg/reconciler/promotionstep/reconciler_test.go
+++ b/pkg/reconciler/promotionstep/reconciler_test.go
@@ -748,3 +748,92 @@ func TestShardIsolation_TwoShards(t *testing.T) {
 	assert.Equal(t, "Promoting", us.Status.State,
 		"US step must be in Promoting after US reconciler ran")
 }
+
+// TestOrphanGuard_SelfDeletesWhenBundleGone verifies that when the parent Bundle
+// no longer exists (e.g. deleted manually), the PromotionStep self-deletes
+// instead of entering an infinite error loop (#248).
+func TestOrphanGuard_SelfDeletesWhenBundleGone(t *testing.T) {
+	s := buildScheme(t)
+
+	// Create a PromotionStep with spec.bundleName pointing to a non-existent bundle.
+	step := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "orphaned-step",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.PromotionStepSpec{
+			PipelineName: "my-pipeline",
+			BundleName:   "deleted-bundle",
+			Environment:  "test",
+		},
+	}
+	pipeline := makePipeline("my-pipeline")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(step, pipeline).
+		WithStatusSubresource(step).
+		Build()
+
+	r := promotionstep.Reconciler{
+		Client:    c,
+		SCM:       &mockSCM{},
+		GitClient: &mockGit{},
+		WorkDirFn: func(_, _ string) string { return t.TempDir() },
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "orphaned-step", Namespace: "default"},
+	})
+	require.NoError(t, err, "orphan guard must not return an error")
+
+	// The PromotionStep must be deleted.
+	var got v1alpha1.PromotionStep
+	err = c.Get(context.Background(), types.NamespacedName{Name: "orphaned-step", Namespace: "default"}, &got)
+	require.Error(t, err, "orphaned PromotionStep must be self-deleted")
+	// controller-runtime fake returns a NotFound-like error for deleted objects.
+	_ = got
+}
+
+// TestOrphanGuard_NoDeleteWhenBundleExists verifies that when the parent Bundle
+// exists the reconciler proceeds normally (no self-deletion).
+func TestOrphanGuard_NoDeleteWhenBundleExists(t *testing.T) {
+	s := buildScheme(t)
+
+	bundle := makeBundle("existing-bundle", "my-pipeline")
+	step := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "normal-step",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.PromotionStepSpec{
+			PipelineName: "my-pipeline",
+			BundleName:   "existing-bundle",
+			Environment:  "test",
+		},
+	}
+	pipeline := makePipeline("my-pipeline")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(step, bundle, pipeline).
+		WithStatusSubresource(step).
+		Build()
+
+	r := promotionstep.Reconciler{
+		Client:    c,
+		SCM:       &mockSCM{},
+		GitClient: &mockGit{},
+		WorkDirFn: func(_, _ string) string { return t.TempDir() },
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "normal-step", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	// The PromotionStep must still exist and have been processed (state = Promoting).
+	var got v1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "normal-step", Namespace: "default"}, &got))
+	assert.Equal(t, "Promoting", got.Status.State, "step must advance to Promoting when bundle exists")
+}


### PR DESCRIPTION
## Summary

Fixes #248 — PromotionStep reconciler loops with errors when parent Bundle is deleted.

### Root Cause

When a Bundle was deleted (e.g. during development/testing), its PromotionSteps remained.
The reconciler tried to load the Bundle each reconcile cycle and logged errors at ERROR level
every ~30 seconds in an infinite loop.

### Fix

Orphan guard in `Reconcile()`: after fetching the PromotionStep, check if `spec.bundleName`
exists. If the Bundle returns `NotFound`, self-delete the PromotionStep and return `nil`.

```
// Before (infinite error loop):
load bundle nginx-demo-kind-test: Bundle not found
load bundle nginx-demo-kind-test: Bundle not found
...

// After:
orphaned PromotionStep nginx-demo-nginx-demo-kind-test-test: self-deleting
```

Transient errors (network timeouts etc.) still requeue as before.

### Graph-First Compliance

The reconciler deletes only its OWN resource (PromotionStep). It does NOT delete the Bundle
or any other CRD. No logic leaks.

### Tests

- `TestOrphanGuard_SelfDeletesWhenBundleGone` — step is deleted when bundle not found
- `TestOrphanGuard_NoDeleteWhenBundleExists` — normal flow unchanged when bundle exists

## Docs updated: no user-facing change
## Examples verified: all existing tests pass
