### PR TITLE
feat(ui): bundle diff panel — compare two bundles field-by-field

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { NodeDetail } from './components/NodeDetail'
 import { HealthChip } from './components/HealthChip'
 import { BlockedBanner } from './components/BlockedBanner'
 import { BundleTimeline } from './components/BundleTimeline'
+import { BundleDiffPanel } from './components/BundleDiffPanel'
 import { PolicyGatesPanel } from './components/PolicyGatesPanel'
 import { PipelineLaneView } from './components/PipelineLaneView'
 import { api } from './api/client'
@@ -50,6 +51,10 @@ export function App() {
 
   // #326: selectedNode lifted from DAGView so NodeDetail is a split-panel sibling.
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null)
+
+  // #338: Bundle diff comparison state.
+  const [compareBundle, setCompareBundle] = useState<string | undefined>()
+  const [showDiffPanel, setShowDiffPanel] = useState(false)
 
   // Refresh indicator: tracks last successful poll for the staleness indicator.
   const { elapsedSeconds, onSuccess: onPollSuccess } = useRefreshIndicator()
@@ -452,8 +457,29 @@ export function App() {
                 bundles={bundles}
                 selectedBundle={activeBundle?.name}
                 onSelectBundle={handleTimelineBundleSelect}
+                compareBundle={compareBundle}
+                onCompareBundle={(name) => {
+                  setCompareBundle(name ?? undefined)
+                  if (!name) setShowDiffPanel(false)
+                }}
+                onCompare={() => setShowDiffPanel(true)}
               />
             </div>
+
+            {/* #338: Bundle diff panel — shows when two bundles are selected for comparison */}
+            {showDiffPanel && compareBundle && activeBundle && (
+              (() => {
+                const compareBundleObj = bundles.find(b => b.name === compareBundle)
+                if (!compareBundleObj) return null
+                return (
+                  <BundleDiffPanel
+                    bundleA={activeBundle}
+                    bundleB={compareBundleObj}
+                    onClose={() => { setShowDiffPanel(false); setCompareBundle(undefined) }}
+                  />
+                )
+              })()
+            )}
 
             {/* #332: Pipeline lane view — horizontal stage cards (Kargo-parity).
                 Shows each PromotionStep environment as a card with state chip, bundle, and actions. */}

--- a/web/src/components/BundleDiffPanel.tsx
+++ b/web/src/components/BundleDiffPanel.tsx
@@ -1,0 +1,241 @@
+// components/BundleDiffPanel.tsx — Side-by-side bundle field comparison.
+// #338: Shows key differences between two Bundle objects. Triggered by
+// shift-clicking a bundle in BundleTimeline and pressing 'Compare'.
+//
+// Adapted from kro-ui InstanceTable.tsx SpecDiffPanel pattern.
+import type { Bundle } from '../types'
+
+interface Props {
+  bundleA: Bundle
+  bundleB: Bundle
+  onClose: () => void
+}
+
+type FieldRow = {
+  label: string
+  valueA: string | null
+  valueB: string | null
+  /** If true, highlight this row as changed */
+  changed: boolean
+}
+
+function truncate(s: string | undefined, max = 40): string {
+  if (!s) return '—'
+  return s.length > max ? s.slice(0, max - 1) + '…' : s
+}
+
+function buildRows(a: Bundle, b: Bundle): FieldRow[] {
+  const rows: FieldRow[] = [
+    {
+      label: 'Phase',
+      valueA: a.phase ?? null,
+      valueB: b.phase ?? null,
+      changed: a.phase !== b.phase,
+    },
+    {
+      label: 'Type',
+      valueA: a.type ?? null,
+      valueB: b.type ?? null,
+      changed: a.type !== b.type,
+    },
+    {
+      label: 'Created',
+      valueA: a.createdAt ? new Date(a.createdAt).toLocaleString() : null,
+      valueB: b.createdAt ? new Date(b.createdAt).toLocaleString() : null,
+      changed: a.createdAt !== b.createdAt,
+    },
+    {
+      label: 'Author',
+      valueA: a.provenance?.author ?? null,
+      valueB: b.provenance?.author ?? null,
+      changed: a.provenance?.author !== b.provenance?.author,
+    },
+    {
+      label: 'Commit SHA',
+      valueA: a.provenance?.commitSHA ? a.provenance.commitSHA.slice(0, 12) : null,
+      valueB: b.provenance?.commitSHA ? b.provenance.commitSHA.slice(0, 12) : null,
+      changed: a.provenance?.commitSHA !== b.provenance?.commitSHA,
+    },
+    {
+      label: 'CI Run',
+      valueA: a.provenance?.ciRunURL ?? null,
+      valueB: b.provenance?.ciRunURL ?? null,
+      changed: a.provenance?.ciRunURL !== b.provenance?.ciRunURL,
+    },
+  ]
+  return rows
+}
+
+export function BundleDiffPanel({ bundleA, bundleB, onClose }: Props) {
+  const rows = buildRows(bundleA, bundleB)
+  const changedCount = rows.filter(r => r.changed).length
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0, left: 0, right: 0, bottom: 0,
+      background: 'rgba(0,0,0,0.7)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000,
+    }}
+    onClick={onClose}
+    role="dialog"
+    aria-modal="true"
+    aria-label="Bundle comparison"
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        style={{
+          background: '#0f172a',
+          border: '1px solid #334155',
+          borderRadius: '8px',
+          padding: '1.5rem',
+          maxWidth: '700px',
+          width: '95%',
+          maxHeight: '80vh',
+          overflowY: 'auto',
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.25rem' }}>
+          <div>
+            <h2 style={{ fontSize: '1rem', fontWeight: 700, color: '#e2e8f0', margin: 0 }}>
+              Bundle Comparison
+            </h2>
+            <p style={{ fontSize: '0.75rem', color: '#64748b', margin: '0.25rem 0 0' }}>
+              {changedCount} field{changedCount !== 1 ? 's' : ''} differ between these bundles
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close comparison"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: '#64748b',
+              cursor: 'pointer',
+              fontSize: '1.2rem',
+              padding: '0 4px',
+              lineHeight: 1,
+            }}
+          >×</button>
+        </div>
+
+        {/* Column headers */}
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: '140px 1fr 1fr',
+          gap: '0.5rem',
+          marginBottom: '0.5rem',
+        }}>
+          <div />
+          <div style={{ fontSize: '0.7rem', color: '#475569', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+            Bundle A
+          </div>
+          <div style={{ fontSize: '0.7rem', color: '#475569', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+            Bundle B
+          </div>
+        </div>
+
+        {/* Bundle names */}
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: '140px 1fr 1fr',
+          gap: '0.5rem',
+          marginBottom: '0.75rem',
+          background: '#1e293b',
+          borderRadius: '4px',
+          padding: '0.4rem 0.6rem',
+        }}>
+          <span style={{ fontSize: '0.75rem', color: '#94a3b8' }}>Name</span>
+          <span style={{ fontFamily: 'monospace', fontSize: '0.75rem', color: '#7dd3fc' }} title={bundleA.name}>
+            {truncate(bundleA.name, 28)}
+          </span>
+          <span style={{ fontFamily: 'monospace', fontSize: '0.75rem', color: '#7dd3fc' }} title={bundleB.name}>
+            {truncate(bundleB.name, 28)}
+          </span>
+        </div>
+
+        {/* Diff rows */}
+        {rows.map(row => (
+          <div key={row.label} style={{
+            display: 'grid',
+            gridTemplateColumns: '140px 1fr 1fr',
+            gap: '0.5rem',
+            marginBottom: '0.3rem',
+            background: row.changed ? '#1a1000' : 'transparent',
+            border: row.changed ? '1px solid #78350f' : '1px solid transparent',
+            borderRadius: '4px',
+            padding: '0.35rem 0.6rem',
+          }}>
+            <span style={{
+              fontSize: '0.75rem',
+              color: row.changed ? '#fbbf24' : '#64748b',
+              fontWeight: row.changed ? 600 : 400,
+            }}>
+              {row.changed ? '▸ ' : ''}{row.label}
+            </span>
+            <DiffCell value={row.valueA} changed={row.changed} isLink={row.label === 'CI Run'} />
+            <DiffCell value={row.valueB} changed={row.changed} isLink={row.label === 'CI Run'} />
+          </div>
+        ))}
+
+        {changedCount === 0 && (
+          <p style={{ textAlign: 'center', color: '#22c55e', fontSize: '0.85rem', marginTop: '0.5rem' }}>
+            ✓ No differences found between these bundles.
+          </p>
+        )}
+
+        <div style={{ marginTop: '1rem', textAlign: 'right' }}>
+          <button
+            onClick={onClose}
+            style={{
+              background: '#1e293b',
+              border: '1px solid #334155',
+              color: '#e2e8f0',
+              borderRadius: '4px',
+              padding: '0.4rem 1rem',
+              cursor: 'pointer',
+              fontSize: '0.82rem',
+            }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DiffCell({ value, changed, isLink }: { value: string | null; changed: boolean; isLink?: boolean }) {
+  if (!value) {
+    return <span style={{ fontSize: '0.75rem', color: '#334155' }}>—</span>
+  }
+  if (isLink && value.startsWith('http')) {
+    return (
+      <a
+        href={value}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ fontSize: '0.75rem', color: '#6366f1', fontFamily: 'monospace' }}
+        title={value}
+      >
+        {truncate(value, 30)}
+      </a>
+    )
+  }
+  return (
+    <span
+      style={{
+        fontSize: '0.75rem',
+        color: changed ? '#fbbf24' : '#94a3b8',
+        fontFamily: 'monospace',
+      }}
+      title={value}
+    >
+      {truncate(value, 30)}
+    </span>
+  )
+}

--- a/web/src/components/BundleTimeline.tsx
+++ b/web/src/components/BundleTimeline.tsx
@@ -4,6 +4,9 @@
 //
 // Bundles are passed as a prop (managed by App) rather than fetched independently,
 // avoiding duplicate requests and stale-state races (issue #321).
+//
+// #338: Shift-click selects a second bundle for comparison.
+// When two bundles are selected, a "Compare" button appears.
 import type { Bundle } from '../types'
 
 interface Props {
@@ -13,6 +16,12 @@ interface Props {
   onSelectBundle?: (bundleName: string) => void
   /** Currently selected bundle (highlighted). */
   selectedBundle?: string
+  /** #338: Second bundle selected for comparison (shift-click). */
+  compareBundle?: string
+  /** Called when user shift-clicks a bundle to start comparison. */
+  onCompareBundle?: (bundleName: string | null) => void
+  /** Called when user clicks the Compare button. */
+  onCompare?: () => void
 }
 
 /** Color for a bundle phase. */
@@ -37,7 +46,7 @@ function shortName(bundleName: string): string {
   return bundleName.slice(-6)
 }
 
-export function BundleTimeline({ bundles, onSelectBundle, selectedBundle }: Props) {
+export function BundleTimeline({ bundles, onSelectBundle, selectedBundle, compareBundle, onCompareBundle, onCompare }: Props) {
   // Sort newest-first by createdAt timestamp (ISO 8601), falling back to name (#337).
   // Name fallback ensures stability when createdAt is not yet populated.
   const sorted = [...bundles]
@@ -52,6 +61,8 @@ export function BundleTimeline({ bundles, onSelectBundle, selectedBundle }: Prop
 
   if (sorted.length === 0) return null
 
+  const showCompare = compareBundle && selectedBundle && compareBundle !== selectedBundle
+
   return (
     <div style={{
       padding: '0.5rem 1rem',
@@ -59,29 +70,80 @@ export function BundleTimeline({ bundles, onSelectBundle, selectedBundle }: Prop
       borderBottom: '1px solid #1e293b',
       overflowX: 'auto',
     }}>
-      <div style={{ fontSize: '0.65rem', color: '#475569', marginBottom: '0.3rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-        Bundle History (newest → oldest)
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.3rem' }}>
+        <span style={{ fontSize: '0.65rem', color: '#475569', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Bundle History (newest → oldest)
+        </span>
+        {/* #338: Compare button appears when two bundles are selected */}
+        {showCompare && (
+          <button
+            onClick={onCompare}
+            style={{
+              fontSize: '0.65rem',
+              background: '#1e1b4b',
+              color: '#a5b4fc',
+              border: '1px solid #4338ca',
+              borderRadius: '3px',
+              padding: '1px 6px',
+              cursor: 'pointer',
+              fontWeight: 600,
+            }}
+            title="Compare selected bundles"
+          >
+            Compare ↔
+          </button>
+        )}
+        {compareBundle && (
+          <button
+            onClick={() => onCompareBundle?.(null)}
+            style={{
+              fontSize: '0.65rem',
+              background: 'none',
+              color: '#64748b',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '0',
+            }}
+            title="Clear comparison selection"
+          >
+            × clear
+          </button>
+        )}
+        {!compareBundle && bundles.length >= 2 && (
+          <span style={{ fontSize: '0.6rem', color: '#334155' }}>
+            Shift-click to compare
+          </span>
+        )}
       </div>
       <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>
         {sorted.map(b => {
           const isSelected = b.name === selectedBundle
+          const isCompare = b.name === compareBundle
           const color = phaseColor(b.phase)
           return (
             <button
               key={b.name}
-              onClick={() => onSelectBundle?.(b.name)}
-              title={`${b.name}: ${b.phase}`}
+              onClick={(e) => {
+                if (e.shiftKey) {
+                  // #338: shift-click selects for comparison
+                  if (onCompareBundle) onCompareBundle(isCompare ? null : b.name)
+                } else {
+                  onSelectBundle?.(b.name)
+                }
+              }}
+              title={`${b.name}: ${b.phase}${isCompare ? ' (comparison target)' : ''}${'\nShift-click to compare'}`}
               style={{
                 display: 'flex',
                 flexDirection: 'column',
                 alignItems: 'center',
                 gap: '2px',
                 padding: '0.3rem 0.5rem',
-                background: isSelected ? '#1e293b' : 'transparent',
-                border: `1px solid ${isSelected ? color : '#334155'}`,
+                background: isCompare ? '#1e1b4b' : isSelected ? '#1e293b' : 'transparent',
+                border: `1px solid ${isCompare ? '#4338ca' : isSelected ? color : '#334155'}`,
                 borderRadius: '4px',
                 cursor: 'pointer',
                 minWidth: '56px',
+                outline: isCompare ? '1px solid #6366f1' : 'none',
               }}
             >
               {/* Phase dot */}
@@ -93,9 +155,9 @@ export function BundleTimeline({ bundles, onSelectBundle, selectedBundle }: Prop
               {/* Short name */}
               <span style={{
                 fontSize: '0.75rem',
-                color: isSelected ? '#e2e8f0' : '#64748b',
+                color: isSelected || isCompare ? '#e2e8f0' : '#64748b',
                 fontFamily: 'monospace',
-                fontWeight: isSelected ? 600 : 400,
+                fontWeight: isSelected || isCompare ? 600 : 400,
               }}>
                 {shortName(b.name)}
               </span>
@@ -106,6 +168,14 @@ export function BundleTimeline({ bundles, onSelectBundle, selectedBundle }: Prop
               }}>
                 {b.phase === 'Superseded' ? 'Sup' : b.phase}
               </span>
+              {/* #338: "B" badge for comparison bundle */}
+              {isCompare && (
+                <span style={{
+                  fontSize: '0.55rem',
+                  color: '#a5b4fc',
+                  fontWeight: 700,
+                }}>⇅B</span>
+              )}
             </button>
           )
         })}


### PR DESCRIPTION
[🔨 ENG]

## Summary
Closes #338: bundle diff panel for comparing two bundle promotions side-by-side.

## How to use

1. In the Bundle Timeline strip, click a bundle (primary selection)
2. Shift-click another bundle (comparison target — shows ⇅B badge)
3. Click "Compare ↔" button that appears
4. Modal shows field-by-field diff with amber highlighting on changed fields

## Components

### `BundleDiffPanel` (new)
Modal overlay with side-by-side comparison:
- Fields compared: Phase, Type, Created, Author, Commit SHA, CI Run URL
- Changed fields highlighted in amber with ▸ indicator
- Count of changed fields shown in header
- CI Run URL rendered as clickable link
- Dismiss: × button, backdrop click, or Close button

### `BundleTimeline` (updated)
- **Shift-click** selects a bundle for comparison (blue border, ⇅B badge)
- **Compare ↔** button appears when primary + comparison bundles both selected
- **× clear** button to clear comparison selection
- **Shift-click to compare** hint shown when ≥2 bundles available
- Regular click continues to select primary bundle (no regression)

### `App.tsx` (updated)
- `compareBundle` and `showDiffPanel` state
- Renders `BundleDiffPanel` as modal when showDiffPanel=true

## Docs updated: No doc changes required
## Examples verified: `tsc --noEmit` + `go build ./...` pass