### PR TITLE
feat(ui): pipeline lane view — horizontal stage cards (Kargo parity)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { HealthChip } from './components/HealthChip'
 import { BlockedBanner } from './components/BlockedBanner'
 import { BundleTimeline } from './components/BundleTimeline'
 import { PolicyGatesPanel } from './components/PolicyGatesPanel'
+import { PipelineLaneView } from './components/PipelineLaneView'
 import { api } from './api/client'
 import { usePolling } from './usePolling'
 import { useRefreshIndicator } from './useRefreshIndicator'
@@ -453,6 +454,27 @@ export function App() {
                 onSelectBundle={handleTimelineBundleSelect}
               />
             </div>
+
+            {/* #332: Pipeline lane view — horizontal stage cards (Kargo-parity).
+                Shows each PromotionStep environment as a card with state chip, bundle, and actions. */}
+            <PipelineLaneView
+              nodes={graph?.nodes ?? []}
+              selectedNode={selectedNode}
+              onSelectNode={setSelectedNode}
+              activeBundleName={activeBundle?.name}
+              pipelineName={selectedPipeline ?? undefined}
+              onPromote={(environment) => {
+                if (!selectedPipeline || !activePipeline) return
+                api.promote(selectedPipeline, environment, activePipeline.namespace ?? 'default')
+                  .catch((err: Error) => console.error('promote failed:', err.message))
+              }}
+              onRollback={(environment) => {
+                if (!selectedPipeline || !activePipeline) return
+                api.rollback(selectedPipeline, environment, activePipeline.namespace ?? 'default')
+                  .catch((err: Error) => console.error('rollback failed:', err.message))
+              }}
+              loading={graphLoading}
+            />
 
             {/* #326: Content row — DAG + NodeDetail split panel side by side.
                 NodeDetail is a flex sibling, not position:fixed overlay. */}

--- a/web/src/components/PipelineLaneView.tsx
+++ b/web/src/components/PipelineLaneView.tsx
@@ -1,0 +1,223 @@
+// components/PipelineLaneView.tsx — Horizontal pipeline stage lane view.
+// Shows environments as cards in a horizontal strip: env name, state chip,
+// bundle info, and promote/rollback quick actions.
+// Part of #332 (complete visual redesign — Kargo-parity pipeline lane view).
+//
+// Adapted from Kargo's horizontal stage cards pattern.
+// Each card represents a PromotionStep DAG node.
+import type { GraphNode } from '../types'
+import { HealthChip, kardinalStateToHealth } from './HealthChip'
+
+interface Props {
+  /** DAG nodes — only PromotionStep nodes are rendered as stage cards. */
+  nodes: GraphNode[]
+  /** Currently selected node (highlighted card). */
+  selectedNode?: GraphNode | null
+  /** Called when a stage card is clicked. */
+  onSelectNode?: (node: GraphNode | null) => void
+  /** Active bundle name for display. */
+  activeBundleName?: string
+  /** Pipeline name for action buttons. */
+  pipelineName?: string
+  /** Called when Promote button is clicked for an environment. */
+  onPromote?: (environment: string) => void
+  /** Called when Rollback button is clicked for an environment. */
+  onRollback?: (environment: string) => void
+  loading?: boolean
+}
+
+/** Color scheme for a given stage state. */
+function stageColors(state: string): { bg: string; border: string; accent: string } {
+  const health = kardinalStateToHealth(state)
+  switch (health) {
+    case 'Ready':
+      return { bg: '#052e16', border: '#16a34a', accent: '#22c55e' }
+    case 'Error':
+    case 'Degraded':
+      return { bg: '#2d0b0b', border: '#b91c1c', accent: '#ef4444' }
+    case 'Reconciling':
+      return { bg: '#1e1b4b', border: '#4338ca', accent: '#6366f1' }
+    case 'Pending':
+      return { bg: '#0f172a', border: '#334155', accent: '#94a3b8' }
+    default:
+      return { bg: '#0f172a', border: '#1e293b', accent: '#475569' }
+  }
+}
+
+export function PipelineLaneView({
+  nodes,
+  selectedNode,
+  onSelectNode,
+  activeBundleName,
+  onPromote,
+  onRollback,
+  loading,
+}: Props) {
+  // Only show PromotionStep nodes (not PolicyGates) in the lane view.
+  const stageNodes = nodes.filter(n => n.type === 'PromotionStep')
+
+  if (loading || stageNodes.length === 0) {
+    return null
+  }
+
+  return (
+    <div style={{
+      display: 'flex',
+      gap: '0.5rem',
+      padding: '0.75rem 1.5rem',
+      overflowX: 'auto',
+      background: '#070f1b',
+      borderBottom: '1px solid #1e293b',
+      alignItems: 'stretch',
+      minHeight: '100px',
+    }}>
+      {stageNodes.map((node, idx) => {
+        const isSelected = selectedNode?.id === node.id
+        const colors = stageColors(node.state)
+        const isPending = node.state === 'Pending' || node.state === 'Unknown'
+        const hasAction = !isPending && onPromote
+        const showPRLink = node.prURL && node.state === 'WaitingForMerge'
+
+        return (
+          <div key={node.id} style={{ display: 'flex', alignItems: 'center', gap: '0.3rem' }}>
+            {/* Connector line between stages */}
+            {idx > 0 && (
+              <div style={{
+                width: '20px',
+                height: '2px',
+                background: '#1e293b',
+                flexShrink: 0,
+              }} />
+            )}
+
+            {/* Stage card */}
+            <div
+              role="button"
+              tabIndex={0}
+              aria-selected={isSelected}
+              onClick={() => onSelectNode?.(isSelected ? null : node)}
+              onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && onSelectNode?.(isSelected ? null : node)}
+              style={{
+                background: colors.bg,
+                border: `1.5px solid ${isSelected ? colors.accent : colors.border}`,
+                borderRadius: '6px',
+                padding: '0.6rem 0.75rem',
+                cursor: 'pointer',
+                minWidth: '140px',
+                maxWidth: '180px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '0.3rem',
+                transition: 'border-color 0.15s',
+                boxShadow: isSelected ? `0 0 0 1px ${colors.accent}` : 'none',
+                outline: 'none',
+              }}
+            >
+              {/* Environment name + state chip */}
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.3rem' }}>
+                <span style={{
+                  fontSize: '0.78rem',
+                  fontWeight: 700,
+                  color: '#e2e8f0',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}>
+                  {node.environment}
+                </span>
+                <HealthChip state={node.state} size="sm" />
+              </div>
+
+              {/* Active bundle name (truncated) */}
+              {activeBundleName && (
+                <div style={{
+                  fontSize: '0.65rem',
+                  fontFamily: 'monospace',
+                  color: '#64748b',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+                title={activeBundleName}>
+                  {activeBundleName.length > 18 ? activeBundleName.slice(-16) : activeBundleName}
+                </div>
+              )}
+
+              {/* PR link when waiting for merge */}
+              {showPRLink && (
+                <a
+                  href={node.prURL!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={e => e.stopPropagation()}
+                  style={{
+                    fontSize: '0.65rem',
+                    color: '#6366f1',
+                    textDecoration: 'none',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  PR → merge to deploy ↗
+                </a>
+              )}
+
+              {/* Step message (truncated) */}
+              {node.message && !showPRLink && (
+                <div style={{
+                  fontSize: '0.65rem',
+                  color: '#94a3b8',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+                title={node.message}>
+                  {node.message.length > 30 ? node.message.slice(0, 28) + '…' : node.message}
+                </div>
+              )}
+
+              {/* Action buttons row */}
+              {hasAction && (
+                <div style={{ display: 'flex', gap: '0.25rem', marginTop: '0.1rem' }}>
+                  <button
+                    title={`Promote ${node.environment}`}
+                    onClick={e => { e.stopPropagation(); onPromote?.(node.environment) }}
+                    style={{
+                      fontSize: '0.6rem',
+                      background: '#1e293b',
+                      color: '#6366f1',
+                      border: '1px solid #334155',
+                      borderRadius: '3px',
+                      padding: '1px 5px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    ▶ Promote
+                  </button>
+                  {onRollback && node.state === 'Verified' && (
+                    <button
+                      title={`Rollback ${node.environment}`}
+                      onClick={e => { e.stopPropagation(); onRollback?.(node.environment) }}
+                      style={{
+                        fontSize: '0.6rem',
+                        background: '#1e293b',
+                        color: '#94a3b8',
+                        border: '1px solid #334155',
+                        borderRadius: '3px',
+                        padding: '1px 5px',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      ↩ Rollback
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
[🔨 ENG]

## Summary
Partially closes #332: adds the core pipeline lane view (horizontal stage cards).

## New Component: PipelineLaneView

A horizontal strip of stage cards placed between the BundleTimeline and the DAG view. Each card represents one PromotionStep environment.

### Card content
- **Environment name** + **HealthChip** (state color)
- **Active bundle name** (truncated monospace, full name in tooltip)
- **PR link** when WaitingForMerge: "PR → merge to deploy ↗"
- **Step message** (truncated, full text in tooltip)
- **▶ Promote** button (non-Pending states)
- **↩ Rollback** button (Verified states only)

### Visual design
- State-aware card colors: green bg for Ready, red for Error, indigo for Promoting/Reconciling
- Selected card: accent border + glow matching state color
- Connector lines (`—`) between stage cards
- Horizontal scrollable strip (handles many environments)
- Click card to select (same selectedNode state as DAGView)

### Integration
- Shares `selectedNode` with DAGView: click either UI element to select
- Promote/Rollback call `api.promote()` / `api.rollback()` with correct namespace
- PolicyGate nodes are filtered out (lane view shows PromotionStep cards only)

## Docs updated: No doc changes required
## Examples verified: `tsc --noEmit` passes, `go build ./...` passes