### PR TITLE
fix(prstatus): skip SCM call for placeholder PRStatus (prNumber=0) — regression fix #276

### DIFF
--- a/docs/aide/items/303-prstatus-regression-tests.md
+++ b/docs/aide/items/303-prstatus-regression-tests.md
@@ -1,0 +1,33 @@
+# Item 303: PRStatus Regression Tests for issues #276/#277
+
+> Issue: #408 (partial)
+> Queue: queue-015
+> Milestone: v0.6.0-proof
+> Size: s
+> Priority: high
+> Area: area/test
+> Kind: kind/enhancement
+> Depends on: 036-prstatuscrd (merged)
+
+## Context
+
+Issues #276 and #277 caused critical bugs (PR merge deadlock and CRD validation
+failures) that were fixed but not regression-tested. Issue #408 requires regression
+tests to ensure these bugs don't reappear.
+
+## Acceptance Criteria
+
+### AC1: PRStatus with empty spec reconciles without error (#276 regression)
+**Given** a PRStatus with no prURL, no prNumber (placeholder state from Graph)
+**When** the reconciler runs
+**Then** no error, requeue after pollingInterval (SCM not called — empty spec)
+
+### AC2: PRStatus reconciler with empty spec does not call SCM (#276 regression)
+**Given** a PRStatus with zero prNumber
+**When** the reconciler runs
+**Then** GetPRStatus is never called
+
+## Tasks
+
+- [x] Add TestReconciler_EmptySpec_NoSCMCall (PRStatus with empty spec)
+- [x] Run go test ./pkg/reconciler/prstatus/... -race — all pass

--- a/pkg/reconciler/prstatus/reconciler.go
+++ b/pkg/reconciler/prstatus/reconciler.go
@@ -91,6 +91,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: requeuePollInterval}, nil
 	}
 
+	// Placeholder guard: PRNumber=0 means the open-pr step has not yet run.
+	// The Graph creates a PRStatus Watch node as a placeholder before the PR exists.
+	// Do not call SCM with prNumber=0 — that would cause a 404 from GitHub (#276).
+	if prs.Spec.PRNumber == 0 {
+		log.Debug().Msg("PRStatus placeholder (prNumber=0), waiting for open-pr step")
+		return ctrl.Result{RequeueAfter: requeuePollInterval}, nil
+	}
+
 	merged, open, err := r.SCM.GetPRStatus(ctx, prs.Spec.Repo, prs.Spec.PRNumber)
 	if err != nil {
 		log.Error().Err(err).

--- a/pkg/reconciler/prstatus/reconciler_test.go
+++ b/pkg/reconciler/prstatus/reconciler_test.go
@@ -276,3 +276,89 @@ func TestReconciler_IdempotentOnSecondReconcile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, scm.calls, "second reconcile should not call SCM again")
 }
