### PR TITLE
test(health): add missing adapter edge case tests for issue #407 (v0.6.0-proof)

### DIFF
--- a/docs/aide/items/302-health-adapter-tests.md
+++ b/docs/aide/items/302-health-adapter-tests.md
@@ -1,0 +1,48 @@
+# Item 302: Health Adapter Test Coverage for issue #407
+
+> Issue: #407
+> Queue: queue-015
+> Milestone: v0.6.0-proof
+> Size: m
+> Priority: high
+> Area: area/health
+> Kind: kind/enhancement
+> Depends on: 014-health-adapters (merged)
+
+## Context
+
+Issue #407 identified gaps in health adapter test coverage:
+- ArgoCD Application not found → no test
+- Flux Kustomization not found → no test
+- ArgoCD with sync OutOfSync → no test
+- ArgoCD with operation in progress (opPhase=Running) → no test
+
+## Spec Reference
+
+`pkg/health/adapter.go`, `docs/health-adapters.md`
+
+## Acceptance Criteria
+
+### AC1: ArgoCD adapter covers not-found and OutOfSync cases
+**Given** an ArgoCDAdapter with no Application in the cluster
+**Then** result.Healthy = false, result.Reason contains "not found"
+
+**Given** an ArgoCDAdapter with Application health=Healthy but sync=OutOfSync
+**Then** result.Healthy = false
+
+### AC2: Flux adapter covers not-found case
+**Given** a FluxAdapter with no Kustomization in the cluster
+**Then** result.Healthy = false, result.Reason contains "not found"
+
+### AC3: ArgoCD adapter with active operation (opPhase=Running) blocks promotion
+**Given** an ArgoCDAdapter with Application health=Healthy, sync=Synced, opPhase=Running
+**Then** result.Healthy = false (operation in progress, wait for it to complete)
+
+## Tasks
+
+- [x] Add TestArgoCDAdapter_NotFound
+- [x] Add TestArgoCDAdapter_OutOfSync
+- [x] Add TestArgoCDAdapter_OperationInProgress
+- [x] Add TestFluxAdapter_NotFound
+- [x] Run go test ./pkg/health/... -race — all pass
+- [x] Post issue #407 evidence

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -497,3 +497,93 @@ func TestAutoDetector_FlaggerType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "flagger", adapter.Name())
 }
