### PR TITLE
fix(cli): kardinal get steps shows one row per environment (most-active bundle)

### DIFF
--- a/cmd/kardinal/cmd/format.go
+++ b/cmd/kardinal/cmd/format.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -42,32 +43,30 @@ func HumanAge(t time.Time) string {
 	}
 }
 
+// stepStatePriority returns a sort priority for a PromotionStep state.
+// Higher priority = displayed first. Used by FormatPipelineTable and FormatStepsTable.
+// Active states (Promoting/WaitingForMerge/HealthChecking) take precedence over
+// terminal states (Verified/Failed) so the currently active bundle is shown.
+func stepStatePriority(state string) int {
+	switch state {
+	case "Promoting", "WaitingForMerge", "HealthChecking":
+		return 4
+	case "Pending":
+		return 3
+	case "Failed":
+		return 2
+	case "Verified":
+		return 1
+	default:
+		return 0
+	}
+}
+
 // FormatPipelineTable writes a tabwriter-formatted table of pipelines to w.
 // steps is the list of PromotionSteps in the same namespace; it is used to
 // derive per-environment status and the active bundle version for each pipeline.
 // If steps is nil or empty the environment columns will show "-".
 func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1alpha1.PromotionStep) error {
-	// stepStatePriority assigns a priority to each PromotionStep state so we can
-	// prefer the most-active step when multiple bundles have steps for the same
-	// pipeline+environment. Higher priority = displayed first.
-	// Active states (Promoting/Pending/WaitingForMerge/HealthChecking) take precedence
-	// over terminal states (Verified/Failed/Superseded).
-	stepStatePriority := func(state string) int {
-		switch state {
-		case "Promoting", "WaitingForMerge", "HealthChecking":
-			return 4
-		case "Pending":
-			return 3
-		case "Failed":
-			return 2
-		case "Verified":
-			return 1
-		default:
-			return 0
-		}
-	}
-
-	// Build a lookup: pipeline → environment → (state, bundleName, createdAt)
 	// When multiple PromotionSteps exist for the same pipeline+env (from different
 	// bundles), prefer the one with the highest state priority, then most recently
 	// created.
@@ -229,12 +228,47 @@ func FormatBundleTable(w io.Writer, bundles []v1alpha1.Bundle) error {
 }
 
 // FormatStepsTable writes a tabwriter-formatted table of promotion steps to w.
+// When multiple bundles have steps for the same environment (e.g. after rapid
+// successive deploys), only the most-active step per environment is shown using
+// the same priority logic as FormatPipelineTable: active states (Promoting,
+// WaitingForMerge, HealthChecking) take precedence over terminal states (Verified,
+// Failed). Within same priority, the most recently created step wins.
 func FormatStepsTable(w io.Writer, steps []v1alpha1.PromotionStep) error {
+	// Filter to the best step per environment (same priority as FormatPipelineTable).
+	type stepKey struct{ env string }
+	type bestEntry struct {
+		step     v1alpha1.PromotionStep
+		priority int
+	}
+	best := make(map[stepKey]bestEntry)
+	for _, s := range steps {
+		key := stepKey{env: s.Spec.Environment}
+		state := s.Status.State
+		if state == "" {
+			state = "Pending"
+		}
+		priority := stepStatePriority(state)
+		existing, ok := best[key]
+		if !ok ||
+			priority > existing.priority ||
+			(priority == existing.priority && s.CreationTimestamp.After(existing.step.CreationTimestamp.Time)) {
+			best[key] = bestEntry{step: s, priority: priority}
+		}
+	}
+
+	// Sort by environment name for stable output.
+	envOrder := make([]string, 0, len(best))
+	for k := range best {
+		envOrder = append(envOrder, k.env)
+	}
+	sort.Strings(envOrder)
+
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	if _, err := fmt.Fprintln(tw, "ENVIRONMENT\tSTEP-TYPE\tSTATE\tMESSAGE"); err != nil {
 		return fmt.Errorf("write steps table header: %w", err)
 	}
-	for _, s := range steps {
+	for _, env := range envOrder {
+		s := best[stepKey{env: env}].step
 		state := s.Status.State
 		if state == "" {
 			state = "Pending"

--- a/cmd/kardinal/cmd/format_test.go
+++ b/cmd/kardinal/cmd/format_test.go
@@ -502,3 +502,48 @@ func TestFormatPipelineTable_ActiveBundlePrefersPromoting(t *testing.T) {
 	assert.NotContains(t, out, "my-app-old",
 		"the old Verified bundle should not appear when a newer Promoting bundle exists")
 }
+
+// TestFormatStepsTable_OnePerEnvWhenMultipleBundles verifies that when multiple
+// bundles have steps for the same environment, only the most active step is shown.
+func TestFormatStepsTable_OnePerEnvWhenMultipleBundles(t *testing.T) {
+	now := time.Now()
+	old := metav1.NewTime(now.Add(-1 * time.Hour))
+	newTime := metav1.NewTime(now.Add(-30 * time.Second))
+
+	steps := []v1alpha1.PromotionStep{
+		// Old bundle — Verified in test
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "old-test", CreationTimestamp: old},
+			Spec:       v1alpha1.PromotionStepSpec{Environment: "test", StepType: "kustomize-set-image", BundleName: "old-bundle"},
+			Status:     v1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+		// New bundle — Promoting in test (higher priority)
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "new-test", CreationTimestamp: newTime},
+			Spec:       v1alpha1.PromotionStepSpec{Environment: "test", StepType: "kustomize-set-image", BundleName: "new-bundle"},
+			Status:     v1alpha1.PromotionStepStatus{State: "Promoting"},
+		},
+		// Old bundle — Verified in prod
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "old-prod", CreationTimestamp: old},
+			Spec:       v1alpha1.PromotionStepSpec{Environment: "prod", StepType: "kustomize-set-image", BundleName: "old-bundle"},
+			Status:     v1alpha1.PromotionStepStatus{State: "Verified"},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cmd.FormatStepsTable(&buf, steps))
+	out := buf.String()
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	// Header + 2 env rows (test, prod) = 3 lines. NOT 4 (no duplicate test row).
+	assert.Len(t, lines, 3, "should show one row per environment, not one per bundle step")
+
+	// The test env row must show Promoting (new bundle), not Verified (old bundle).
+	for _, line := range lines[1:] {
+		if strings.HasPrefix(strings.TrimSpace(line), "test") {
+			assert.Contains(t, line, "Promoting",
+				"test env row must show the active Promoting step, not old Verified")
+		}
+	}
+}


### PR DESCRIPTION
Fixes #261. De-duplicates get steps output — one row per environment using same priority logic as get pipelines. New test: TestFormatStepsTable_OnePerEnvWhenMultipleBundles.