### PR TITLE
feat(scm): rollback PR body notice and descriptive title

### DIFF
--- a/pkg/scm/pr_template.go
+++ b/pkg/scm/pr_template.go
@@ -77,6 +77,10 @@ type PRBody struct {
 	// BundleName is the Bundle resource name.
 	BundleName string
 
+	// RollbackOf is the name of the Bundle this rollback reverts (if this is a rollback PR).
+	// When non-empty, the PR body includes a rollback notice section (#402).
+	RollbackOf string
+
 	// GateResults holds PolicyGate evaluation results for this environment.
 	GateResults []v1alpha1.GateResult
 
@@ -109,7 +113,16 @@ var prBodyTemplate = template.Must(template.New("pr-body").Funcs(template.FuncMa
 		return repo + "/compare/" + prevSHA + "..." + newSHA
 	},
 }).Parse(`<!-- kardinal-promoter auto-generated PR -->
-## Promotion: {{.BundleName}} → {{.PipelineName}}/{{.Environment}}
+{{- if .RollbackOf}}
+## ROLLBACK: {{.BundleName}} -> {{.PipelineName}}/{{.Environment}}
+
+> **This is a rollback PR.** It reverts environment {{.Environment}} to the state of bundle {{.RollbackOf}}.
+> Rolling back FROM: the current (failed) bundle
+> Rolling back TO: {{.BundleName}} (copy of {{.RollbackOf}})
+
+{{- else}}
+## Promotion: {{.BundleName}} -> {{.PipelineName}}/{{.Environment}}
+{{- end}}
 
 ### Artifact Provenance
 

--- a/pkg/scm/scm_test.go
+++ b/pkg/scm/scm_test.go
@@ -771,3 +771,66 @@ func TestNewProvider_Gitea(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, p)
 }
+
+// TestRenderPRBody_RollbackSection verifies that rollback PRs include a rollback
+// notice section with the bundle being rolled back to and the one being reverted.
+// This is required by issue #402 — rollback PR body must contain structured evidence.
+func TestRenderPRBody_RollbackSection(t *testing.T) {
+	data := scm.PRBody{
+		PipelineName: "nginx-demo",
+		Environment:  "prod",
+		BundleName:   "nginx-demo-rollback-abc123",
+		RollbackOf:   "nginx-demo-bad-version",
+		Bundle: v1alpha1.BundleSpec{
+			Type: "image",
+			Images: []v1alpha1.ImageRef{
+				{Repository: "ghcr.io/nginx/nginx", Tag: "1.29.0"},
+			},
+			Provenance: &v1alpha1.BundleProvenance{
+				CommitSHA:  "abc123",
+				Author:     "ci",
+				RollbackOf: "nginx-demo-bad-version",
+			},
+		},
+	}
+
+	body, err := scm.RenderPRBody(data)
+	require.NoError(t, err)
+
+	// Rollback PR must contain the rollback notice (#402)
+	assert.Contains(t, body, "ROLLBACK", "rollback PR body must contain ROLLBACK header")
+	assert.Contains(t, body, "nginx-demo-bad-version",
+		"rollback PR body must mention the bundle being reverted")
+	assert.Contains(t, body, "nginx-demo-rollback-abc123",
+		"rollback PR body must mention the new rollback bundle name")
+	assert.Contains(t, body, "prod", "rollback PR body must mention the environment")
+	// Rollback body must NOT show standard 'Promotion:' header
+	assert.NotContains(t, body, "## Promotion:",
+		"rollback PR must use ROLLBACK header, not Promotion header")
+	t.Logf("rollback PR body:\n%s", body)
+}
+
+// TestRenderPRBody_NormalPromotion_NoRollbackSection verifies that normal promotion
+// PRs do NOT include the rollback section.
+func TestRenderPRBody_NormalPromotion_NoRollbackSection(t *testing.T) {
+	data := scm.PRBody{
+		PipelineName: "nginx-demo",
+		Environment:  "prod",
+		BundleName:   "nginx-demo-v1-29-0",
+		// RollbackOf intentionally empty
+		Bundle: v1alpha1.BundleSpec{
+			Type: "image",
+			Images: []v1alpha1.ImageRef{
+				{Repository: "ghcr.io/nginx/nginx", Tag: "1.29.0"},
+			},
+		},
+	}
+
+	body, err := scm.RenderPRBody(data)
+	require.NoError(t, err)
+
+	assert.NotContains(t, body, "ROLLBACK",
+		"normal promotion PR must NOT have ROLLBACK header")
+	assert.Contains(t, body, "Promotion:",
+		"normal promotion PR must have standard Promotion header")
+}

--- a/pkg/steps/steps/open_pr.go
+++ b/pkg/steps/steps/open_pr.go
@@ -52,13 +52,22 @@ func (s *openPRStep) Execute(ctx context.Context, state *parentsteps.StepState) 
 		branch = fmt.Sprintf("kardinal/%s/%s", state.BundleName, state.Environment.Name)
 	}
 
+	// Use a more descriptive PR title for rollback promotions.
+	rollbackOf := ""
+	if state.Bundle.Provenance != nil && state.Bundle.Provenance.RollbackOf != "" {
+		rollbackOf = state.Bundle.Provenance.RollbackOf
+	}
 	title := fmt.Sprintf("[kardinal] Promote %s to %s", state.BundleName, state.Environment.Name)
+	if rollbackOf != "" {
+		title = fmt.Sprintf("[kardinal] Rollback %s to %s (reverts %s)", state.Environment.Name, state.BundleName, rollbackOf)
+	}
 
 	body, err := scm.RenderPRBody(scm.PRBody{
 		PipelineName:         state.PipelineName,
 		Environment:          state.Environment.Name,
 		BundleName:           state.BundleName,
 		Bundle:               state.Bundle,
+		RollbackOf:           rollbackOf,
 		GateResults:          state.GateResults,
 		UpstreamEnvironments: buildPRBodyUpstreamEnvs(state.UpstreamEnvironments),
 		Pipeline:             state.Pipeline,


### PR DESCRIPTION
[🔨 ENG]

## Summary
Partially closes #402: rollback PRs now have structured evidence in the PR body distinguishing them from normal promotion PRs.

## Changes

### PRBody struct (pr_template.go)
- New `RollbackOf string` field — when set, triggers the rollback section

### PR body template
When `RollbackOf` is set:
```
## ROLLBACK: nginx-demo-rollback-abc123 -> nginx-demo/prod

> **This is a rollback PR.** It reverts environment prod to the state of bundle nginx-demo-bad-version.
> Rolling back FROM: the current (failed) bundle
> Rolling back TO: nginx-demo-rollback-abc123 (copy of nginx-demo-bad-version)
```

When `RollbackOf` is empty (normal promotion):
```
## Promotion: nginx-demo-v1-29-0 -> nginx-demo/prod
```

### PR title (open_pr.go)
- Rollback: `[kardinal] Rollback prod to nginx-demo-rollback-abc123 (reverts nginx-demo-bad-version)`
- Normal: `[kardinal] Promote nginx-demo-v1-29-0 to prod`

## Tests
- `TestRenderPRBody_RollbackSection` — ROLLBACK header, bundle names present
- `TestRenderPRBody_NormalPromotion_NoRollbackSection` — normal PR unchanged

## Docs updated: No doc changes required
## Examples verified: `go test ./pkg/scm/... ./pkg/steps/steps/... PASS`