### PR TITLE
feat(ui): pipeline health summary — multi-segment state bar in sidebar

### DIFF
--- a/cmd/kardinal-controller/ui_api.go
+++ b/cmd/kardinal-controller/ui_api.go
@@ -175,6 +175,11 @@ func (s *uiAPIServer) handlePipelines(w http.ResponseWriter, r *http.Request) {
 	}
 	activeBundles := make(map[string]*activeBundleEntry)
 	phaseOrder := map[string]int{"Promoting": 3, "Available": 2, "Verified": 1, "Failed": 0, "Superseded": -1}
+	// Build a name→phase index for existing bundle lookup.
+	bundlePhase := make(map[string]string, len(bundleList.Items))
+	for _, b := range bundleList.Items {
+		bundlePhase[b.Name] = b.Status.Phase
+	}
 	for _, b := range bundleList.Items {
 		if b.Spec.Pipeline == "" {
 			continue
@@ -184,17 +189,7 @@ func (s *uiAPIServer) handlePipelines(w http.ResponseWriter, r *http.Request) {
 		newScore := phaseOrder[b.Status.Phase]
 		existingScore := -99
 		if existing != nil {
-			existingScore = phaseOrder[b.Labels["kardinal.io/phase"]] // use score from existing
-			// Use the phase of the existing entry's name would need a reverse lookup
-			// Simpler: just compare phase strings directly
-			existingPhaseScore := 0
-			for _, bl := range bundleList.Items {
-				if bl.Name == existing.name {
-					existingPhaseScore = phaseOrder[bl.Status.Phase]
-					break
-				}
-			}
-			existingScore = existingPhaseScore
+			existingScore = phaseOrder[bundlePhase[existing.name]]
 		}
 		if existing == nil || newScore > existingScore {
 			envStates := make(map[string]string, len(b.Status.Environments))

--- a/cmd/kardinal-controller/ui_api.go
+++ b/cmd/kardinal-controller/ui_api.go
@@ -42,6 +42,10 @@ type uiPipelineResponse struct {
 	EnvironmentCount int    `json:"environmentCount"`
 	ActiveBundleName string `json:"activeBundleName,omitempty"`
 	Paused           bool   `json:"paused,omitempty"` // true when spec.paused=true (#328)
+	// #342: per-environment state counts for the multi-segment health bar.
+	// Derived from the active Bundle's status.environments.
+	// Keys are environment names, values are the promotion phase.
+	EnvironmentStates map[string]string `json:"environmentStates,omitempty"`
 }
 
 // uiBundleResponse is the JSON shape for a Bundle in the UI API.
@@ -157,15 +161,72 @@ func (s *uiAPIServer) handlePipelines(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
+
+	// Build per-pipeline active bundle index:
+	// For each pipeline, find the most recent Promoting (or Verified) Bundle
+	// and read its per-environment states for the health bar (#342).
+	var bundleList v1alpha1.BundleList
+	// List all bundles — ignore error (best-effort; env states will be nil on error)
+	_ = s.client.List(r.Context(), &bundleList)
+	// Index: pipelineName → active bundle (prefer Promoting > Available > Verified)
+	type activeBundleEntry struct {
+		name      string
+		envStates map[string]string
+	}
+	activeBundles := make(map[string]*activeBundleEntry)
+	phaseOrder := map[string]int{"Promoting": 3, "Available": 2, "Verified": 1, "Failed": 0, "Superseded": -1}
+	for _, b := range bundleList.Items {
+		if b.Spec.Pipeline == "" {
+			continue
+		}
+		key := fmt.Sprintf("%s/%s", b.Namespace, b.Spec.Pipeline)
+		existing := activeBundles[key]
+		newScore := phaseOrder[b.Status.Phase]
+		existingScore := -99
+		if existing != nil {
+			existingScore = phaseOrder[b.Labels["kardinal.io/phase"]] // use score from existing
+			// Use the phase of the existing entry's name would need a reverse lookup
+			// Simpler: just compare phase strings directly
+			existingPhaseScore := 0
+			for _, bl := range bundleList.Items {
+				if bl.Name == existing.name {
+					existingPhaseScore = phaseOrder[bl.Status.Phase]
+					break
+				}
+			}
+			existingScore = existingPhaseScore
+		}
+		if existing == nil || newScore > existingScore {
+			envStates := make(map[string]string, len(b.Status.Environments))
+			for _, env := range b.Status.Environments {
+				if env.Phase != "" {
+					envStates[env.Name] = env.Phase
+				}
+			}
+			activeBundles[key] = &activeBundleEntry{
+				name:      b.Name,
+				envStates: envStates,
+			}
+		}
+	}
+
 	result := make([]uiPipelineResponse, 0, len(list.Items))
 	for _, p := range list.Items {
-		result = append(result, uiPipelineResponse{
+		key := fmt.Sprintf("%s/%s", p.Namespace, p.Name)
+		resp := uiPipelineResponse{
 			Name:             p.Name,
 			Namespace:        p.Namespace,
 			Phase:            pipelinePhase(&p),
 			EnvironmentCount: len(p.Spec.Environments),
 			Paused:           p.Spec.Paused,
-		})
+		}
+		if ab := activeBundles[key]; ab != nil {
+			resp.ActiveBundleName = ab.name
+			if len(ab.envStates) > 0 {
+				resp.EnvironmentStates = ab.envStates
+			}
+		}
+		result = append(result, resp)
 	}
 	writeJSON(w, result)
 }

--- a/web/src/components/PipelineList.tsx
+++ b/web/src/components/PipelineList.tsx
@@ -289,22 +289,58 @@ export function PipelineList({ pipelines, selected, onSelect, loading, error }: 
               </div>
             </div>
 
-            {/* Sub-line: env count + active bundle */}
+             {/* Sub-line: env count + health bar + active bundle (#342) */}
             {(bundle || envCount > 0) && (
-              <div style={{ fontSize: '0.7rem', color: '#64748b', display: 'flex', gap: '0.4rem' }}>
-                {envCount > 0 && (
-                  <span>{envCount} env{envCount !== 1 ? 's' : ''}</span>
+              <div style={{ fontSize: '0.7rem', color: '#64748b', display: 'flex', flexDirection: 'column', gap: '0.2rem' }}>
+                {/* Multi-segment health bar when env states are available (#342) */}
+                {p.environmentStates && Object.keys(p.environmentStates).length > 0 ? (
+                  <div style={{ display: 'flex', gap: '0.3rem', alignItems: 'center', flexWrap: 'wrap' }}>
+                    <span>{envCount} env{envCount !== 1 ? 's' : ''}</span>
+                    <span style={{ color: '#1e293b' }}>·</span>
+                    {/* State badges: count per phase */}
+                    {(() => {
+                      const counts: Record<string, number> = {}
+                      for (const phase of Object.values(p.environmentStates!)) {
+                        counts[phase] = (counts[phase] ?? 0) + 1
+                      }
+                      const phaseColor: Record<string, string> = {
+                        Verified: '#22c55e', Promoting: '#6366f1', WaitingForMerge: '#6366f1',
+                        HealthChecking: '#a78bfa', Failed: '#ef4444', Pending: '#475569',
+                      }
+                      return Object.entries(counts).map(([phase, count]) => (
+                        <span key={phase} style={{
+                          fontSize: '0.6rem',
+                          color: phaseColor[phase] ?? '#64748b',
+                          fontWeight: 600,
+                        }} title={`${count} env${count !== 1 ? 's' : ''} in ${phase}`}>
+                          {count} {phase === 'WaitingForMerge' ? 'PR' : phase === 'HealthChecking' ? 'health' : phase.toLowerCase()}
+                        </span>
+                      ))
+                    })()}
+                  </div>
+                ) : (
+                  <div style={{ display: 'flex', gap: '0.4rem' }}>
+                    {envCount > 0 && (
+                      <span>{envCount} env{envCount !== 1 ? 's' : ''}</span>
+                    )}
+                    {bundle && (
+                      <>
+                        {envCount > 0 && <span>·</span>}
+                        <span
+                          style={{ fontFamily: 'monospace', color: '#94a3b8' }}
+                          title={p.activeBundleName}
+                        >
+                          {bundle}
+                        </span>
+                      </>
+                    )}
+                  </div>
                 )}
-                {bundle && (
-                  <>
-                    {envCount > 0 && <span>·</span>}
-                    <span
-                      style={{ fontFamily: 'monospace', color: '#94a3b8' }}
-                      title={p.activeBundleName}
-                    >
-                      {bundle}
-                    </span>
-                  </>
+                {/* Bundle name shown below the health bar when env states are shown */}
+                {p.environmentStates && bundle && (
+                  <span style={{ fontFamily: 'monospace', color: '#94a3b8' }} title={p.activeBundleName}>
+                    {bundle}
+                  </span>
                 )}
               </div>
             )}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -8,6 +8,9 @@ export interface Pipeline {
   activeBundleName?: string
   /** True when the pipeline has spec.paused=true (#328). */
   paused?: boolean
+  /** #342: per-environment promotion phases from active Bundle status.
+   * Keys are environment names, values are the promotion phase (Promoting, Verified, etc.) */
+  environmentStates?: Record<string, string>
 }
 
 export interface Bundle {


### PR DESCRIPTION
[🔨 ENG]

## Summary
Closes #342: multi-segment environment state count bar in the pipeline sidebar.

## Changes

### Backend (ui_api.go)
- `handlePipelines()` now builds an active-bundle index by listing all Bundles
- Picks the most active bundle per pipeline (priority: Promoting > Available > Verified)
- Adds `EnvironmentStates map[string]string` to `uiPipelineResponse`
- Also now populates `ActiveBundleName` (was in struct but not set before!)

### Frontend (types.ts + PipelineList.tsx)
- `Pipeline` type gets `environmentStates?: Record<string, string>`
- When `environmentStates` available: shows color-coded state badges:
  ```
  3 envs · 1 verified · 1 promoting · 1 pr
  ```
  - green = Verified
  - indigo = Promoting/WaitingForMerge  
  - purple = HealthChecking
  - red = Failed
  - gray = Pending
- Falls back to simple `3 envs` display when states unavailable

## Docs updated: No doc changes required
## Examples verified: `tsc --noEmit` + `go test ./cmd/kardinal-controller/...` pass