### PR TITLE
docs: document K-01 bake, K-02 when, K-03 onHealthFailure fields

### DIFF
--- a/docs/pipeline-reference.md
+++ b/docs/pipeline-reference.md
@@ -95,6 +95,9 @@ spec:
 | `delivery.delegate` | No | `none` | Progressive delivery delegation. `argoRollouts`: watch Argo Rollouts Rollout status after promotion. `flagger`: watch Flagger Canary status (future). `none`: instant deploy (rolling update). |
 | `shard` | No | (none) | Agent shard name for distributed mode. When set, only a kardinal-agent started with `--shard=<value>` will reconcile this environment's PromotionSteps. When omitted, the control plane controller handles the step. |
 | `steps` | No | (inferred) | Custom promotion step sequence. When omitted, the default sequence is inferred from `update.strategy`, `approval`, and `renderManifests`. When specified, overrides the default entirely. See [Promotion Steps](#promotion-steps). |
+| `bake.minutes` | No | (none) | Contiguous-healthy soak window in minutes (K-01). When set, the step must observe healthy deployment status *continuously* for this many minutes before transitioning to Verified. A health alarm resets the timer. |
+| `bake.policy` | No | `reset-on-alarm` | What to do when health fails during the bake window. `reset-on-alarm`: reset the elapsed timer to 0, stay in HealthChecking. `fail-on-alarm`: immediately apply `onHealthFailure` policy. |
+| `onHealthFailure` | No | `none` | What to do when health fails during bake with `policy: fail-on-alarm` (K-03). `none`: step → Failed (default behavior). `abort`: step → AbortedByAlarm; requires human intervention. `rollback`: create a rollback Bundle at the previous image version; step → RollingBack. |
 
 ### spec.historyLimit
 

--- a/docs/policy-gates.md
+++ b/docs/policy-gates.md
@@ -26,6 +26,28 @@ spec:
   expression: <string>                  # CEL expression
   message: <string>                     # human-readable explanation shown when gate blocks
   recheckInterval: <duration>           # how often to re-evaluate (default: "5m")
+  when: <string>                        # "pre-deploy" or "post-deploy" (default: "post-deploy")
+```
+
+### `when` field (K-02)
+
+The `when` field controls at which point in the promotion lifecycle the gate is evaluated:
+
+- `post-deploy` (default): gate is evaluated **after** the PR is merged and the deployment starts. This is the standard behavior for soak gates, error-rate checks, and other post-deployment conditions.
+- `pre-deploy`: gate is evaluated **before** git operations begin. If a `pre-deploy` gate is not ready, the PromotionStep stays in `Pending` and no `git-clone` starts. Use this to block deployments when upstream health is degraded.
+
+**Example: block prod deployments when staging error rate is high**
+
+```yaml
+kind: PolicyGate
+metadata:
+  name: staging-healthy-before-prod
+  namespace: platform-policies
+spec:
+  when: pre-deploy
+  expression: 'metrics.staging_error_rate.value < 0.01'
+  message: "Staging error rate is above 1% — do not start prod deployment"
+  recheckInterval: 1m
 ```
 
 ## Scoping


### PR DESCRIPTION
## Summary

Documents the three Safety & Observability fields shipped in PRs #455, #457, #458.

**Changes:**
- `docs/pipeline-reference.md`: adds `bake.minutes`, `bake.policy`, `onHealthFailure` to the environment spec field table
- `docs/policy-gates.md`: adds `when` field to the PolicyGate CRD reference, with a K-02 section explaining pre-deploy vs post-deploy evaluation and an example

## Journey Validation

Docs-only change. `go build ./...` — success.

Docs updated: docs/pipeline-reference.md, docs/policy-gates.md
Examples verified: n/a (inline examples in docs)