### PR TITLE
fix(cli): rollback uses PromotionStep history, not Bundle.Phase

### DIFF
--- a/cmd/kardinal/cmd/cli_test.go
+++ b/cmd/kardinal/cmd/cli_test.go
@@ -61,14 +61,30 @@ func TestCreateBundle_CreatesBundle(t *testing.T) {
 }
 
 // TestRollback_CreatesBundleWithRollbackOf verifies rollback bundle creation.
+// The rollback command now queries PromotionStep history (not Bundle.Phase) to find
+// the last Verified bundle for the target environment (#264).
 func TestRollback_CreatesBundleWithRollbackOf(t *testing.T) {
 	s := cliTestScheme(t)
+	// Original bundle is Superseded (normal in production after multiple deploys).
 	verifiedBundle := &v1alpha1.Bundle{
 		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v1", Namespace: "default"},
 		Spec:       v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
-		Status:     v1alpha1.BundleStatus{Phase: "Verified"},
+		Status:     v1alpha1.BundleStatus{Phase: "Superseded"},
 	}
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(verifiedBundle).WithStatusSubresource(verifiedBundle).Build()
+	// Verified PromotionStep for prod — this is what rollback now uses.
+	prodStep := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-demo-v1-prod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kardinal.io/pipeline":    "nginx-demo",
+				"kardinal.io/environment": "prod",
+			},
+		},
+		Spec:   v1alpha1.PromotionStepSpec{PipelineName: "nginx-demo", Environment: "prod", BundleName: "nginx-demo-v1"},
+		Status: v1alpha1.PromotionStepStatus{State: "Verified"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(verifiedBundle, prodStep).WithStatusSubresource(verifiedBundle, prodStep).Build()
 
 	var buf bytes.Buffer
 	err := rollbackFn(&buf, c, "default", "nginx-demo", "prod", "", false)
@@ -426,13 +442,26 @@ func TestPolicySimulate_EnvSpecificGateExcluded(t *testing.T) {
 // copies Type from the original Verified bundle, not hardcoding "image" (CLI-5 fix).
 func TestRollback_CopiesTypeFromOriginalBundle(t *testing.T) {
 	s := cliTestScheme(t)
-	// Verified bundle with type=config; no special label needed — rollbackFn filters by Spec.Pipeline.
+	// Bundle is Superseded (realistic production state).
 	verifiedBundle := &v1alpha1.Bundle{
 		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-cfg-v1", Namespace: "default"},
 		Spec:       v1alpha1.BundleSpec{Type: "config", Pipeline: "nginx-demo"},
-		Status:     v1alpha1.BundleStatus{Phase: "Verified"},
+		Status:     v1alpha1.BundleStatus{Phase: "Superseded"},
 	}
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(verifiedBundle).WithStatusSubresource(verifiedBundle).Build()
+	// Verified PromotionStep points to this bundle.
+	prodStep := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-demo-cfg-v1-prod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kardinal.io/pipeline":    "nginx-demo",
+				"kardinal.io/environment": "prod",
+			},
+		},
+		Spec:   v1alpha1.PromotionStepSpec{PipelineName: "nginx-demo", Environment: "prod", BundleName: "nginx-demo-cfg-v1"},
+		Status: v1alpha1.PromotionStepStatus{State: "Verified"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(verifiedBundle, prodStep).WithStatusSubresource(verifiedBundle, prodStep).Build()
 
 	var buf bytes.Buffer
 	err := rollbackFn(&buf, c, "default", "nginx-demo", "prod", "", false)
@@ -477,6 +506,58 @@ func TestRollback_CopiesTypeWhenExplicitToBundle(t *testing.T) {
 	}
 	require.NotNil(t, rb)
 	assert.Equal(t, "mixed", rb.Spec.Type, "rollback bundle must copy type from target bundle")
+}
+
+// TestRollback_WorksWhenAllBundlesSuperseded verifies that rollback succeeds even when
+// all Bundle objects have Phase=Superseded — the realistic production state (#264).
+func TestRollback_WorksWhenAllBundlesSuperseded(t *testing.T) {
+	s := cliTestScheme(t)
+	// All bundles are Superseded (as in production after multiple deploys).
+	oldBundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-old", Namespace: "default"},
+		Spec:       v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status:     v1alpha1.BundleStatus{Phase: "Superseded"},
+	}
+	newBundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-new", Namespace: "default"},
+		Spec:       v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status:     v1alpha1.BundleStatus{Phase: "Superseded"},
+	}
+	// Old bundle has a Verified prod step; new bundle is still Promoting.
+	oldProdStep := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nginx-demo-old-prod",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Now(),
+			Labels: map[string]string{
+				"kardinal.io/pipeline":    "nginx-demo",
+				"kardinal.io/environment": "prod",
+			},
+		},
+		Spec:   v1alpha1.PromotionStepSpec{PipelineName: "nginx-demo", Environment: "prod", BundleName: "nginx-demo-old"},
+		Status: v1alpha1.PromotionStepStatus{State: "Verified"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(oldBundle, newBundle, oldProdStep).
+		WithStatusSubresource(oldBundle, newBundle, oldProdStep).
+		Build()
+
+	var buf bytes.Buffer
+	err := rollbackFn(&buf, c, "default", "nginx-demo", "prod", "", false)
+	require.NoError(t, err, "rollback must succeed even when all bundles are Superseded")
+
+	var bundles v1alpha1.BundleList
+	require.NoError(t, c.List(context.Background(), &bundles))
+
+	var rb *v1alpha1.Bundle
+	for i := range bundles.Items {
+		if bundles.Items[i].Labels["kardinal.io/rollback"] == "true" {
+			rb = &bundles.Items[i]
+		}
+	}
+	require.NotNil(t, rb, "rollback bundle must be created")
+	assert.Equal(t, "nginx-demo-old", rb.Spec.Provenance.RollbackOf,
+		"rollback must target the bundle with the most recent Verified prod PromotionStep")
 }
 
 // TestSplitImageRef verifies image reference parsing.

