### PR TITLE
feat(ui): promote action button on DAG PromotionStep nodes (Kargo parity)

### DIFF
--- a/cmd/kardinal-controller/ui_api.go
+++ b/cmd/kardinal-controller/ui_api.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
@@ -111,6 +112,7 @@ func (s *uiAPIServer) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/ui/pipelines/", s.handlePipelinesSubpath)
 	mux.HandleFunc("/api/v1/ui/bundles/", s.handleBundleSubresource)
 	mux.HandleFunc("/api/v1/ui/gates", s.handleGates)
+	mux.HandleFunc("/api/v1/ui/promote", s.handlePromote)
 }
 
 func writeJSON(w http.ResponseWriter, v interface{}) {
@@ -326,4 +328,93 @@ func pipelinePhase(p *v1alpha1.Pipeline) string {
 		}
 	}
 	return "Initializing"
+}
+
+// handlePromote handles POST /api/v1/ui/promote — creates a Bundle targeting the
+// given pipeline and environment, triggering a new promotion. This is the UI
+// equivalent of `kardinal promote <pipeline> --env <env>`.
+//
+// Request body (JSON):
+//
+//	{"pipeline": "nginx-demo", "environment": "prod", "namespace": "default"}
+//
+// Response (JSON on success):
+//
+//	{"bundle": "nginx-demo-abc123", "message": "promotion started"}
+func (s *uiAPIServer) handlePromote(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Pipeline    string `json:"pipeline"`
+		Environment string `json:"environment"`
+		Namespace   string `json:"namespace"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Pipeline == "" || req.Environment == "" {
+		http.Error(w, "pipeline and environment are required", http.StatusBadRequest)
+		return
+	}
+	ns := req.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+
+	// Verify the pipeline exists.
+	var pl v1alpha1.Pipeline
+	if err := s.client.Get(r.Context(), client.ObjectKey{Name: req.Pipeline, Namespace: ns}, &pl); err != nil {
+		http.Error(w, "pipeline not found", http.StatusNotFound)
+		return
+	}
+
+	// Verify the environment exists in the pipeline.
+	found := false
+	for _, e := range pl.Spec.Environments {
+		if e.Name == req.Environment {
+			found = true
+			break
+		}
+	}
+	if !found {
+		http.Error(w, "environment not found in pipeline", http.StatusBadRequest)
+		return
+	}
+
+	// Create a Bundle targeting the specified environment (same as CLI promote).
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: req.Pipeline + "-",
+			Namespace:    ns,
+		},
+		Spec: v1alpha1.BundleSpec{
+			Type:     "image",
+			Pipeline: req.Pipeline,
+			Intent: &v1alpha1.BundleIntent{
+				TargetEnvironment: req.Environment,
+			},
+		},
+	}
+	if err := s.client.Create(r.Context(), bundle); err != nil {
+		s.log.Error().Err(err).Str("pipeline", req.Pipeline).Str("env", req.Environment).Msg("ui: create promote bundle")
+		http.Error(w, "failed to create bundle", http.StatusInternalServerError)
+		return
+	}
+
+	s.log.Info().
+		Str("bundle", bundle.Name).
+		Str("pipeline", req.Pipeline).
+		Str("env", req.Environment).
+		Msg("ui: promote triggered")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"bundle":  bundle.Name,
+		"message": "promotion started — track with kardinal get bundles " + req.Pipeline,
+	})
 }

--- a/cmd/kardinal-controller/ui_api_test.go
+++ b/cmd/kardinal-controller/ui_api_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -268,4 +269,83 @@ func TestUIAPI_GateStatusFields(t *testing.T) {
 	var gateList v1alpha1.PolicyGateList
 	require.NoError(t, c.List(context.Background(), &gateList))
 	assert.Empty(t, gateList.Items)
+}
+
+// TestUIAPI_Promote_CreatesBundleForEnvironment verifies that POST /api/v1/ui/promote
+// creates a Bundle targeting the specified environment.
+func TestUIAPI_Promote_CreatesBundleForEnvironment(t *testing.T) {
+	s := uiScheme()
+	pipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test"},
+				{Name: "prod"},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body := `{"pipeline": "nginx-demo", "environment": "prod", "namespace": "default"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ui/promote", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "promote must return 201 Created")
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["bundle"], "response must include bundle name")
+
+	// Verify the Bundle was created.
+	var bundles v1alpha1.BundleList
+	require.NoError(t, c.List(context.Background(), &bundles))
+	require.Len(t, bundles.Items, 1, "one bundle must be created")
+	b := bundles.Items[0]
+	assert.Equal(t, "nginx-demo", b.Spec.Pipeline)
+	assert.Equal(t, "prod", b.Spec.Intent.TargetEnvironment)
+}
+
+// TestUIAPI_Promote_RejectsMissingPipeline verifies that a promote request for
+// a nonexistent pipeline returns 404.
+func TestUIAPI_Promote_RejectsMissingPipeline(t *testing.T) {
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body := `{"pipeline": "does-not-exist", "environment": "prod"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ui/promote", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code, "unknown pipeline must return 404")
+}
+
+// TestUIAPI_Promote_RejectsUnknownEnvironment verifies that a promote request for
+// an environment not in the pipeline spec returns 400.
+func TestUIAPI_Promote_RejectsUnknownEnvironment(t *testing.T) {
+	s := uiScheme()
+	pipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Environments: []v1alpha1.EnvironmentSpec{{Name: "test"}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body := `{"pipeline": "nginx-demo", "environment": "nonexistent"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ui/promote", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "unknown env must return 400")
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -292,6 +292,8 @@ export function App() {
                 error={graphError}
                 highlightNodeIds={highlightIds}
                 bundleName={activeBundle?.name}
+                pipelineName={selectedPipeline}
+                namespace={activePipeline?.namespace ?? 'default'}
               />
             </div>
           </>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -12,10 +12,26 @@ async function get<T>(path: string): Promise<T> {
   return resp.json() as Promise<T>
 }
 
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const resp = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!resp.ok) {
+    const text = await resp.text()
+    throw new Error(`API error ${resp.status}: ${text || resp.statusText}`)
+  }
+  return resp.json() as Promise<T>
+}
+
 export const api = {
   listPipelines: () => get<Pipeline[]>('/pipelines'),
   listBundles: (pipelineName: string) => get<Bundle[]>(`/pipelines/${pipelineName}/bundles`),
   getGraph: (bundleName: string) => get<GraphResponse>(`/bundles/${bundleName}/graph`),
   getSteps: (bundleName: string) => get<PromotionStep[]>(`/bundles/${bundleName}/steps`),
   listGates: () => get<PolicyGate[]>('/gates'),
+  /** Trigger a new promotion for the given pipeline+environment (UI promote button). */
+  promote: (pipeline: string, environment: string, namespace = 'default') =>
+    post<{ bundle: string; message: string }>('/promote', { pipeline, environment, namespace }),
 }

--- a/web/src/components/DAGView.tsx
+++ b/web/src/components/DAGView.tsx
@@ -16,6 +16,10 @@ interface Props {
   highlightNodeIds?: Set<string>
   /** Bundle name — passed to NodeDetail to fetch step detail. */
   bundleName?: string
+  /** Pipeline name — passed to NodeDetail for the promote button. */
+  pipelineName?: string
+  /** Namespace of the pipeline. Defaults to 'default'. */
+  namespace?: string
 }
 
 const NODE_WIDTH = 180
@@ -52,7 +56,7 @@ function computeLayout(nodes: GraphNode[], edges: GraphEdge[]): LayoutNode[] {
   })
 }
 
