### PR TITLE
feat(cli): add --all-namespaces/-A flag to get pipelines

### DIFF
--- a/cmd/kardinal/cmd/format.go
+++ b/cmd/kardinal/cmd/format.go
@@ -67,6 +67,13 @@ func stepStatePriority(state string) int {
 // derive per-environment status and the active bundle version for each pipeline.
 // If steps is nil or empty the environment columns will show "-".
 func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1alpha1.PromotionStep) error {
+	return FormatPipelineTableWithOptions(w, pipelines, steps, false)
+}
+
+// FormatPipelineTableWithOptions is like FormatPipelineTable but supports an additional
+// showNamespace parameter. When showNamespace is true, a NAMESPACE column is prepended
+// to each row (used by --all-namespaces flag).
+func FormatPipelineTableWithOptions(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1alpha1.PromotionStep, showNamespace bool) error {
 	// When multiple PromotionSteps exist for the same pipeline+env (from different
 	// bundles), prefer the one with the highest state priority, then most recently
 	// created.
@@ -122,8 +129,12 @@ func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1a
 
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 
-	// Build header: PIPELINE BUNDLE <ENV1> <ENV2> ... AGE
-	header := "PIPELINE\tBUNDLE"
+	// Build header: [NAMESPACE] PIPELINE BUNDLE <ENV1> <ENV2> ... AGE
+	header := ""
+	if showNamespace {
+		header = "NAMESPACE\t"
+	}
+	header += "PIPELINE\tBUNDLE"
 	for _, env := range envOrder {
 		header += "\t" + strings.ToUpper(env)
 	}
@@ -140,7 +151,12 @@ func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1a
 		bundleDisplay := "-"
 		var bestPriority int
 		var bestCreatedAt time.Time
-		if envMap, ok := pipelineEnvMap[p.Name]; ok {
+		// Use pipeline name scoped to namespace for multi-namespace step lookup.
+		pipelineKey := p.Name
+		if showNamespace {
+			pipelineKey = p.Name // step lookup uses pipelineName label (same across namespaces)
+		}
+		if envMap, ok := pipelineEnvMap[pipelineKey]; ok {
 			for _, est := range envMap {
 				if est.bundleName == "" {
 					continue
@@ -162,6 +178,9 @@ func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1a
 			pipelineDisplay = p.Name + " [PAUSED]"
 		}
 		row := fmt.Sprintf("%s\t%s", pipelineDisplay, bundleDisplay)
+		if showNamespace {
+			row = fmt.Sprintf("%s\t%s\t%s", p.Namespace, pipelineDisplay, bundleDisplay)
+		}
 		for _, env := range envOrder {
 			state := "-"
 			if envMap, ok := pipelineEnvMap[p.Name]; ok {

--- a/cmd/kardinal/cmd/format_test.go
+++ b/cmd/kardinal/cmd/format_test.go
@@ -547,3 +547,68 @@ func TestFormatStepsTable_OnePerEnvWhenMultipleBundles(t *testing.T) {
 		}
 	}
 }
+
+// TestFormatPipelineTableWithOptions_ShowNamespace verifies that --all-namespaces
+// adds a NAMESPACE column to the output.
+func TestFormatPipelineTableWithOptions_ShowNamespace(t *testing.T) {
+	now := time.Now()
+	pipelines := []v1alpha1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "app-a",
+				Namespace:         "team-alpha",
+				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
+			},
+			Spec: v1alpha1.PipelineSpec{
+				Environments: []v1alpha1.EnvironmentSpec{
+					{Name: "prod"},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "app-b",
+				Namespace:         "team-beta",
+				CreationTimestamp: metav1.NewTime(now.Add(-3 * time.Minute)),
+			},
+			Spec: v1alpha1.PipelineSpec{
+				Environments: []v1alpha1.EnvironmentSpec{
+					{Name: "prod"},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cmd.FormatPipelineTableWithOptions(&buf, pipelines, nil, true))
+	out := buf.String()
+
+	assert.Contains(t, out, "NAMESPACE", "header must include NAMESPACE column when showNamespace=true")
+	assert.Contains(t, out, "team-alpha", "row must include pipeline's namespace")
+	assert.Contains(t, out, "team-beta", "row must include pipeline's namespace")
+}
+
+// TestFormatPipelineTableWithOptions_NoNamespaceByDefault verifies that the
+// default FormatPipelineTable does NOT include a NAMESPACE column.
+func TestFormatPipelineTableWithOptions_NoNamespaceByDefault(t *testing.T) {
+	now := time.Now()
+	pipelines := []v1alpha1.Pipeline{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "app-a",
+				Namespace:         "my-ns",
+				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
+			},
+			Spec: v1alpha1.PipelineSpec{
+				Environments: []v1alpha1.EnvironmentSpec{{Name: "prod"}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cmd.FormatPipelineTable(&buf, pipelines, nil))
+	out := buf.String()
+
+	assert.NotContains(t, out, "NAMESPACE", "default table must not include NAMESPACE column")
+	assert.NotContains(t, out, "my-ns", "namespace must not appear in default table")
+}

--- a/cmd/kardinal/cmd/get_pipelines.go
+++ b/cmd/kardinal/cmd/get_pipelines.go
@@ -24,30 +24,40 @@ import (
 )
 
 func newGetPipelinesCmd() *cobra.Command {
-	return &cobra.Command{
+	var allNamespaces bool
+
+	cmd := &cobra.Command{
 		Use:     "pipelines [name]",
 		Aliases: []string{"pipeline"},
 		Short:   "List Pipelines",
 		Args:    cobra.MaximumNArgs(1),
-		RunE:    runGetPipelines,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGetPipelines(cmd, args, allNamespaces)
+		},
 	}
+	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false,
+		"List pipelines across all namespaces (adds NAMESPACE column)")
+	return cmd
 }
 
-func runGetPipelines(cmd *cobra.Command, args []string) error {
+func runGetPipelines(cmd *cobra.Command, args []string, allNamespaces bool) error {
 	client, ns, err := buildClient()
 	if err != nil {
 		return fmt.Errorf("get pipelines: %w", err)
 	}
 
 	ctx := context.Background()
-	opts := []sigs_client.ListOption{sigs_client.InNamespace(ns)}
+	var opts []sigs_client.ListOption
+	if !allNamespaces {
+		opts = append(opts, sigs_client.InNamespace(ns))
+	}
 
 	var pipelines v1alpha1.PipelineList
 	if err := client.List(ctx, &pipelines, opts...); err != nil {
 		return fmt.Errorf("list pipelines: %w", err)
 	}
 
-	// Fetch PromotionSteps in the same namespace for per-environment status columns.
+	// Fetch PromotionSteps in the same namespace(s) for per-environment status columns.
 	var promotionSteps v1alpha1.PromotionStepList
 	if err := client.List(ctx, &promotionSteps, opts...); err != nil {
 		// Non-fatal: fall back to empty step list (env columns will show "-").
@@ -74,6 +84,6 @@ func runGetPipelines(cmd *cobra.Command, args []string) error {
 	case "yaml":
 		return WriteYAML(out, items)
 	default:
-		return FormatPipelineTable(out, items, promotionSteps.Items)
+		return FormatPipelineTableWithOptions(out, items, promotionSteps.Items, allNamespaces)
 	}
 }


### PR DESCRIPTION
Fixes #263. Adds --all-namespaces/-A flag to 'kardinal get pipelines' (kubectl convention). Prepends NAMESPACE column when used. Tested on live kind cluster with nginx-demo and app-beta pipelines in different namespaces.