### PR TITLE
test(e2e): enhance TestJourney5CLI with policy test command

### DIFF
--- a/test/e2e/journeys_test.go
+++ b/test/e2e/journeys_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -475,7 +476,43 @@ func TestJourney5CLI(t *testing.T) {
 		assert.NotContains(t, out, "panic", "journey 5: must not panic")
 		assert.NotContains(t, out, "nil pointer dereference", "journey 5: must not nil-deref")
 	}
-	t.Log("Journey 5: CLI — version and policy simulate verified ✅")
+	t.Log("journey 5: kardinal policy simulate (no cluster) — no panic ✅")
+
+	// policy test: runs locally without a cluster (validates CEL syntax from file)
+	// Write a test gate file to a temp dir.
+	gateFile := filepath.Join(t.TempDir(), "test-gate.yaml")
+	gateContent := `apiVersion: kardinal.io/v1alpha1
+kind: PolicyGate
+metadata:
+  name: no-weekend
+spec:
+  expression: "!schedule.isWeekend"
+  message: "Block weekends"
+  recheckInterval: 5m
+`
+	require.NoError(t, os.WriteFile(gateFile, []byte(gateContent), 0600))
+
+	out, err = runCLICmd(kardinal, "policy", "test", gateFile)
+	require.NoError(t, err, "journey 5: policy test with valid gate must exit 0; got: %s", out)
+	assert.Contains(t, out, "valid", "journey 5: policy test output must contain 'valid'")
+	t.Logf("journey 5: kardinal policy test → %s ✅", strings.TrimSpace(out))
+
+	// policy test with invalid CEL must exit non-zero
+	badGateFile := filepath.Join(t.TempDir(), "bad-gate.yaml")
+	badGateContent := `apiVersion: kardinal.io/v1alpha1
+kind: PolicyGate
+metadata:
+  name: bad-gate
+spec:
+  expression: "this is not valid CEL !!!"
+`
+	require.NoError(t, os.WriteFile(badGateFile, []byte(badGateContent), 0600))
+	out, err = runCLICmd(kardinal, "policy", "test", badGateFile)
+	assert.Error(t, err, "journey 5: policy test with invalid CEL must exit non-zero")
+	assert.Contains(t, out, "INVALID", "journey 5: invalid CEL output must contain 'INVALID'")
+	t.Logf("journey 5: kardinal policy test (invalid CEL) → exit non-zero ✅")
+
+	t.Log("Journey 5: CLI — version, policy simulate, policy test all verified ✅")
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
[🔨 ENG]

## Summary
Partially closes #403: TestJourney5CLI now verifies `kardinal policy test` works correctly.

## New tests (no cluster required)

### `kardinal policy test <file>` — valid CEL exits 0
- Writes a valid PolicyGate YAML to temp file
- Runs `kardinal policy test <file>`
- Asserts: exit code 0, output contains 'valid'

### `kardinal policy test <file>` — invalid CEL exits non-zero
- Writes an invalid CEL expression to temp file  
- Runs `kardinal policy test <file>`
- Asserts: non-zero exit code, output contains 'INVALID'

### Existing test kept:
- `kardinal version` exits 0, contains version string

## Test output
```
journey 5: kardinal policy test → ... Syntax: valid, Result: PASS ✅
journey 5: kardinal policy test (invalid CEL) → exit non-zero ✅
Journey 5: CLI — version, policy simulate, policy test all verified ✅
```

## Docs updated: No doc changes required
## Examples verified: `go test ./test/e2e/... -run TestJourney5CLI PASS`