### PR TITLE
fix(graph): propagate PolicyGate scope/applies-to labels to instantiated nodes

### DIFF
--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -538,6 +538,15 @@ func buildPolicyGateNode(
 	pipelineName, bundleName, envName string,
 	upstreams []string,
 ) GraphNode {
+	// Propagate scope and applies-to from the gate template so that
+	// `kardinal policy list` can show the correct scope (org/team) and
+	// applies-to value on the instantiated PolicyGate CRs (#249).
+	scopeLabel := gate.Labels["kardinal.io/scope"]
+	if scopeLabel == "" {
+		scopeLabel = "team"
+	}
+	appliesToLabel := gate.Labels["kardinal.io/applies-to"]
+
 	templateMeta := map[string]interface{}{
 		"name": k8sName, // K8s resource name (RFC 1123 subdomain — hyphens allowed, no underscores)
 		"labels": map[string]interface{}{
@@ -547,6 +556,9 @@ func buildPolicyGateNode(
 			"kardinal.io/bundle":        bundleName,
 			"kardinal.io/environment":   envName,
 			"kardinal.io/gate-template": gate.Name,
+			// Propagated from original PolicyGate template for CLI display.
+			"kardinal.io/scope":      scopeLabel,
+			"kardinal.io/applies-to": appliesToLabel,
 		},
 	}
 

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -538,3 +538,108 @@ func findUpstreamRef(t *testing.T, n graph.GraphNode) string {
 	uv, _ := spec["upstreamVerified"].(string)
 	return uv
 }
+
+// TestBuilder_PolicyGateScopeLabelsPropagate verifies that the scope and applies-to
+// labels from the original PolicyGate template are copied to the instantiated node's
+// metadata.labels. This is needed so `kardinal policy list` can display correct scope.
+func TestBuilder_PolicyGateScopeLabelsPropagate(t *testing.T) {
+	b := graph.NewBuilder()
+	pipeline := makeLinearPipeline("my-app", "test", "prod")
+	bundle := makeBundle("my-app-v1", "my-app")
+
+	// Org-scoped gate with applies-to=prod.
+	orgGate := kardinalv1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-weekend-deploys",
+			Namespace: "platform-policies",
+			Labels: map[string]string{
+				"kardinal.io/applies-to": "prod",
+				"kardinal.io/scope":      "org",
+			},
+		},
+		Spec: kardinalv1alpha1.PolicyGateSpec{
+			Expression:      "!schedule.isWeekend",
+			Message:         "blocked on weekends",
+			RecheckInterval: "5m",
+		},
+	}
+
+	result, err := b.Build(graph.BuildInput{
+		Pipeline:    pipeline,
+		Bundle:      bundle,
+		PolicyGates: []kardinalv1alpha1.PolicyGate{orgGate},
+	})
+	require.NoError(t, err)
+
+	// Find the instantiated PolicyGate node.
+	var gateNode *graph.GraphNode
+	for i := range result.Graph.Spec.Nodes {
+		n := result.Graph.Spec.Nodes[i]
+		if containsStr(n.ID, "no_weekend_deploys") {
+			gateNode = &n
+			break
+		}
+	}
+	require.NotNil(t, gateNode, "PolicyGate node must exist")
+
+	// Extract labels from template.metadata.labels.
+	meta, ok := gateNode.Template["metadata"].(map[string]interface{})
+	require.True(t, ok, "template must have metadata")
+	labels, ok := meta["labels"].(map[string]interface{})
+	require.True(t, ok, "metadata must have labels")
+
+	assert.Equal(t, "org", labels["kardinal.io/scope"],
+		"scope label must be propagated from the original gate template")
+	assert.Equal(t, "prod", labels["kardinal.io/applies-to"],
+		"applies-to label must be propagated from the original gate template")
+}
+
+// TestBuilder_PolicyGateScopeDefault verifies that a gate without scope label
+// gets the default 'team' scope propagated.
+func TestBuilder_PolicyGateScopeDefault(t *testing.T) {
+	b := graph.NewBuilder()
+	pipeline := makeLinearPipeline("my-app", "prod")
+	bundle := makeBundle("my-app-v1", "my-app")
+
+	// Team gate with no scope label.
+	teamGate := kardinalv1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-gate",
+			Namespace: "my-team",
+			Labels: map[string]string{
+				"kardinal.io/applies-to": "prod",
+				// no kardinal.io/scope label
+			},
+		},
+		Spec: kardinalv1alpha1.PolicyGateSpec{
+			Expression:      "true",
+			Message:         "always pass",
+			RecheckInterval: "5m",
+		},
+	}
+
+	result, err := b.Build(graph.BuildInput{
+		Pipeline:    pipeline,
+		Bundle:      bundle,
+		PolicyGates: []kardinalv1alpha1.PolicyGate{teamGate},
+	})
+	require.NoError(t, err)
+
+	var gateNode *graph.GraphNode
+	for i := range result.Graph.Spec.Nodes {
+		n := result.Graph.Spec.Nodes[i]
+		if containsStr(n.ID, "team_gate") {
+			gateNode = &n
+			break
+		}
+	}
+	require.NotNil(t, gateNode, "PolicyGate node must exist")
+
+	meta, ok := gateNode.Template["metadata"].(map[string]interface{})
+	require.True(t, ok)
+	labels, ok := meta["labels"].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "team", labels["kardinal.io/scope"],
+		"default scope must be 'team' when label is absent")
+}


### PR DESCRIPTION
## Summary

Fixes #249 — `kardinal policy list` showed `scope=team` for all gates including org-level ones.

### Root Cause

When the graph builder instantiates PolicyGate nodes from templates, it copies only
pipeline/bundle/env labels. The `kardinal.io/scope` and `kardinal.io/applies-to` labels
from the original PolicyGate template were NOT included in the instantiated node's metadata.

So even though `no-weekend-deploys` in the `platform-policies` namespace has
`kardinal.io/scope: org`, the instantiated node had no scope label and defaulted to `team`.

### Fix

`buildPolicyGateNode()` now reads `scope` and `applies-to` from the original gate template
and propagates them to the node template's `metadata.labels`. Default: `team` when absent.

### Expected after fix (new bundles)

```
kardinal policy list
NAME                            NAMESPACE   SCOPE   APPLIES-TO   RECHECK   ...
no-weekend-deploys-...-prod     default     org     prod         5m        ...
```

Note: existing PolicyGate instances on the cluster need to be re-created (new bundle) 
to pick up the new labels.

### Tests

- `TestBuilder_PolicyGateScopeLabelsPropagate` — org gate propagates scope=org and applies-to=prod
- `TestBuilder_PolicyGateScopeDefault` — gate without scope gets scope=team by default

## Docs updated: behavior now matches docs/policy-gates.md
## Examples verified: all 18 test packages pass
