### PR TITLE
test(ui): add UI API regression tests for issue #410 (no-duplicate gates, PAUSED badge)

### DIFF
--- a/cmd/kardinal-controller/ui_api_test.go
+++ b/cmd/kardinal-controller/ui_api_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
@@ -444,4 +445,105 @@ func TestUIAPI_ValidateCEL_KroFunctionsAvailable(t *testing.T) {
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.Equal(t, tc.wantValid, resp["valid"], "expression: %s", tc.expression)
 	}
+}
+
+// TestUIAPI_ListGates_NoDuplicates is a regression test for the "176 PolicyGates" bug
+// (issue #410 — proof(UI)). When multiple PolicyGate CRs exist (e.g. one per
+// environment per gate name from the Graph), the /api/v1/ui/gates endpoint must
+// return exactly the number of CRs that exist — not inflate them via deduplication
+// or template expansion.
+//
+// The current implementation lists PolicyGate CRs directly (one entry per CR),
+// which is correct. This test verifies that 3 distinct gate CRs → 3 response items.
+func TestUIAPI_ListGates_NoDuplicates(t *testing.T) {
+	gates := []v1alpha1.PolicyGate{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-weekend-deploys", Namespace: "platform-policies"},
+			Spec:       v1alpha1.PolicyGateSpec{Expression: "!schedule.isWeekend"},
+			Status:     v1alpha1.PolicyGateStatus{Ready: true, Reason: "Weekday"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "staging-soak-30m", Namespace: "platform-policies"},
+			Spec:       v1alpha1.PolicyGateSpec{Expression: "bundle.upstreamSoakMinutes >= 30"},
+			Status:     v1alpha1.PolicyGateStatus{Ready: true, Reason: "soak=45m"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-bot-deploys", Namespace: "my-team"},
+			Spec:       v1alpha1.PolicyGateSpec{Expression: `bundle.provenance.author != "dependabot[bot]"`},
+			Status:     v1alpha1.PolicyGateStatus{Ready: false, Reason: "author is dependabot"},
+		},
+	}
+
+	s := uiScheme()
+	clientObjects := make([]client.Object, len(gates))
+	for i := range gates {
+		clientObjects[i] = &gates[i]
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clientObjects...).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ui/gates", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp []uiGateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Exactly 3 gates — no duplicates, no inflation (#410 regression)
+	assert.Len(t, resp, 3, "API must return exactly 3 gates — no duplicates from templates")
+
+	// Names match the CRs
+	names := make([]string, len(resp))
+	for i, g := range resp {
+		names[i] = g.Name
+	}
+	assert.Contains(t, names, "no-weekend-deploys")
+	assert.Contains(t, names, "staging-soak-30m")
+	assert.Contains(t, names, "no-bot-deploys")
+
+	// Namespaces preserved (org vs team)
+	namespaces := make(map[string]string)
+	for _, g := range resp {
+		namespaces[g.Name] = g.Namespace
+	}
+	assert.Equal(t, "platform-policies", namespaces["no-weekend-deploys"])
+	assert.Equal(t, "my-team", namespaces["no-bot-deploys"])
+}
+
+// TestUIAPI_ListPipelines_PausedBadge verifies that a paused Pipeline is reflected
+// in the pipeline list response (issue #410 — proof(UI): PAUSED badge in pipeline list).
+func TestUIAPI_ListPipelines_PausedBadge(t *testing.T) {
+	p := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Paused: true,
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test"},
+				{Name: "prod"},
+			},
+		},
+		Status: v1alpha1.PipelineStatus{Phase: "Ready"},
+	}
+
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(p).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ui/pipelines", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp []uiPipelineResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+
+	// UI should surface Paused=true so the frontend can show the PAUSED badge (#410)
+	assert.True(t, resp[0].Paused, "paused pipeline must have Paused=true in API response")
+	assert.Equal(t, "my-app", resp[0].Name)
 }

--- a/docs/aide/items/304-ui-api-regression-tests.md
+++ b/docs/aide/items/304-ui-api-regression-tests.md
@@ -1,0 +1,27 @@
+# Item 304: UI API Regression Tests for issue #410
+
+> Issue: #410 (partial)
+> Queue: queue-015
+> Milestone: v0.6.0-proof
+> Size: s
+> Priority: high
+> Area: area/test
+> Kind: kind/enhancement
+> Depends on: 019-embedded-react-ui (merged)
+
+## Context
+
+Issue #410 (proof(UI)) requires evidence that UI panels show correct data.
+The "176 PolicyGates blocking promotion" bug was fixed but not regression-tested.
+The PAUSED badge in the pipeline list also needs a test.
+
+## Acceptance Criteria
+
+### AC1: /api/v1/ui/gates returns exactly N gates for N CRs (no duplicates)
+### AC2: Paused pipeline is reflected in the pipeline list response
+
+## Tasks
+
+- [x] Add TestUIAPI_ListGates_NoDuplicates (3 distinct gate CRs → 3 response items)
+- [x] Add TestUIAPI_ListPipelines_PausedBadge (paused pipeline → Paused=true in response)
+- [x] Run go test ./cmd/kardinal-controller/... -race — all pass


### PR DESCRIPTION
## Summary

Partial close of #410 (proof(UI): browser walkthrough). Adds automated regression tests for two specific UI bugs documented in the issue.

## Item ID

304-ui-api-regression

## Spec Reference

`cmd/kardinal-controller/ui_api.go`, issue #410

## Acceptance Criteria Checked

- [x] AC1: TestUIAPI_ListGates_NoDuplicates — 3 gate CRs → 3 response items (no inflation) ✅
- [x] AC2: TestUIAPI_ListPipelines_PausedBadge — paused=true in spec → Paused=true in response ✅

## Test Output

```
=== RUN   TestUIAPI_ListGates_NoDuplicates
--- PASS: TestUIAPI_ListGates_NoDuplicates (0.45s)
=== RUN   TestUIAPI_ListPipelines_PausedBadge
--- PASS: TestUIAPI_ListPipelines_PausedBadge (0.01s)
PASS
ok      github.com/kardinal-promoter/kardinal-promoter/cmd/kardinal-controller  2.219s
```

## Verify Tasks Output

- [x] TestUIAPI_ListGates_NoDuplicates added and passes
- [x] TestUIAPI_ListPipelines_PausedBadge added and passes
- [x] go test ./cmd/kardinal-controller/... -race — PASS (15 total tests)
- [x] go build ./... — success

## Journey Validation Output

`go build ./...` — success
`go vet ./...` — success
`go test ./cmd/kardinal-controller/... -race -count=1` — PASS

Note: Full browser walkthrough evidence (#410) still requires live browser testing (playwright/screenshot set). This PR provides the backend API regression coverage.

Docs updated: n/a (tests only)
Examples verified: n/a