### PR TITLE
fix(crd): regenerate CRD schemas — add missing soakMinutes, policyNamespaces

### DIFF
--- a/config/crd/bases/kardinal.io_bundles.yaml
+++ b/config/crd/bases/kardinal.io_bundles.yaml
@@ -132,7 +132,11 @@ spec:
                     type: string
                 type: object
               type:
-                description: Type classifies the bundle content.
+                description: |-
+                  Type classifies the bundle content.
+                  Supersession rule (BU-4): each bundle type supersedes only bundles of the same type.
+                  An image bundle does NOT supersede a config bundle and vice versa.
+                  This allows image and config promotions to coexist independently in the same pipeline.
                 enum:
                 - image
                 - config
@@ -263,6 +267,15 @@ spec:
                       description: PRURL is the URL of the pull request opened for
                         this promotion.
                       type: string
+                    soakMinutes:
+                      description: |-
+                        SoakMinutes is the number of minutes that have elapsed since HealthCheckedAt.
+                        Written by the BundleReconciler as part of its own CRD status write.
+                        The PolicyGate reconciler reads this field from Bundle.status.environments
+                        to populate bundle.upstreamSoakMinutes in the CEL context. This eliminates
+                        the time.Since() call from the PolicyGate reconciler hot path (PG-3 fix).
+                      format: int64
+                      type: integer
                   required:
                   - name
                   type: object

--- a/config/crd/bases/kardinal.io_pipelines.yaml
+++ b/config/crd/bases/kardinal.io_pipelines.yaml
@@ -54,7 +54,13 @@ spec:
             description: PipelineSpec defines the desired state of a Pipeline.
             properties:
               environments:
-                description: Environments lists the promotion path in order.
+                description: |-
+                  Environments lists the promotion path.
+                  Sequential ordering (GB-1): when an environment does not specify dependsOn,
+                  it implicitly depends on the previous entry in this list. The first environment
+                  has no upstream dependency. This sequential default means a list of N environments
+                  without dependsOn fields produces a linear chain. Override with dependsOn to
+                  express parallel fan-out or explicit DAG structure.
                 items:
                   description: EnvironmentSpec defines one environment in a Pipeline.
                   properties:
@@ -303,6 +309,16 @@ spec:
                   required:
                   - name
                   type: object
+                type: array
+              policyNamespaces:
+                description: |-
+                  PolicyNamespaces lists additional namespaces to scan for org-level PolicyGates.
+                  The pipeline's own namespace is always included. When unset, the controller
+                  defaults to "platform-policies". Setting this field makes the namespace list
+                  explicit in the Pipeline spec rather than hardcoded in the controller.
+                  Eliminates TR-2 from docs/design/11-graph-purity-tech-debt.md.
+                items:
+                  type: string
                 type: array
             required:
             - environments

--- a/config/crd/bases/kardinal.io_promotionsteps.yaml
+++ b/config/crd/bases/kardinal.io_promotionsteps.yaml
@@ -72,6 +72,13 @@ spec:
                 description: PipelineName is the Pipeline this step belongs to.
                 minLength: 1
                 type: string
+              prStatusRef:
+                description: |-
+                  PRStatusRef is the name of the companion PRStatus CRD in the same namespace.
+                  Set by the Graph controller from the PRStatus Watch node's metadata.name CEL reference.
+                  The PromotionStep reconciler reads the PRStatus CRD instead of polling GitHub
+                  directly, eliminating the PS-4 / SCM-2 external API call on the reconcile hot path.
+                type: string
               requiredGates:
                 description: |-
                   RequiredGates holds the names of PolicyGate instances that must be ready
@@ -175,6 +182,14 @@ spec:
                   is currently executing. Persisted to etcd for idempotent crash recovery
                   (spec 003 FR-002).
                 type: integer
+              healthCheckExpiry:
+                description: |-
+                  HealthCheckExpiry is the deadline for the health check, computed as
+                  healthCheckStartedAt + timeout. Set once when the health check begins.
+                  A Graph CEL expression can observe this field to detect a stale health check.
+                  Graph-purity: replaces the time.Since() call (PS-5 in 11-graph-purity-tech-debt.md).
+                format: date-time
+                type: string
               message:
                 description: Message provides human-readable detail about the current
                   state.
@@ -203,6 +218,15 @@ spec:
                 - HealthChecking
                 - Verified
                 - Failed
+                type: string
+              workDir:
+                description: |-
+                  WorkDir is the working directory on the controller node used for git operations
+                  (clone, commit, push) and kustomize builds. Persisted to etcd so that a restarted
+                  controller can re-use the same directory and resume in-flight git work.
+                  ST-7/ST-8/ST-9 short-term mitigation: the workdir path is made observable via
+                  CRD status, enabling crash-recovery without re-cloning.
+                  Long-term: git operations become Kubernetes Jobs (owned nodes in the Graph).
                 type: string
             type: object
         type: object


### PR DESCRIPTION
Regenerate CRD schemas via 'make manifests'. Found via live cluster testing — controller was logging 'unknown field status.environments[0].soakMinutes' because the Bundle CRD schema was out of sync with the Go types.

Critical: without this fix, soakMinutes is silently dropped by the API server, breaking the upstreamSoakMinutes CEL context fix from #255.

Also adds policyNamespaces to Pipeline CRD and additional PromotionStep fields.