### PR TITLE
feat(ui): server-side CEL expression syntax validator + validation chip

### DIFF
--- a/cmd/kardinal-controller/ui_api.go
+++ b/cmd/kardinal-controller/ui_api.go
@@ -19,14 +19,18 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
 	"github.com/rs/zerolog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/cel/library"
 )
 
 // uiPipelineResponse is the JSON shape for a Pipeline in the UI API.
@@ -113,6 +117,7 @@ func (s *uiAPIServer) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/ui/bundles/", s.handleBundleSubresource)
 	mux.HandleFunc("/api/v1/ui/gates", s.handleGates)
 	mux.HandleFunc("/api/v1/ui/promote", s.handlePromote)
+	mux.HandleFunc("/api/v1/ui/validate-cel", s.handleValidateCEL)
 }
 
 func writeJSON(w http.ResponseWriter, v interface{}) {
@@ -416,5 +421,68 @@ func (s *uiAPIServer) handlePromote(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]string{
 		"bundle":  bundle.Name,
 		"message": "promotion started — track with kardinal get bundles " + req.Pipeline,
+	})
+}
+
+// handleValidateCEL validates a PolicyGate CEL expression using the same CEL
+// environment as the backend evaluator. The UI calls this on-the-fly as the
+// user types to provide syntax feedback without needing the full evaluation context.
+//
+// POST /api/v1/ui/validate-cel
+// Request: {"expression": "!schedule.isWeekend"}
+// Response: {"valid": true} or {"valid": false, "error": "no such key: ..."}
+//
+// This endpoint uses pkg/cel/library directly (not pkg/cel) — library is explicitly
+// allowed outside policygate and creates no logic leaks (stateless, no CRD writes).
+func (s *uiAPIServer) handleValidateCEL(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Expression string `json:"expression"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Expression == "" {
+		http.Error(w, "expression field required", http.StatusBadRequest)
+		return
+	}
+
+	// Build a CEL environment with all kro library extensions — same function set
+	// as the backend PolicyGate evaluator. Uses pkg/cel/library directly.
+	env, err := cel.NewEnv(
+		cel.Variable("bundle", cel.DynType),
+		cel.Variable("schedule", cel.DynType),
+		cel.Variable("environment", cel.DynType),
+		cel.Variable("metrics", cel.DynType),
+		cel.Variable("upstream", cel.DynType),
+		cel.Variable("previousBundle", cel.DynType),
+		ext.Strings(),
+		library.JSON(),
+		library.Maps(),
+		library.Lists(),
+		library.Random(),
+	)
+	if err != nil {
+		http.Error(w, "failed to build CEL environment", http.StatusInternalServerError)
+		return
+	}
+
+	_, issues := env.Compile(req.Expression)
+	w.Header().Set("Content-Type", "application/json")
+	if issues != nil && issues.Err() != nil {
+		// Normalise error to a short, user-friendly message.
+		msg := issues.Err().Error()
+		if len(msg) > 200 {
+			msg = msg[:197] + "…"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"valid": false,
+			"error": fmt.Sprintf("CEL compile error: %s", msg),
+		})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"valid": true,
 	})
 }

--- a/cmd/kardinal-controller/ui_api_test.go
+++ b/cmd/kardinal-controller/ui_api_test.go
@@ -349,3 +349,77 @@ func TestUIAPI_Promote_RejectsUnknownEnvironment(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, w.Code, "unknown env must return 400")
 }
+
+// TestUIAPI_ValidateCEL_ValidExpression verifies that a valid CEL expression returns valid=true.
+func TestUIAPI_ValidateCEL_ValidExpression(t *testing.T) {
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body := `{"expression": "!schedule.isWeekend"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ui/validate-cel", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["valid"], "valid expression must return valid=true")
+}
+
+// TestUIAPI_ValidateCEL_InvalidExpression verifies that a malformed CEL expression
+// returns valid=false with an error message.
+func TestUIAPI_ValidateCEL_InvalidExpression(t *testing.T) {
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body := `{"expression": "this is not valid CEL @@@"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ui/validate-cel", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["valid"], "invalid expression must return valid=false")
+	assert.NotEmpty(t, resp["error"], "error message must be provided")
+}
+
+// TestUIAPI_ValidateCEL_KroFunctionsAvailable verifies that kro CEL library functions
+// (lists.*, random.*) are available in the expression validator.
+func TestUIAPI_ValidateCEL_KroFunctionsAvailable(t *testing.T) {
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	tests := []struct {
+		expression string
+		wantValid  bool
+	}{
+		{`lists.setAtIndex([1,2,3], 0, 99)[0] == 99`, true},
+		{`!schedule.isWeekend`, true},
+		{`bundle.upstreamSoakMinutes >= 30`, true},
+		{`upstream.uat.soakMinutes >= 30`, true},
+	}
+	for _, tc := range tests {
+		// Use json.Marshal to correctly encode expression strings with special chars.
+		bodyMap := map[string]string{"expression": tc.expression}
+		bodyBytes, err := json.Marshal(bodyMap)
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/ui/validate-cel", strings.NewReader(string(bodyBytes)))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, "expression: %s", tc.expression)
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, tc.wantValid, resp["valid"], "expression: %s", tc.expression)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -34,4 +34,7 @@ export const api = {
   /** Trigger a new promotion for the given pipeline+environment (UI promote button). */
   promote: (pipeline: string, environment: string, namespace = 'default') =>
     post<{ bundle: string; message: string }>('/promote', { pipeline, environment, namespace }),
+  /** Validate a CEL expression using the server-side kro CEL environment. */
+  validateCEL: (expression: string) =>
+    post<{ valid: boolean; error?: string }>('/validate-cel', { expression }),
 }

--- a/web/src/components/NodeDetail.tsx
+++ b/web/src/components/NodeDetail.tsx
@@ -127,10 +127,31 @@ export function NodeDetail({ node, onClose, bundleName, pipelineName, namespace 
   const [stepLoading, setStepLoading] = useState(false)
   const [promoteState, setPromoteState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
   const [promoteMessage, setPromoteMessage] = useState<string | null>(null)
+  const [celValid, setCelValid] = useState<boolean | null>(null)
+  const [celError, setCelError] = useState<string | null>(null)
 
   const isPolicyGate = node?.type === 'PolicyGate'
   const isPromotionStep = node?.type === 'PromotionStep'
   const isActiveState = node && ['Running', 'Promoting', 'WaitingForMerge', 'HealthChecking'].includes(node.state)
+
+  /** Validate the CEL expression of a PolicyGate node when it is selected. */
+  useEffect(() => {
+    if (!isPolicyGate || !node?.expression) {
+      setCelValid(null)
+      setCelError(null)
+      return
+    }
+    // Validate the expression asynchronously (best effort — UI only).
+    api.validateCEL(node.expression)
+      .then(res => {
+        setCelValid(res.valid)
+        setCelError(res.error ?? null)
+      })
+      .catch(() => {
+        setCelValid(null)
+        setCelError(null)
+      })
+  }, [node?.id, isPolicyGate])
 
   /** Trigger a new promotion for this environment. */
   function handlePromote() {
@@ -280,16 +301,34 @@ export function NodeDetail({ node, onClose, bundleName, pipelineName, namespace 
         </div>
       )}
 
-      {/* PolicyGate: CEL expression display */}
+      {/* PolicyGate: CEL expression display with server-side syntax validation */}
       {isPolicyGate && node.expression && (
         <div style={{ marginBottom: '0.75rem' }}>
-          <h4 style={{ fontSize: '0.8rem', color: '#cbd5e1', marginBottom: '0.4rem' }}>
-            CEL Expression
-          </h4>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', marginBottom: '0.4rem' }}>
+            <h4 style={{ fontSize: '0.8rem', color: '#cbd5e1', margin: 0 }}>
+              CEL Expression
+            </h4>
+            {/* Syntax validity chip — populated by POST /api/v1/ui/validate-cel */}
+            {celValid === true && (
+              <span style={{
+                fontSize: '0.65rem', background: '#14532d', color: '#86efac',
+                borderRadius: '4px', padding: '1px 6px',
+              }}>✓ valid</span>
+            )}
+            {celValid === false && (
+              <span
+                style={{
+                  fontSize: '0.65rem', background: '#7f1d1d', color: '#fca5a5',
+                  borderRadius: '4px', padding: '1px 6px', cursor: 'help',
+                }}
+                title={celError ?? 'syntax error'}
+              >✗ error</span>
+            )}
+          </div>
           <code style={{
             display: 'block',
             background: '#0f172a',
-            border: '1px solid #334155',
+            border: `1px solid ${celValid === false ? '#7f1d1d' : '#334155'}`,
             borderRadius: '4px',
             padding: '0.5rem 0.75rem',
             fontSize: '0.8rem',
@@ -300,6 +339,11 @@ export function NodeDetail({ node, onClose, bundleName, pipelineName, namespace 
           }}>
             {node.expression}
           </code>
+          {celValid === false && celError && (
+            <div style={{ fontSize: '0.7rem', color: '#fca5a5', marginTop: '0.25rem' }}>
+              {celError}
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Closes #244 (partial — syntax validation done; full editor future work).

**Backend**: POST /api/v1/ui/validate-cel validates CEL expression using kro library. Uses pkg/cel/library (allowed).
**Frontend**: Auto-validates on PolicyGate node select. Shows ✓/✗ chip + error message.

3 new backend tests covering valid, invalid, and kro function expressions.