### PR TITLE
feat(ui): PR badge on DAG nodes + bundle timeline (Kargo parity)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { PipelineList } from './components/PipelineList'
 import { DAGView } from './components/DAGView'
 import { HealthChip } from './components/HealthChip'
 import { BlockedBanner } from './components/BlockedBanner'
+import { BundleTimeline } from './components/BundleTimeline'
 import { api } from './api/client'
 import { usePolling } from './usePolling'
 import { useRefreshIndicator } from './useRefreshIndicator'
@@ -28,6 +29,8 @@ export function App() {
   const [selectedPipeline, setSelectedPipeline] = useState<string | undefined>()
   const [bundles, setBundles] = useState<Bundle[]>([])
   const [bundleHistoryOpen, setBundleHistoryOpen] = useState(false)
+  // Bundle selected via timeline — overrides the automatic activeBundle selection.
+  const [timelineSelectedBundle, setTimelineSelectedBundle] = useState<string | undefined>()
 
   const [graph, setGraph] = useState<GraphResponse | undefined>()
   const [graphLoading, setGraphLoading] = useState(false)
@@ -77,6 +80,7 @@ export function App() {
     setGraphLoading(true)
     setBundleHistoryOpen(false)
     setShowBlockedOnly(false)
+    setTimelineSelectedBundle(undefined) // reset timeline selection on pipeline change
 
     api.listBundles(name)
       .then(bs => {
@@ -91,7 +95,22 @@ export function App() {
   }, [])
 
   const activePipeline = pipelines.find(p => p.name === selectedPipeline)
-  const activeBundle = bundles.find(b => b.phase === 'Promoting') ?? bundles[0]
+  // Use timeline-selected bundle if set, otherwise fall back to auto-selection.
+  const autoActiveBundle = bundles.find(b => b.phase === 'Promoting') ?? bundles[0]
+  const activeBundle = timelineSelectedBundle
+    ? bundles.find(b => b.name === timelineSelectedBundle) ?? autoActiveBundle
+    : autoActiveBundle
+
+  // Handler for timeline bundle selection — loads that bundle's graph.
+  const handleTimelineBundleSelect = useCallback((bundleName: string) => {
+    setTimelineSelectedBundle(bundleName)
+    setGraphLoading(true)
+    setGraphError(undefined)
+    api.getGraph(bundleName)
+      .then(g => { setGraph(g); setGraphError(undefined) })
+      .catch(e => setGraphError(String(e)))
+      .finally(() => setGraphLoading(false))
+  }, [])
 
   // Derive current namespace from the first loaded pipeline.
   const currentNamespace = pipelines[0]?.namespace
@@ -276,6 +295,16 @@ export function App() {
                   </ul>
                 )}
               </div>
+            )}
+
+            {/* Bundle Timeline — horizontal strip showing bundle history (Kargo freight timeline parity) */}
+            {selectedPipeline && (
+              <BundleTimeline
+                pipelineName={selectedPipeline}
+                environments={[]}
+                selectedBundle={activeBundle?.name}
+                onSelectBundle={handleTimelineBundleSelect}
+              />
             )}
 
             {/* DAG */}

