### PR TITLE
fix(cli): policy simulate registers kro CEL library functions

### DIFF
--- a/cmd/kardinal/cmd/cli_test.go
+++ b/cmd/kardinal/cmd/cli_test.go
@@ -438,6 +438,32 @@ func TestPolicySimulate_EnvSpecificGateExcluded(t *testing.T) {
 	assert.Contains(t, out, "PASS", "no applicable gates means PASS")
 }
 
+// TestPolicySimulate_KroCELFunctionsAvailable verifies that kro CEL library functions
+// (json.*, maps.*, lists.*) are available in policy simulate (#243).
+func TestPolicySimulate_KroCELFunctionsAvailable(t *testing.T) {
+	s := cliTestScheme(t)
+	jsonGate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "json-gate",
+			Namespace: "default",
+			Labels:    map[string]string{"kardinal.io/applies-to": "prod"},
+		},
+		Spec: v1alpha1.PolicyGateSpec{
+			Expression: `json.unmarshal("{\"ready\": true}").ready == true`,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(jsonGate).Build()
+
+	var buf bytes.Buffer
+	err := policySimulateFn(&buf, c, "default", "nginx-demo", "prod", "Tuesday 10am", 0)
+	require.NoError(t, err, "policy simulate with json.unmarshal must not error")
+
+	out := buf.String()
+	assert.Contains(t, out, "PASS", "json.unmarshal expression evaluating true must PASS")
+	assert.NotContains(t, out, "compile error",
+		"kro library functions must be registered; no compile error expected")
+}
+
 // TestRollback_CopiesTypeFromOriginalBundle verifies that the rollback bundle
 // copies Type from the original Verified bundle, not hardcoding "image" (CLI-5 fix).
 func TestRollback_CopiesTypeFromOriginalBundle(t *testing.T) {

--- a/cmd/kardinal/cmd/policy.go
+++ b/cmd/kardinal/cmd/policy.go
@@ -30,6 +30,7 @@ import (
 	sigsyaml "sigs.k8s.io/yaml"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/cel/library"
 )
 
 func newPolicyCmd() *cobra.Command {
@@ -387,9 +388,11 @@ func trimSpace(s string) string {
 }
 
 // newSimulateCELEnvironment creates a CEL environment for policy simulation in the CLI.
-// This is intentionally a separate function from pkg/cel.NewCELEnvironment() to avoid
-// the banned import of pkg/cel outside pkg/reconciler/policygate.
-// The variables registered here must match pkg/cel/environment.go exactly.
+// It registers the same variables and library extensions as pkg/cel.NewCELEnvironment()
+// so that complex expressions using json.*, maps.*, lists.*, random.* work correctly.
+//
+// The import of pkg/cel/library is allowed (see AGENTS.md — only pkg/cel itself is banned
+// outside pkg/reconciler/policygate). pkg/cel/library has no dependency on pkg/cel.
 func newSimulateCELEnvironment() (*cel.Env, error) {
 	env, err := cel.NewEnv(
 		cel.Variable("bundle", cel.DynType),
@@ -398,6 +401,12 @@ func newSimulateCELEnvironment() (*cel.Env, error) {
 		cel.Variable("metrics", cel.DynType),
 		cel.Variable("upstream", cel.DynType),
 		cel.Variable("previousBundle", cel.DynType),
+		// kro CEL library extensions — same set as pkg/cel.NewCELEnvironment().
+		// Ensures expressions like json.unmarshal(...), maps.merge(...), etc. work in simulate.
+		library.JSON(),
+		library.Maps(),
+		library.Lists(),
+		library.Random(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cel.NewEnv: %w", err)


### PR DESCRIPTION
## Summary

Fixes #243 — policy simulate created a raw `cel.NewEnv()` without kro extensions.

### Root Cause

`newSimulateCELEnvironment()` registered context variables but did NOT register the
kro CEL library functions (json.*, maps.*, lists.*, random.*). Any expression using
these functions would fail to compile.

### Fix

Import `pkg/cel/library` (NOT `pkg/cel` — that import remains banned outside
`pkg/reconciler/policygate`) and register JSON(), Maps(), Lists(), Random().

`pkg/cel/library` has no dependency on `pkg/cel` and is explicitly allowed
per AGENTS.md: 'github.com/kubernetes-sigs/kro/pkg/cel/library is ALLOWED and encouraged'.

### Verified live

```bash
# Create gate with json.unmarshal expression
kardinal policy simulate --pipeline nginx-demo --env prod --time "Tuesday 10am" --soak-minutes 45
# json-test-gate: PASS   (json.unmarshal({"enabled": true}).enabled == true = true)
```

### Test

`TestPolicySimulate_KroCELFunctionsAvailable` — creates a gate with `json.unmarshal()`,
runs policy simulate, verifies PASS (no compile error).
