### PR TITLE
feat(helm): ValidatingAdmissionPolicy for PolicyGate CEL validation

### DIFF
--- a/chart/kardinal-promoter/templates/validating-admission-policy.yaml
+++ b/chart/kardinal-promoter/templates/validating-admission-policy.yaml
@@ -1,0 +1,41 @@
+{{/*
+ValidatingAdmissionPolicy for PolicyGate CEL expression validation.
+Requires Kubernetes 1.28+ (ValidatingAdmissionPolicy graduated to GA in 1.30).
+Rejects PolicyGate resources with empty spec.expression at admission time.
+
+Note: This policy validates that spec.expression is non-empty. Full CEL syntax
+validation requires a validating webhook (issue #317) with server-side compilation.
+This policy catches the most common mistake (missing expression field) at apply time.
+
+Enabled by default. Set validatingAdmissionPolicy.enabled=false to disable.
+*/}}
+{{- if .Values.validatingAdmissionPolicy.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kardinal-policygate-expression-required
+  labels:
+    {{- include "kardinal-promoter.labels" . | nindent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["kardinal.io"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["policygates"]
+  validations:
+  - expression: "object.spec.expression != ''"
+    message: "spec.expression must not be empty — provide a CEL expression (e.g. '!schedule.isWeekend')"
+    reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: kardinal-policygate-expression-required
+  labels:
+    {{- include "kardinal-promoter.labels" . | nindent 4 }}
+spec:
+  policyName: kardinal-policygate-expression-required
+  validationActions: [Deny]
+{{- end }}

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -116,3 +116,10 @@ krocodile:
   apiGroup: "experimental.kro.run"
   # Namespace where the Graph controller runs
   namespace: "kro-system"
+
+# -- ValidatingAdmissionPolicy for PolicyGate CEL expression validation.
+# Requires Kubernetes 1.28+. When enabled, prevents PolicyGates with empty
+# spec.expression from being created or updated (issue #317).
+# Full CEL syntax validation requires a validating webhook.
+validatingAdmissionPolicy:
+  enabled: true

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -91,6 +91,7 @@ kubectl get pods -n kardinal-system
 | `nodeSelector` | `{}` | Node selector |
 | `tolerations` | `[]` | Pod tolerations |
 | `affinity` | `{}` | Pod affinity |
+| `validatingAdmissionPolicy.enabled` | `true` | Deploy `ValidatingAdmissionPolicy` to reject PolicyGates with empty `spec.expression` at apply time (requires Kubernetes ≥ 1.28) |
 
 ---
 


### PR DESCRIPTION
[🔨 ENG]

## Summary
Partially closes #317: adds a ValidatingAdmissionPolicy that rejects PolicyGates with empty `spec.expression` at apply time.

## Approach

Uses `ValidatingAdmissionPolicy` (Kubernetes 1.28+ beta, 1.30+ GA) — no TLS or webhook server required.

```yaml
spec:
  validations:
  - expression: "object.spec.expression != ''"
    message: "spec.expression must not be empty"
    reason: Invalid
```

## What this does

- Rejects `kubectl apply` of a PolicyGate without `spec.expression`
- Error shown immediately at apply time (not silently accepted)
- Does NOT validate CEL syntax (that still requires a full webhook with server-side compilation)
- Controlled by `validatingAdmissionPolicy.enabled: true` (default on)

## What this does NOT do (full #317)

Full CEL syntax validation (catching `this is not valid CEL !!!`) requires a ValidatingWebhookConfiguration with server-side CEL compilation. That is a separate, larger feature requiring TLS certificate management.

## Files
- `chart/kardinal-promoter/templates/validating-admission-policy.yaml`
- `chart/kardinal-promoter/values.yaml` — adds `validatingAdmissionPolicy.enabled: true`
- `docs/installation.md` — adds new value to Helm reference table

## Docs updated: docs/installation.md
## Examples verified: `helm lint` passes, `go test ./test/helm/...` passes