### PR TITLE
fix(graph): remove PropagateWhen from PRStatus — breaks circular dependency

### DIFF
--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -592,13 +592,18 @@ func buildPolicyGateNode(
 
 // buildPRStatusNode builds a Graph Watch node for a PRStatus CRD.
 //
-// The PRStatus CRD is created by the open-pr step at the appropriate point in
-// the promotion sequence. This Graph node watches it and propagates when
-// status.merged == true — replacing the direct GitHub API polling that was
-// previously in handleWaitingForMerge and the wait-for-merge step.
+// The PRStatus CRD is created as a placeholder by the Graph; the open-pr step
+// populates spec.prURL, spec.prNumber, spec.repo after opening the PR.
+// The PRStatus reconciler monitors GitHub and sets status.merged = true.
 //
-// Graph-purity: this node is the canonical integration point for PS-4, SCM-2,
-// ST-10, ST-11 (docs/design/11-graph-purity-tech-debt.md).
+// This node uses readyWhen (not propagateWhen) so it does NOT block downstream
+// PromotionSteps. The PromotionStep reconciler checks prStatusRef.status.merged
+// in its own WaitingForMerge state. Using propagateWhen would create a circular
+// dependency: PromotionStep references prstatus.metadata.name (creating a dep),
+// but if prstatus.propagateWhen == false, the PromotionStep could never start.
+//
+// Graph-purity: this node provides observable PR merge state for the UI and
+// for the PromotionStep reconciler (eliminates direct GitHub API polling PS-4, SCM-2).
 func buildPRStatusNode(nodeID, k8sName, pipelineName, bundleName, envName string) GraphNode {
 	templateMeta := map[string]interface{}{
 		// The name is set at runtime by the open-pr step; the Graph creates a
@@ -628,15 +633,16 @@ func buildPRStatusNode(nodeID, k8sName, pipelineName, bundleName, envName string
 			"metadata":   templateMeta,
 			"spec":       templateSpec,
 		},
-		// ReadyWhen: UI health signal — green when merged.
+		// ReadyWhen: health signal only — green in UI when PR is merged.
+		// NOT propagateWhen: the PromotionStep references this node's metadata.name
+		// which creates a dependency edge. Adding propagateWhen would block the
+		// PromotionStep from starting (circular: PS can't start → PR never opened
+		// → PRStatus never merged → propagateWhen never true → PS never starts).
 		ReadyWhen: []string{
 			fmt.Sprintf(`${%s.status.merged == true}`, nodeID),
 		},
-		// PropagateWhen: blocks downstream PromotionStep from advancing until
-		// the PR is merged. This is the gate that replaces WaitingForMerge polling.
-		PropagateWhen: []string{
-			fmt.Sprintf(`${%s.status.merged == true}`, nodeID),
-		},
+		// PropagateWhen is intentionally omitted — always propagates (unblocked).
+		// Merge-gate is enforced by the PromotionStep WaitingForMerge state machine.
 	}
 }
 

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -461,10 +461,17 @@ func TestBuilder_PRStatusWatchNode(t *testing.T) {
 	kind, _ := prStatusTestNode.Template["kind"].(string)
 	assert.Equal(t, "PRStatus", kind, "Watch node kind must be PRStatus")
 
-	// Check PropagateWhen references status.merged
-	require.NotEmpty(t, prStatusTestNode.PropagateWhen)
-	assert.Contains(t, prStatusTestNode.PropagateWhen[0], "status.merged == true",
-		"PropagateWhen must gate on status.merged")
+	// Check PropagateWhen is EMPTY to avoid circular dependency:
+	// PromotionStep references ${prstatus.metadata.name} creating a dep edge;
+	// if PRStatus also had propagateWhen=merged, the PromotionStep could never start
+	// because PRStatus can't be merged before the PR is opened.
+	assert.Empty(t, prStatusTestNode.PropagateWhen,
+		"PropagateWhen must be empty — PRStatus must not block PromotionStep (circular dep)")
+
+	// Check ReadyWhen references status.merged (health signal for UI only)
+	require.NotEmpty(t, prStatusTestNode.ReadyWhen)
+	assert.Contains(t, prStatusTestNode.ReadyWhen[0], "status.merged == true",
+		"ReadyWhen must gate on status.merged for UI health display")
 
 	// Check PromotionStep node has prStatusRef referencing the Watch node
 	testStepNode, ok := nodeMap["test"]


### PR DESCRIPTION
Fixes circular dependency found via live cluster testing. PRStatus propagateWhen=merged blocked PromotionStep from starting. The PromotionStep needs to start to open the PR so PRStatus can merge. Classic deadlock.

Fix: PropagateWhen removed from PRStatus. ReadyWhen kept (UI health signal). PromotionStep WaitingForMerge state handles the merge gate.