### PR TITLE
fix(cli): policy list shows template gates only, not per-bundle Graph instances

### DIFF
--- a/cmd/kardinal/cmd/cli_test.go
+++ b/cmd/kardinal/cmd/cli_test.go
@@ -627,6 +627,45 @@ func TestPolicyList_ShowsPendingState(t *testing.T) {
 	assert.Contains(t, buf.String(), "Pending", "unevaluated gate must show Pending")
 }
 
+// TestPolicyList_FiltersGraphInstances verifies that Graph-managed per-bundle
+// PolicyGate instances are excluded from policy list (#285).
+func TestPolicyList_FiltersGraphInstances(t *testing.T) {
+	s := cliTestScheme(t)
+	// Template gate — should be shown.
+	templateGate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-weekend-deploys",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kardinal.io/scope":      "org",
+				"kardinal.io/applies-to": "prod",
+			},
+		},
+		Spec: v1alpha1.PolicyGateSpec{Expression: "!schedule.isWeekend"},
+	}
+	// Graph instance with kro label — must be filtered out.
+	instanceGate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-weekend-deploys--nginx-demo-v1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"internal.kro.run/graph-name": "nginx-demo-nginx-demo-v1",
+				"kardinal.io/bundle":          "nginx-demo-v1",
+			},
+		},
+		Spec: v1alpha1.PolicyGateSpec{Expression: "true"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(templateGate, instanceGate).Build()
+
+	var buf bytes.Buffer
+	err := policyListFn(&buf, c, "default", "")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "no-weekend-deploys", "template gate must be shown")
+	assert.NotContains(t, out, "nginx-demo-v1", "Graph instance must be filtered out")
+}
+
 // TestVersionOutput_ThreeLines verifies that versionFn outputs CLI, Controller, and Graph lines.
 func TestVersionOutput_ThreeLines(t *testing.T) {
 	tests := []struct {

--- a/cmd/kardinal/cmd/policy.go
+++ b/cmd/kardinal/cmd/policy.go
@@ -65,8 +65,16 @@ func newPolicyListCmd() *cobra.Command {
 }
 
 // policyListFn is the testable implementation of policy list.
+// It lists all PolicyGates across ALL namespaces and filters to show only
+// user-defined template gates (not per-bundle Graph instances). This ensures
+// org-level gates in namespaces like 'platform-policies' are always shown,
+// matching the documented behavior (Journey 3 pass criteria).
 func policyListFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Client, ns, pipelineFilter string) error {
-	opts := []sigs_client.ListOption{sigs_client.InNamespace(ns)}
+	// List across all namespaces — policy templates can be in any namespace
+	// (e.g. platform-policies for org-level, or team namespaces for team-level).
+	// The current-namespace default is intentionally NOT used here; operators
+	// want to see all gates regardless of where kubectl is pointed.
+	opts := []sigs_client.ListOption{}
 	if pipelineFilter != "" {
 		opts = append(opts, sigs_client.MatchingLabels{"kardinal.io/pipeline": pipelineFilter})
 	}
@@ -76,7 +84,22 @@ func policyListFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Clien
 		return fmt.Errorf("list policy gates: %w", listErr)
 	}
 
-	return formatPolicyGateTable(w, gates.Items)
+	// Filter out Graph-managed per-bundle instances. These have either the
+	// internal.kro.run/graph-name label (set by krocodile) or kardinal.io/bundle
+	// label (set by the graph builder). User-defined template PolicyGates in
+	// namespaces like platform-policies have neither of these labels.
+	var templateGates []v1alpha1.PolicyGate
+	for _, g := range gates.Items {
+		if _, isGraphInstance := g.Labels["internal.kro.run/graph-name"]; isGraphInstance {
+			continue
+		}
+		if _, isBundleInstance := g.Labels["kardinal.io/bundle"]; isBundleInstance {
+			continue
+		}
+		templateGates = append(templateGates, g)
+	}
+
+	return formatPolicyGateTable(w, templateGates)
 }
 
 func formatPolicyGateTable(w io.Writer, gates []v1alpha1.PolicyGate) error {


### PR DESCRIPTION
Fixes #285. Filters out Graph-managed PolicyGate instances (internal.kro.run/graph-name + kardinal.io/bundle labels). Lists across all namespaces so template gates in platform-policies are shown. Journey 3 pass criteria now satisfied.

Before: 60+ rows. After: 2 rows (template gates with scope, applies-to, recheckInterval).