-export function DAGView({ nodes, edges, loading, error, highlightNodeIds, bundleName }: Props) {
+export function DAGView({ nodes, edges, loading, error, highlightNodeIds, bundleName, pipelineName, namespace }: Props) {
   const [selected, setSelected] = useState<GraphNode | null>(null)
 
   if (loading) {
@@ -159,7 +163,13 @@ export function DAGView({ nodes, edges, loading, error, highlightNodeIds, bundle
         })}
       </svg>
 
-      <NodeDetail node={selected} onClose={() => setSelected(null)} bundleName={bundleName} />
+      <NodeDetail
+        node={selected}
+        onClose={() => setSelected(null)}
+        bundleName={bundleName}
+        pipelineName={pipelineName}
+        namespace={namespace}
+      />
     </div>
   )
 }

--- a/web/src/components/NodeDetail.tsx
+++ b/web/src/components/NodeDetail.tsx
@@ -11,6 +11,10 @@ interface Props {
   onClose: () => void
   /** Bundle name — needed to fetch detailed step data. */
   bundleName?: string
+  /** Pipeline name — needed for the promote action. */
+  pipelineName?: string
+  /** Namespace of the pipeline. Defaults to 'default'. */
+  namespace?: string
 }
 
 /** Format an ISO timestamp to a human-readable string. */