+
+// TestArgoCDAdapter_NotFound verifies that a missing Application returns Unhealthy
+// with a "not found" reason, not an error. This covers the issue #407 gap.
+func TestArgoCDAdapter_NotFound(t *testing.T) {
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+	adapter := health.NewArgoCDAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		ArgoCD: health.ArgoCDConfig{Name: "missing-app", Namespace: "argocd"},
+	})
+
+	require.NoError(t, err, "not-found must not return an error, just Unhealthy")
+	assert.False(t, result.Healthy, "missing Application must be Unhealthy")
+	assert.Contains(t, result.Reason, "not found")
+}
+
+// TestArgoCDAdapter_OutOfSync verifies that a Healthy but OutOfSync Application
+// is reported as Unhealthy. Promotion must wait for sync to complete.
+func TestArgoCDAdapter_OutOfSync(t *testing.T) {
+	app := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata":   map[string]interface{}{"name": "nginx-prod", "namespace": "argocd"},
+			"status": map[string]interface{}{
+				"health": map[string]interface{}{"status": "Healthy"},
+				"sync":   map[string]interface{}{"status": "OutOfSync"},
+			},
+		},
+	}
+	app.SetGroupVersionKind(schema.GroupVersionKind{Group: "argoproj.io", Version: "v1alpha1", Kind: "Application"})
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), app)
+
+	adapter := health.NewArgoCDAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		ArgoCD: health.ArgoCDConfig{Name: "nginx-prod", Namespace: "argocd"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy, "Healthy+OutOfSync must be Unhealthy — sync must complete")
+	assert.Contains(t, result.Reason, "OutOfSync")
+}
+
+// TestArgoCDAdapter_OperationInProgress verifies that an Application with
+// opPhase=Running (sync operation in progress) is reported as Unhealthy.
+// The promotion health check must wait for the sync operation to finish
+// before declaring the environment healthy.
+func TestArgoCDAdapter_OperationInProgress(t *testing.T) {
+	app := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata":   map[string]interface{}{"name": "nginx-prod", "namespace": "argocd"},
+			"status": map[string]interface{}{
+				"health": map[string]interface{}{"status": "Healthy"},
+				"sync":   map[string]interface{}{"status": "Synced"},
+				"operationState": map[string]interface{}{
+					"phase": "Running",
+				},
+			},
+		},
+	}
+	app.SetGroupVersionKind(schema.GroupVersionKind{Group: "argoproj.io", Version: "v1alpha1", Kind: "Application"})
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), app)
+
+	adapter := health.NewArgoCDAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		ArgoCD: health.ArgoCDConfig{Name: "nginx-prod", Namespace: "argocd"},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy, "opPhase=Running must be Unhealthy — operation not yet complete")
+	// Reason should mention the operation phase so operators know what to wait for
+	assert.Contains(t, result.Reason, "Running")
+}
+
+// TestFluxAdapter_NotFound verifies that a missing Kustomization returns Unhealthy
+// with a "not found" reason, not an error. This covers the issue #407 gap.
+func TestFluxAdapter_NotFound(t *testing.T) {
+	dynClient := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+	adapter := health.NewFluxAdapter(dynClient)
+	result, err := adapter.Check(context.Background(), health.CheckOptions{
+		Flux: health.FluxConfig{Name: "missing-ks", Namespace: "flux-system"},
+	})
+
+	require.NoError(t, err, "not-found must not return an error, just Unhealthy")
+	assert.False(t, result.Healthy, "missing Kustomization must be Unhealthy")
+	assert.Contains(t, result.Reason, "not found")
+}


### PR DESCRIPTION
## Summary

Closes #407 (proof(health): all health adapter types work — partial: adds unit test coverage for missing edge cases)

## Item ID

302-health-adapter-tests

## Spec Reference

`pkg/health/adapter.go`, `docs/health-adapters.md`

## Acceptance Criteria Checked

- [x] AC1: ArgoCDAdapter_NotFound — missing Application returns Unhealthy (not error)
- [x] AC1: ArgoCDAdapter_OutOfSync — Healthy+OutOfSync is Unhealthy (sync must complete)
- [x] AC2: FluxAdapter_NotFound — missing Kustomization returns Unhealthy (not error)
- [x] AC3: ArgoCDAdapter_OperationInProgress — opPhase=Running is Unhealthy (wait for op to finish)

## Test Output

```
=== RUN   TestArgoCDAdapter_NotFound
--- PASS: TestArgoCDAdapter_NotFound (0.00s)
=== RUN   TestArgoCDAdapter_OutOfSync
--- PASS: TestArgoCDAdapter_OutOfSync (0.00s)
=== RUN   TestArgoCDAdapter_OperationInProgress
--- PASS: TestArgoCDAdapter_OperationInProgress (0.00s)
=== RUN   TestFluxAdapter_NotFound
--- PASS: TestFluxAdapter_NotFound (0.00s)
PASS
ok      github.com/kardinal-promoter/kardinal-promoter/pkg/health  1.989s
```

## Verify Tasks Output

All tasks in 302-health-adapter-tests.md completed:
- [x] TestArgoCDAdapter_NotFound added
- [x] TestArgoCDAdapter_OutOfSync added
- [x] TestArgoCDAdapter_OperationInProgress added
- [x] TestFluxAdapter_NotFound added
- [x] go test ./pkg/health/... -race — PASS (24 total tests)

## Journey Validation Output

`go build ./...` — success
`go vet ./...` — success
`go test ./pkg/health/... -race -count=1` — PASS

Advances Journey 1 (Quickstart health check) and v0.6.0-proof milestone.

Docs updated: n/a (tests only)
Examples verified: n/a (unit tests only)