### PR TITLE
feat(policygate): pre-deploy gate type via when: pre-deploy field (K-02, closes #445)

### DIFF
--- a/api/v1alpha1/policygate_types.go
+++ b/api/v1alpha1/policygate_types.go
@@ -40,6 +40,16 @@ type PolicyGateSpec struct {
 	// that must be Verified before this gate is evaluated.
 	// +optional
 	UpstreamEnvironment string `json:"upstreamEnvironment,omitempty"`
+
+	// When controls when this gate is evaluated in the promotion lifecycle (K-02).
+	// "pre-deploy" (default: post-deploy): evaluated before git operations start.
+	//   If not ready, the PromotionStep stays in Pending and no git-clone begins.
+	// "post-deploy": evaluated after deployment (during bake/health check phase).
+	//   This is the default behavior for all existing gates.
+	// +kubebuilder:validation:Enum=pre-deploy;post-deploy
+	// +kubebuilder:default=post-deploy
+	// +optional
+	When string `json:"when,omitempty"`
 }
 
 // PolicyGateStatus defines the observed state of a PolicyGate.

--- a/config/crd/bases/kardinal.io_policygates.yaml
+++ b/config/crd/bases/kardinal.io_policygates.yaml
@@ -134,6 +134,18 @@ spec:
                   substitution. It carries the resolved state of the upstream PromotionStep
                   that must be Verified before this gate is evaluated.
                 type: string
+              when:
+                default: post-deploy
+                description: |-
+                  When controls when this gate is evaluated in the promotion lifecycle (K-02).
+                  "pre-deploy" (default: post-deploy): evaluated before git operations start.
+                    If not ready, the PromotionStep stays in Pending and no git-clone begins.
+                  "post-deploy": evaluated after deployment (during bake/health check phase).
+                    This is the default behavior for all existing gates.
+                enum:
+                - pre-deploy
+                - post-deploy
+                type: string
             required:
             - expression
             type: object

--- a/pkg/reconciler/promotionstep/reconciler.go
+++ b/pkg/reconciler/promotionstep/reconciler.go
@@ -228,10 +228,36 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 // handlePending initializes the step sequence and transitions to Promoting.
+// Before transitioning, checks all required pre-deploy PolicyGates (K-02).
+// If any pre-deploy gate is not ready, stays in Pending and requeues.
 func (r *Reconciler) handlePending(ctx context.Context, log zerolog.Logger, ps *v1alpha1.PromotionStep) (ctrl.Result, error) {
 	pipeline, err := r.loadPipeline(ctx, ps)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("load pipeline: %w", err)
+	}
+
+	// K-02: Check pre-deploy gates before starting any git operations.
+	// Required gates are listed in ps.Spec.RequiredGates (set by the Graph controller).
+	// Only gates with spec.when == "pre-deploy" block the Pending → Promoting transition.
+	if len(ps.Spec.RequiredGates) > 0 {
+		blocked, blockingGate, checkErr := r.checkPreDeployGates(ctx, ps)
+		if checkErr != nil {
+			log.Warn().Err(checkErr).Msg("failed to check pre-deploy gates — will retry")
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+		if blocked {
+			log.Info().
+				Str("gate", blockingGate).
+				Str("env", ps.Spec.Environment).
+				Msg("pre-deploy gate not ready — step stays in Pending")
+			// Update message for visibility but do NOT change state.
+			patch := client.MergeFrom(ps.DeepCopy())
+			ps.Status.Message = fmt.Sprintf("waiting for pre-deploy gate: %s", blockingGate)
+			if patchErr := r.Status().Patch(ctx, ps, patch); patchErr != nil {
+				log.Warn().Err(patchErr).Msg("failed to patch pre-deploy wait message (non-fatal)")
+			}
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
 	}
 
 	env := findEnv(pipeline, ps.Spec.Environment)
@@ -746,6 +772,27 @@ func (r *Reconciler) handleHealthChecking(ctx context.Context, log zerolog.Logge
 		}
 		return ctrl.Result{}, nil
 	}
+}
+
+// checkPreDeployGates looks up all gates in ps.Spec.RequiredGates and returns
+// true + the first blocking gate name if any pre-deploy gate is not ready.
+// Returns (false, "", nil) when all pre-deploy gates are ready (or there are none).
+// Graph-first: reads CRD status fields only — no external calls.
+func (r *Reconciler) checkPreDeployGates(ctx context.Context, ps *v1alpha1.PromotionStep) (blocked bool, blockingGate string, err error) {
+	for _, gateName := range ps.Spec.RequiredGates {
+		var gate v1alpha1.PolicyGate
+		if getErr := r.Get(ctx, types.NamespacedName{Name: gateName, Namespace: ps.Namespace}, &gate); getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				// Gate not yet created by the Graph — treat as not ready.
+				return true, gateName, nil
+			}
+			return false, "", fmt.Errorf("get policy gate %s: %w", gateName, getErr)
+		}
+		if gate.Spec.When == "pre-deploy" && !gate.Status.Ready {
+			return true, gateName, nil
+		}
+	}
+	return false, "", nil
 }
 
 // handleBake implements the K-01 contiguous-healthy soak window.

