### PR TITLE
fix(cli): kardinal explain shows only active bundle rows

### DIFF
--- a/cmd/kardinal/cmd/explain.go
+++ b/cmd/kardinal/cmd/explain.go
@@ -107,10 +107,47 @@ func explainOnce(w io.Writer, c sigs_client.Client, ns, pipeline, envFilter stri
 		expression  string // CEL expression for PolicyGate rows (empty for Step rows)
 	}
 
+	// Determine the active bundle per environment using the same priority logic
+	// as FormatPipelineTable and FormatStepsTable: most-active state wins; within
+	// same priority, most recently created step wins. This ensures we show only
+	// the current promotion state, not rows from all superseded bundles.
+	type envBest struct {
+		bundleName string
+		priority   int
+		createdAt  time.Time
+	}
+	activeBundleByEnv := make(map[string]envBest)
+	for _, s := range steps.Items {
+		env := s.Spec.Environment
+		if envFilter != "" && env != envFilter {
+			continue
+		}
+		state := s.Status.State
+		if state == "" {
+			state = "Pending"
+		}
+		priority := stepStatePriority(state)
+		existing, ok := activeBundleByEnv[env]
+		if !ok ||
+			priority > existing.priority ||
+			(priority == existing.priority && s.CreationTimestamp.After(existing.createdAt)) {
+			activeBundleByEnv[env] = envBest{
+				bundleName: s.Spec.BundleName,
+				priority:   priority,
+				createdAt:  s.CreationTimestamp.Time,
+			}
+		}
+	}
+
 	var rows []explainRow
 
 	for _, s := range steps.Items {
-		if envFilter != "" && s.Spec.Environment != envFilter {
+		env := s.Spec.Environment
+		if envFilter != "" && env != envFilter {
+			continue
+		}
+		// Only show the step for the active bundle in this environment.
+		if best, ok := activeBundleByEnv[env]; ok && s.Spec.BundleName != best.bundleName {
 			continue
 		}
 		state := s.Status.State
@@ -135,6 +172,15 @@ func explainOnce(w io.Writer, c sigs_client.Client, ns, pipeline, envFilter stri
 		env := g.Labels["kardinal.io/environment"]
 		if envFilter != "" && env != envFilter {
 			continue
+		}
+		// Only show gates for the active bundle in this environment.
+		// PolicyGates carry a kardinal.io/bundle label set by the graph builder (since PR #258).
+		// Gates without this label (e.g. from older deployments) are shown for all bundles.
+		gateBundle := g.Labels["kardinal.io/bundle"]
+		if gateBundle != "" {
+			if best, ok := activeBundleByEnv[env]; ok && gateBundle != best.bundleName {
+				continue
+			}
 		}
 		gateState := PolicyGatePhase(g)
 		reason := g.Status.Reason

--- a/cmd/kardinal/cmd/explain_test.go
+++ b/cmd/kardinal/cmd/explain_test.go
@@ -174,3 +174,76 @@ func TestExplain_UnevaluatedGateExpression(t *testing.T) {
 	assert.Contains(t, out, "bundle.upstreamSoakMinutes >= 30", "CEL expression must be shown")
 	assert.Contains(t, out, "Pending", "unevaluated gate must show Pending state")
 }
+
+// TestExplain_ShowsOnlyActiveBundleRows verifies that when multiple bundles have
+// PromotionSteps and PolicyGates, only the active bundle's rows are shown (#267).
+func TestExplain_ShowsOnlyActiveBundleRows(t *testing.T) {
+	now := metav1.Now()
+	old := metav1.NewTime(now.Time.Add(-1 * 3600 * 1e9))
+
+	// Old bundle: Verified in prod.
+	oldStep := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "old-prod",
+			Namespace:         "default",
+			CreationTimestamp: old,
+			Labels:            map[string]string{"kardinal.io/pipeline": "my-app", "kardinal.io/environment": "prod"},
+		},
+		Spec:   v1alpha1.PromotionStepSpec{PipelineName: "my-app", Environment: "prod", BundleName: "old-bundle", StepType: "old-step"},
+		Status: v1alpha1.PromotionStepStatus{State: "Verified"},
+	}
+	oldGate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "old-gate",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kardinal.io/pipeline":    "my-app",
+				"kardinal.io/environment": "prod",
+				"kardinal.io/bundle":      "old-bundle",
+			},
+		},
+		Spec:   v1alpha1.PolicyGateSpec{Expression: "true"},
+		Status: v1alpha1.PolicyGateStatus{Ready: true, LastEvaluatedAt: &now},
+	}
+
+	// New bundle: Promoting in prod (higher priority).
+	newStep := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "new-prod",
+			Namespace:         "default",
+			CreationTimestamp: now,
+			Labels:            map[string]string{"kardinal.io/pipeline": "my-app", "kardinal.io/environment": "prod"},
+		},
+		Spec:   v1alpha1.PromotionStepSpec{PipelineName: "my-app", Environment: "prod", BundleName: "new-bundle", StepType: "new-step"},
+		Status: v1alpha1.PromotionStepStatus{State: "Promoting"},
+	}
+	newGate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "new-gate",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kardinal.io/pipeline":    "my-app",
+				"kardinal.io/environment": "prod",
+				"kardinal.io/bundle":      "new-bundle",
+			},
+		},
+		Spec:   v1alpha1.PolicyGateSpec{Expression: "!schedule.isWeekend"},
+		Status: v1alpha1.PolicyGateStatus{Ready: false, LastEvaluatedAt: &now},
+	}
+
+	s := buildExplainScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(oldStep, oldGate, newStep, newGate).Build()
+
+	var buf bytes.Buffer
+	err := explainOnce(&buf, c, "default", "my-app", "")
+	require.NoError(t, err)
+
+	out := buf.String()
+	// New bundle's step and gate should appear.
+	assert.Contains(t, out, "new-step", "active bundle step must be shown")
+	assert.Contains(t, out, "new-gate", "active bundle gate must be shown")
+	assert.Contains(t, out, "Promoting", "active bundle step state must be shown")
+	// Old bundle's step and gate should NOT appear.
+	assert.NotContains(t, out, "old-step", "superseded bundle step must not appear")
+	assert.NotContains(t, out, "old-gate", "superseded bundle gate must not appear")
+}

--- a/cmd/kardinal/cmd/explain_test.go
+++ b/cmd/kardinal/cmd/explain_test.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -179,7 +180,7 @@ func TestExplain_UnevaluatedGateExpression(t *testing.T) {
 // PromotionSteps and PolicyGates, only the active bundle's rows are shown (#267).
 func TestExplain_ShowsOnlyActiveBundleRows(t *testing.T) {
 	now := metav1.Now()
-	old := metav1.NewTime(now.Time.Add(-1 * 3600 * 1e9))
+	old := metav1.NewTime(now.Add(-1 * time.Hour))
 
 	// Old bundle: Verified in prod.
 	oldStep := &v1alpha1.PromotionStep{


### PR DESCRIPTION
Fixes #267. Apply same active-bundle-per-env deduplication logic from #261 to explain output. New test: TestExplain_ShowsOnlyActiveBundleRows. Backward compatible: gates without bundle label are always shown.