### PR TITLE
fix(cli): validate image repository format on bundle creation

### DIFF
--- a/cmd/kardinal/cmd/cli_test.go
+++ b/cmd/kardinal/cmd/cli_test.go
@@ -60,6 +60,33 @@ func TestCreateBundle_CreatesBundle(t *testing.T) {
 	assert.Contains(t, buf.String(), "nginx-demo")
 }
 
+// TestCreateBundle_RejectsMalformedImage verifies that image references with
+// invalid characters are rejected before creating a Bundle (#283).
+func TestCreateBundle_RejectsMalformedImage(t *testing.T) {
+	s := cliTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	tests := []struct {
+		image   string
+		wantErr bool
+	}{
+		{"ghcr.io/pnz1990/app:sha-abc1234", false},
+		{"nginx:1.29", false},
+		{"nginx", false},
+		{"!!! bad", true},
+		{"space bad", true},
+	}
+	for _, tc := range tests {
+		var buf bytes.Buffer
+		err := createBundleFn(&buf, c, "default", "nginx-demo", []string{tc.image}, "image")
+		if tc.wantErr {
+			require.Error(t, err, "image %q must be rejected", tc.image)
+		} else {
+			require.NoError(t, err, "image %q must be accepted", tc.image)
+		}
+	}
+}
+
 // TestRollback_CreatesBundleWithRollbackOf verifies rollback bundle creation.
 // The rollback command now queries PromotionStep history (not Bundle.Phase) to find
 // the last Verified bundle for the target environment (#264).

--- a/cmd/kardinal/cmd/create_bundle.go
+++ b/cmd/kardinal/cmd/create_bundle.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +26,12 @@ import (
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 )
+
+// imageRepoPattern matches valid OCI image repository references.
+// Valid: nginx, docker.io/library/nginx, ghcr.io/org/repo
+// Invalid: "not valid@@@", " ", spaces, multiple colons in unusual positions
+// This is a best-effort check; the full OCI spec is more complex.
+var imageRepoPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._\-/]*$`)
 
 func newCreateCmd() *cobra.Command {
 	create := &cobra.Command{
@@ -69,6 +76,12 @@ func createBundleFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Cli
 	var imageRefs []v1alpha1.ImageRef
 	for _, img := range images {
 		repo, tag := splitImageRef(img)
+		// Validate that the repository portion looks like a valid OCI image reference.
+		// This prevents silently-succeeding bundles with obviously wrong image strings
+		// (e.g. "not-valid-image@@@") that would later fail kustomize-set-image.
+		if repo != "" && !imageRepoPattern.MatchString(repo) {
+			return fmt.Errorf("invalid image repository %q: must match [a-zA-Z0-9][a-zA-Z0-9._-/]* (e.g. ghcr.io/org/image)", repo)
+		}
 		imageRefs = append(imageRefs, v1alpha1.ImageRef{
 			Repository: repo,
 			Tag:        tag,


### PR DESCRIPTION
Fixes #283. Validates image repo format before creating Bundle. Prevents bundles with '!!! bad', spaces etc. from silently proceeding to promotion. Test included.