--- a/pkg/reconciler/promotionstep/reconciler_test.go
+++ b/pkg/reconciler/promotionstep/reconciler_test.go
@@ -1060,6 +1060,144 @@ func TestOrphanCleanup_MultipleStepsForBundle(t *testing.T) {
 	}
 }
 
+// ─── K-02: Pre-deploy gates ───────────────────────────────────────────────────
+
+// TestPreDeployGate_BlocksPendingTransition verifies that a pre-deploy gate
+// that is NOT ready prevents the Pending → Promoting transition.
+func TestPreDeployGate_BlocksPendingTransition(t *testing.T) {
+	scheme := buildScheme(t)
+	step := makeStep("step-prod", "my-app", "bundle-1", "prod")
+	// step.Spec.RequiredGates = ["pre-deploy-gate"] set after creation
+	step.Spec.RequiredGates = []string{"pre-deploy-gate"}
+
+	pipeline := makePipeline("my-app")
+	bundle := makeBundle("bundle-1", "my-app")
+
+	// Pre-deploy gate that is NOT ready
+	gate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{Name: "pre-deploy-gate", Namespace: "default"},
+		Spec: v1alpha1.PolicyGateSpec{
+			Expression: "!schedule.isWeekend",
+			When:       "pre-deploy",
+		},
+		Status: v1alpha1.PolicyGateStatus{Ready: false, Reason: "weekend"},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(step, pipeline, bundle, gate).
+		WithStatusSubresource(&v1alpha1.PromotionStep{}).
+		Build()
+
+	r := &promotionstep.Reconciler{
+		Client:    c,
+		SCM:       &mockSCM{},
+		GitClient: &mockGit{},
+		WorkDirFn: func(_, _ string) string { return t.TempDir() },
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "step-prod", Namespace: "default"}}
+	result, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	var got v1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
+
+	// Step must NOT advance to Promoting — pre-deploy gate is blocking
+	assert.NotEqual(t, "Promoting", got.Status.State,
+		"step must not advance to Promoting when pre-deploy gate is not ready")
+	// Should requeue to check again later
+	assert.Greater(t, result.RequeueAfter.Milliseconds(), int64(0),
+		"should requeue when blocked by pre-deploy gate")
+}
+
+// TestPreDeployGate_AllowsTransitionWhenReady verifies that when all pre-deploy
+// gates are ready, the step advances normally to Promoting.
+func TestPreDeployGate_AllowsTransitionWhenReady(t *testing.T) {
+	scheme := buildScheme(t)
+	step := makeStep("step-prod", "my-app", "bundle-1", "prod")
+	step.Spec.RequiredGates = []string{"pre-deploy-gate"}
+
+	pipeline := makePipeline("my-app")
+	bundle := makeBundle("bundle-1", "my-app")
+
+	// Pre-deploy gate that IS ready
+	gate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{Name: "pre-deploy-gate", Namespace: "default"},
+		Spec: v1alpha1.PolicyGateSpec{
+			Expression: "!schedule.isWeekend",
+			When:       "pre-deploy",
+		},
+		Status: v1alpha1.PolicyGateStatus{Ready: true, Reason: "weekday"},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(step, pipeline, bundle, gate).
+		WithStatusSubresource(&v1alpha1.PromotionStep{}).
+		Build()
+
+	r := &promotionstep.Reconciler{
+		Client:    c,
+		SCM:       &mockSCM{},
+		GitClient: &mockGit{},
+		WorkDirFn: func(_, _ string) string { return t.TempDir() },
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "step-prod", Namespace: "default"}}
+	_, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	var got v1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
+
+	// Step must advance to Promoting — all pre-deploy gates are ready
+	assert.Equal(t, "Promoting", got.Status.State,
+		"step must advance to Promoting when all pre-deploy gates are ready")
+}
+
+// TestPreDeployGate_PostDeployGatesDoNotBlockPending verifies that gates with
+// when: post-deploy (or no when field) do NOT block the Pending → Promoting transition.
+func TestPreDeployGate_PostDeployGatesDoNotBlockPending(t *testing.T) {
+	scheme := buildScheme(t)
+	step := makeStep("step-prod", "my-app", "bundle-1", "prod")
+	step.Spec.RequiredGates = []string{"post-deploy-gate"}
+
+	pipeline := makePipeline("my-app")
+	bundle := makeBundle("bundle-1", "my-app")
+
+	// Post-deploy gate that is NOT ready — should NOT block Pending → Promoting
+	gate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{Name: "post-deploy-gate", Namespace: "default"},
+		Spec: v1alpha1.PolicyGateSpec{
+			Expression: "upstream.uat.soakMinutes >= 30",
+			When:       "post-deploy", // or "" (default)
+		},
+		Status: v1alpha1.PolicyGateStatus{Ready: false, Reason: "not enough soak"},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(step, pipeline, bundle, gate).
+		WithStatusSubresource(&v1alpha1.PromotionStep{}).
+		Build()
+
+	r := &promotionstep.Reconciler{
+		Client:    c,
+		SCM:       &mockSCM{},
+		GitClient: &mockGit{},
+		WorkDirFn: func(_, _ string) string { return t.TempDir() },
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "step-prod", Namespace: "default"}}
+	_, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	var got v1alpha1.PromotionStep
+	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
+
+	// Post-deploy gate NOT ready must NOT block the transition to Promoting
+	assert.Equal(t, "Promoting", got.Status.State,
+		"post-deploy gate must not block Pending → Promoting transition")
+}
+
 // ─── K-01: Contiguous soak / bake ────────────────────────────────────────────
 
 // TestBakeTracking_FirstHealthyPass verifies that when a PromotionStep enters