@@ -118,13 +122,31 @@ function StepProgress({ step }: { step: PromotionStep }) {
   )
 }
 
-export function NodeDetail({ node, onClose, bundleName }: Props) {
+export function NodeDetail({ node, onClose, bundleName, pipelineName, namespace = 'default' }: Props) {
   const [stepDetail, setStepDetail] = useState<PromotionStep | null>(null)
   const [stepLoading, setStepLoading] = useState(false)
+  const [promoteState, setPromoteState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
+  const [promoteMessage, setPromoteMessage] = useState<string | null>(null)
 
   const isPolicyGate = node?.type === 'PolicyGate'
   const isPromotionStep = node?.type === 'PromotionStep'
   const isActiveState = node && ['Running', 'Promoting', 'WaitingForMerge', 'HealthChecking'].includes(node.state)
+
+  /** Trigger a new promotion for this environment. */
+  function handlePromote() {
+    if (!pipelineName || !node?.environment) return
+    setPromoteState('loading')
+    setPromoteMessage(null)
+    api.promote(pipelineName, node.environment, namespace)
+      .then(res => {
+        setPromoteState('success')
+        setPromoteMessage(`Bundle ${res.bundle} created`)
+      })
+      .catch((err: unknown) => {
+        setPromoteState('error')
+        setPromoteMessage(err instanceof Error ? err.message : 'Promote failed')
+      })
+  }
 
   // Fetch step detail when a PromotionStep node is selected and bundle is known.
   useEffect(() => {
@@ -200,6 +222,48 @@ export function NodeDetail({ node, onClose, bundleName }: Props) {
       <div style={{ fontSize: '0.85rem', color: '#94a3b8', marginBottom: '0.5rem' }}>
         <strong style={{ color: '#cbd5e1' }}>Environment:</strong> {node.environment}
       </div>
+
+      {/* Promote button — shown on PromotionStep nodes when a pipeline is known */}
+      {isPromotionStep && pipelineName && node.environment && (
+        <div style={{ marginBottom: '0.75rem' }}>
+          <button
+            onClick={handlePromote}
+            disabled={promoteState === 'loading'}
+            title={`Promote ${pipelineName} to ${node.environment}`}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.4rem',
+              padding: '0.35rem 0.8rem',
+              background: promoteState === 'success' ? '#166534' : promoteState === 'error' ? '#7f1d1d' : '#4f46e5',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: promoteState === 'loading' ? 'wait' : 'pointer',
+              fontSize: '0.8rem',
+              fontWeight: 500,
+              opacity: promoteState === 'loading' ? 0.7 : 1,
+            }}
+          >
+            <span>▶</span>
+            <span>
+              {promoteState === 'loading' ? 'Promoting…'
+                : promoteState === 'success' ? 'Promoted!'
+                : promoteState === 'error' ? 'Failed'
+                : `Promote to ${node.environment}`}
+            </span>
+          </button>
+          {promoteMessage && (
+            <div style={{
+              marginTop: '0.3rem',
+              fontSize: '0.7rem',
+              color: promoteState === 'error' ? '#fca5a5' : '#86efac',
+            }}>
+              {promoteMessage}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* PromotionStep: step progress log */}
       {isPromotionStep && stepLoading && (


### PR DESCRIPTION
Fixes #227. Adds a promote button on PromotionStep nodes in the DAG — same UX pattern as Kargo's truck icon.

**Backend**: POST /api/v1/ui/promote — creates a Bundle targeting the environment.
**Frontend**: '▶ Promote to <env>' button in NodeDetail with loading/success/error states.

3 new backend tests. Frontend builds with bun. All 18 Go packages pass.