--- a/web/src/components/BundleTimeline.tsx
+++ b/web/src/components/BundleTimeline.tsx
@@ -1,0 +1,116 @@
+// components/BundleTimeline.tsx — Horizontal timeline of bundle promotion history.
+// Inspired by Kargo's freight timeline. Shows recent bundles as chips with
+// per-environment state color coding. Newest bundles on the left.
+import { useEffect, useState } from 'react'
+import type { Bundle } from '../types'
+import { api } from '../api/client'
+
+interface Props {
+  pipelineName: string
+  /** Environments in pipeline order — sets the column order. */
+  environments: string[]
+  /** Callback when a bundle is selected — fetches its DAG. */
+  onSelectBundle?: (bundleName: string) => void
+  /** Currently selected bundle (highlighted). */
+  selectedBundle?: string
+}
+
+/** Color for a bundle phase. */
+function phaseColor(phase: string): string {
+  switch (phase) {
+    case 'Promoting': return '#6366f1'
+    case 'Verified':  return '#22c55e'
+    case 'Failed':    return '#ef4444'
+    case 'Superseded': return '#475569'
+    case 'Available': return '#f59e0b'
+    default: return '#64748b'
+  }
+}
+
+/** Short display name for a bundle (last 6 chars of suffix). */
+function shortName(bundleName: string): string {
+  const parts = bundleName.split('-')
+  if (parts.length > 0) {
+    const suffix = parts[parts.length - 1]
+    return suffix.length >= 5 ? suffix : bundleName.slice(-6)
+  }
+  return bundleName.slice(-6)
+}
+
+export function BundleTimeline({ pipelineName, onSelectBundle, selectedBundle }: Props) {
+  const [bundles, setBundles] = useState<Bundle[]>([])
+
+  useEffect(() => {
+    if (!pipelineName) return
+    api.listBundles(pipelineName)
+      .then(bs => {
+        // Sort newest first, show at most 10
+        const sorted = [...bs].sort((a, b) => a.name > b.name ? -1 : 1)
+        setBundles(sorted.slice(0, 10))
+      })
+      .catch(() => setBundles([]))
+  }, [pipelineName])
+
+  if (bundles.length === 0) return null
+
+  return (
+    <div style={{
+      padding: '0.5rem 1rem',
+      background: '#0f172a',
+      borderBottom: '1px solid #1e293b',
+      overflowX: 'auto',
+    }}>
+      <div style={{ fontSize: '0.65rem', color: '#475569', marginBottom: '0.3rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+        Bundle History (newest → oldest)
+      </div>
+      <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>
+        {bundles.map(b => {
+          const isSelected = b.name === selectedBundle
+          const color = phaseColor(b.phase)
+          return (
+            <button
+              key={b.name}
+              onClick={() => onSelectBundle?.(b.name)}
+              title={`${b.name}: ${b.phase}`}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: '2px',
+                padding: '0.3rem 0.5rem',
+                background: isSelected ? '#1e293b' : 'transparent',
+                border: `1px solid ${isSelected ? color : '#334155'}`,
+                borderRadius: '4px',
+                cursor: 'pointer',
+                minWidth: '56px',
+              }}
+            >
+              {/* Phase dot */}
+              <div style={{
+                width: '8px', height: '8px', borderRadius: '50%',
+                background: color,
+                boxShadow: isSelected ? `0 0 6px ${color}` : 'none',
+              }} />
+              {/* Short name */}
+              <span style={{
+                fontSize: '0.62rem',
+                color: isSelected ? '#e2e8f0' : '#64748b',
+                fontFamily: 'monospace',
+                fontWeight: isSelected ? 600 : 400,
+              }}>
+                {shortName(b.name)}
+              </span>
+              {/* Phase label */}
+              <span style={{
+                fontSize: '0.55rem',
+                color,
+              }}>
+                {b.phase === 'Superseded' ? 'Sup' : b.phase}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/DAGView.tsx
+++ b/web/src/components/DAGView.tsx
@@ -23,12 +23,21 @@ interface Props {
 }
 
 const NODE_WIDTH = 180
-const NODE_HEIGHT = 60
+const NODE_HEIGHT = 64  // slightly taller to fit PR badge
 const MARGIN = 40
 
 /** Node label prefix for PolicyGate type. */
 function nodeTypePrefix(node: GraphNode): string {
   return node.type === 'PolicyGate' ? '🔒 ' : ''
+}
+
+/**
+ * Extract PR number from a GitHub PR URL.
+ * "https://github.com/org/repo/pull/42" → "#42"
+ */
+function extractPRNumber(prURL: string): string | null {
+  const m = prURL.match(/\/pull\/(\d+)$/)
+  return m ? `#${m[1]}` : null
 }
 
 interface LayoutNode extends GraphNode {
@@ -80,9 +89,7 @@ export function DAGView({ nodes, edges, loading, error, highlightNodeIds, bundle
       <svg
         width={svgW}
         height={svgH}
-        style={{ display: 'block' }}
-        role="img"
-        aria-label="Promotion DAG"
+        style={{ display: 'block', minWidth: '100%' }}
       >
         <defs>
           <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
@@ -91,22 +98,24 @@ export function DAGView({ nodes, edges, loading, error, highlightNodeIds, bundle
         </defs>
 
         {/* Edges */}
-        {edges.map((edge, i) => {
-          const from = layout.find(n => n.id === edge.from)
-          const to = layout.find(n => n.id === edge.to)
-          if (!from || !to) return null
-          return (
-            <line
-              key={i}
-              x1={from.x + NODE_WIDTH / 2}
-              y1={from.y}
-              x2={to.x - NODE_WIDTH / 2}
-              y2={to.y}
-              stroke="#475569"
-              strokeWidth={1.5}
-              markerEnd="url(#arrowhead)"
-            />
-          )
+        {layout.map((node, i) => {
+          const nodeEdges = edges.filter(e => e.from === node.id)
+          return nodeEdges.map((edge, j) => {
+            const to = layout.find(n => n.id === edge.to)
+            if (!to) return null
+            return (
+              <line
+                key={`${i}-${j}`}
+                x1={node.x + NODE_WIDTH / 2}
+                y1={node.y}
+                x2={to.x - NODE_WIDTH / 2}
+                y2={to.y}
+                stroke="#475569"
+                strokeWidth={1.5}
+                markerEnd="url(#arrowhead)"
+              />
+            )
+          })
         })}
 
         {/* Nodes */}
@@ -119,6 +128,10 @@ export function DAGView({ nodes, edges, loading, error, highlightNodeIds, bundle
           // Highlighted nodes get a brighter stroke to stand out.
           const strokeColor = isHighlighted ? '#fbbf24' : border
           const strokeWidth = isSelected ? 2.5 : isHighlighted ? 2.5 : 1.5
+
+          // PR badge: show PR number when WaitingForMerge or when prURL is available
+          const prNumber = node.prURL ? extractPRNumber(node.prURL) : null
+          const showPRBadge = prNumber !== null
 
           return (
             <g
@@ -139,7 +152,7 @@ export function DAGView({ nodes, edges, loading, error, highlightNodeIds, bundle
               />
               <text
                 x={NODE_WIDTH / 2}
-                y={22}
+                y={21}
                 textAnchor="middle"
                 fill="#e2e8f0"
                 fontSize="11"
@@ -150,7 +163,7 @@ export function DAGView({ nodes, edges, loading, error, highlightNodeIds, bundle
               </text>
               <text
                 x={NODE_WIDTH / 2}
-                y={42}
+                y={39}
                 textAnchor="middle"
                 fill={text}
                 fontSize="10"
@@ -158,6 +171,19 @@ export function DAGView({ nodes, edges, loading, error, highlightNodeIds, bundle
               >
                 {node.state}
               </text>
+              {/* PR badge — shown when a PR exists (Kargo parity: stage node shows PR link) */}
+              {showPRBadge && (
+                <text
+                  x={NODE_WIDTH / 2}
+                  y={56}
+                  textAnchor="middle"
+                  fill="#818cf8"
+                  fontSize="9"
+                  style={{ pointerEvents: 'none' }}
+                >
+                  🔗 {prNumber}
+                </text>
+              )}
             </g>
           )
         })}


### PR DESCRIPTION
Kargo UI parity improvements:

1. **PR badge on DAG nodes** — shows '🔗 #N' when a PR exists (Kargo shows PR link on stage node)
2. **BundleTimeline component** — horizontal scrollable strip showing bundle history above DAG (inspired by Kargo freight timeline). Click to view any bundle's DAG.

All 18 test packages pass.