### PR DESCRIPTION
## Summary

Implements K-02: PolicyGate.spec.when field to block deployment from *starting* based on real-time conditions.

**Why this matters:** Today all PolicyGates are post-deploy (after git-clone starts). There is no way to block a promotion from starting when upstream is degraded. Neither Kargo nor GitOps Promoter have this.

## New API

```yaml
kind: PolicyGate
spec:
  when: pre-deploy   # evaluated before git-clone
  expression: 'health.deployment("my-app", "staging").errorRate < 0.01'
```

## Implementation

- `PolicyGateSpec.When` field: `pre-deploy` | `post-deploy` (default: `post-deploy`)
- `handlePending()` now calls `checkPreDeployGates()` before transitioning to Promoting
- `checkPreDeployGates()`: reads `status.ready` on required gates with `when==pre-deploy`
- If any pre-deploy gate is not ready: stays in Pending, updates message, requeues in 30s
- Post-deploy gates are unaffected (backward compatible)

## Tests

```
--- PASS: TestPreDeployGate_BlocksPendingTransition
--- PASS: TestPreDeployGate_AllowsTransitionWhenReady
--- PASS: TestPreDeployGate_PostDeployGatesDoNotBlockPending
```

## Journey Validation

`go build ./...` — success
`go vet ./...` — success
`go test ./... -race -count=1 -timeout 120s` — all packages pass

CRD YAML regenerated for PolicyGate.
Docs updated: n/a (new field, pipeline-reference.md update tracked separately)
Examples verified: n/a