+
+// TestReconciler_EmptySpec_NoSCMCall is a regression test for issue #276
+// (PRStatus with empty spec — graph placeholder — must not trigger SCM calls).
+//
+// When the Graph creates a PRStatus Watch node as a placeholder (before the
+// open-pr step fills in the PR URL and number), the spec fields are empty/zero.
+// The reconciler must skip SCM polling for placeholder PRStatus objects.
+// Calling GetPRStatus with prNumber=0 would cause an API error.
+func TestReconciler_EmptySpec_NoSCMCall(t *testing.T) {
+	scheme := buildScheme(t)
+
+	// Placeholder PRStatus: all spec fields empty/zero (mirroring what Graph creates
+	// before the open-pr step runs and sets the real PR URL+number).
+	prs := &v1alpha1.PRStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "placeholder-pr",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.PRStatusSpec{
+			PRURL:    "", // empty — not yet opened
+			PRNumber: 0,  // zero — not yet opened
+			Repo:     "", // empty — not yet opened
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(prs).
+		WithStatusSubresource(&v1alpha1.PRStatus{}).
+		Build()
+
+	scm := &fakeSCM{}
+	r := &prstatus.Reconciler{
+		Client: fakeClient,
+		SCM:    scm,
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "placeholder-pr", Namespace: "default"},
+	})
+
+	require.NoError(t, err, "empty-spec PRStatus must not error (#276 regression)")
+	assert.Equal(t, 0, scm.calls, "GetPRStatus must NOT be called for placeholder PRStatus with empty spec (#276 regression)")
+	// Reconciler should requeue to poll later when the spec might be filled in
+	assert.Greater(t, result.RequeueAfter.Milliseconds(), int64(0),
+		"placeholder PRStatus should requeue for later polling")
+}
+
+// TestReconciler_ZeroPRNumber_NoSCMCall is a regression test for issue #276.
+// PRNumber=0 explicitly means the PR has not yet been created. The reconciler
+// must not call GetPRStatus with prNumber=0 as that would cause a 404 from GitHub.
+func TestReconciler_ZeroPRNumber_NoSCMCall(t *testing.T) {
+	scheme := buildScheme(t)
+
+	prs := &v1alpha1.PRStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "zero-pr-number",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.PRStatusSpec{
+			PRURL:    "https://github.com/owner/repo/pull/0",
+			PRNumber: 0, // explicitly zero — not yet assigned
+			Repo:     "owner/repo",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(prs).
+		WithStatusSubresource(&v1alpha1.PRStatus{}).
+		Build()
+
+	scm := &fakeSCM{}
+	r := &prstatus.Reconciler{
+		Client: fakeClient,
+		SCM:    scm,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "zero-pr-number", Namespace: "default"},
+	})
+
+	require.NoError(t, err, "zero prNumber must not error (#276 regression)")
+	assert.Equal(t, 0, scm.calls,
+		"GetPRStatus must NOT be called for PRStatus with prNumber=0 (#276 regression)")
+}


### PR DESCRIPTION
## Summary

Regression fix for issue #276 (PRStatus empty spec must allow Graph placeholder creation).

Adds explicit guard: if `spec.prNumber==0` (placeholder state before open-pr step runs), skip `GetPRStatus` API call and requeue for later polling.

## Bug Found by Tests

The regression tests exposed that the reconciler was calling `GitHub.GetPRStatus(repo, 0)` for placeholder PRStatus objects, which would:
1. Return a 404 from GitHub API  
2. Error was swallowed and requeued — unnecessary API calls and error log noise
3. Potential rate limiting if many placeholder PRStatus objects exist simultaneously

## Item ID

303-prstatus-regression (closes #408 partial — regression tests added)

## Spec Reference

`pkg/reconciler/prstatus/reconciler.go`, issue #276

## Acceptance Criteria Checked

- [x] AC1: Empty spec PRStatus reconciles without error (no SCM call) ✅
- [x] AC2: prNumber=0 PRStatus does not call GetPRStatus ✅

## Test Output

```
=== RUN   TestReconciler_EmptySpec_NoSCMCall
--- PASS: TestReconciler_EmptySpec_NoSCMCall (0.01s)
=== RUN   TestReconciler_ZeroPRNumber_NoSCMCall
--- PASS: TestReconciler_ZeroPRNumber_NoSCMCall (0.01s)
PASS
ok      github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/prstatus  3.284s
```

## Verify Tasks Output

All tasks completed:
- [x] Guard added at reconciler.go line 89
- [x] TestReconciler_EmptySpec_NoSCMCall — PASS
- [x] TestReconciler_ZeroPRNumber_NoSCMCall — PASS
- [x] go test ./pkg/reconciler/prstatus/... -race — all 6 tests pass
- [x] go build ./... — success
- [x] go vet ./... — success

## Journey Validation Output

`go build ./...` — success
`go vet ./...` — success
`go test ./... -race -count=1 -timeout 120s` — all packages pass (E2E infra skips without cluster)

Docs updated: n/a
Examples verified: n/a