--- a/cmd/kardinal/cmd/rollback.go
+++ b/cmd/kardinal/cmd/rollback.go
@@ -94,11 +94,11 @@ func rollbackFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client,
 			}
 		}
 		if latestStep == nil {
-			return fmt.Errorf("no Verified PromotionStep found for pipeline %s env %s", pipeline, envFilter)
+			return fmt.Errorf("no verified PromotionStep found for pipeline %s env %s", pipeline, envFilter)
 		}
 		rollbackOf = latestStep.Spec.BundleName
 		if rollbackOf == "" {
-			return fmt.Errorf("Verified PromotionStep for %s/%s has no bundleName", pipeline, envFilter)
+			return fmt.Errorf("verified PromotionStep for %s/%s has no bundleName", pipeline, envFilter)
 		}
 	}
 

--- a/cmd/kardinal/cmd/rollback.go
+++ b/cmd/kardinal/cmd/rollback.go
@@ -65,28 +65,41 @@ func rollbackFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client,
 
 	rollbackOf := toBundle
 	if rollbackOf == "" {
-		// List all bundles in the namespace and filter by Spec.Pipeline.
-		// A label selector is not used here because bundles created by the CLI
-		// may not carry the kardinal.io/pipeline label; Spec.Pipeline is authoritative.
-		var bundles v1alpha1.BundleList
-		if listErr := c.List(ctx, &bundles, sigs_client.InNamespace(ns)); listErr != nil {
-			return fmt.Errorf("list bundles: %w", listErr)
+		// Find the bundle to roll back to by querying PromotionStep history.
+		// We look for the most recently created PromotionStep that is Verified in the
+		// target environment for this pipeline. This is correct even when all Bundle
+		// objects have Phase=Superseded (which is the normal state after multiple deploys).
+		//
+		// Using PromotionStep instead of Bundle.Phase ensures rollback works in
+		// real-world production scenarios where bundles are always Superseded (#264).
+		var steps v1alpha1.PromotionStepList
+		if listErr := c.List(ctx, &steps,
+			sigs_client.InNamespace(ns),
+			sigs_client.MatchingLabels{
+				"kardinal.io/pipeline":    pipeline,
+				"kardinal.io/environment": envFilter,
+			},
+		); listErr != nil {
+			return fmt.Errorf("list promotion steps: %w", listErr)
 		}
 
-		var latest *v1alpha1.Bundle
-		for i := range bundles.Items {
-			b := &bundles.Items[i]
-			if b.Spec.Pipeline != pipeline || b.Status.Phase != "Verified" {
+		var latestStep *v1alpha1.PromotionStep
+		for i := range steps.Items {
+			s := &steps.Items[i]
+			if s.Status.State != "Verified" {
 				continue
 			}
-			if latest == nil || b.CreationTimestamp.After(latest.CreationTimestamp.Time) {
-				latest = b
+			if latestStep == nil || s.CreationTimestamp.After(latestStep.CreationTimestamp.Time) {
+				latestStep = s
 			}
 		}
-		if latest == nil {
-			return fmt.Errorf("no Verified bundles found for pipeline %s", pipeline)
+		if latestStep == nil {
+			return fmt.Errorf("no Verified PromotionStep found for pipeline %s env %s", pipeline, envFilter)
 		}
-		rollbackOf = latest.Name
+		rollbackOf = latestStep.Spec.BundleName
+		if rollbackOf == "" {
+			return fmt.Errorf("Verified PromotionStep for %s/%s has no bundleName", pipeline, envFilter)
+		}
 	}
 
 	// Copy the bundle type from the target bundle so the rollback is type-compatible.


### PR DESCRIPTION
## Summary

Fixes #264 — `kardinal rollback` fails with 'no Verified bundles found' because in production all Bundle objects have `Phase=Superseded`.

### Root cause

When a new bundle is created, all previous bundles transition to `Superseded`. The rollback command was filtering for `Bundle.Status.Phase == "Verified"` — which is only true for a brief window before the next bundle is created.

In real production, there are **never** any Verified-phase bundles to roll back to.

### Fix

Query PromotionSteps with matching `kardinal.io/pipeline` and `kardinal.io/environment` labels, filter to `status.state == "Verified"`, and pick the most recently created one. The bundle name comes from `spec.bundleName`.

### Before
```
kardinal rollback nginx-demo --env prod
no Verified bundles found for pipeline nginx-demo
```

### After
```
kardinal rollback nginx-demo --env prod
Rolling back nginx-demo in prod
Bundle nginx-demo-rollback-xxxxx created (rollbackOf=nginx-demo-czmqv)
Track with: kardinal explain nginx-demo --env prod
```

### Tests

- Updated `TestRollback_CreatesBundleWithRollbackOf` — bundle is now Superseded, PromotionStep is Verified
- Updated `TestRollback_CopiesTypeFromOriginalBundle` — same
- New `TestRollback_WorksWhenAllBundlesSuperseded` — explicitly verifies the fix scenario

All 18 packages pass with -race.

## Docs updated: behavior now matches definition-of-done.md Journey 4 requirements
