### PR TITLE
feat(policygate): PR review gate — bundle.pr[stage].isApproved CEL function (K-08, closes #452)

### DIFF
--- a/api/v1alpha1/prstatus_types.go
+++ b/api/v1alpha1/prstatus_types.go
@@ -54,12 +54,12 @@ type PRStatusStatus struct {
 
 	// Approved is true when the pull request has at least one approved review
 	// and no outstanding change-request reviews. Written by PRStatusReconciler.
-	// CEL: bundle.pr("staging").isApproved()
+	// CEL: bundle.pr["staging"].isApproved
 	// +optional
 	Approved bool `json:"approved,omitempty"`
 
 	// ApprovalCount is the number of distinct approved reviews on this PR.
-	// Written by PRStatusReconciler. CEL: bundle.pr("staging").hasMinReviewers(2)
+	// Written by PRStatusReconciler. CEL: bundle.pr["staging"].approvalCount >= 2
 	// +optional
 	ApprovalCount int `json:"approvalCount,omitempty"`
 

--- a/api/v1alpha1/prstatus_types.go
+++ b/api/v1alpha1/prstatus_types.go
@@ -52,6 +52,17 @@ type PRStatusStatus struct {
 	// +optional
 	Open bool `json:"open,omitempty"`
 
+	// Approved is true when the pull request has at least one approved review
+	// and no outstanding change-request reviews. Written by PRStatusReconciler.
+	// CEL: bundle.pr("staging").isApproved()
+	// +optional
+	Approved bool `json:"approved,omitempty"`
+
+	// ApprovalCount is the number of distinct approved reviews on this PR.
+	// Written by PRStatusReconciler. CEL: bundle.pr("staging").hasMinReviewers(2)
+	// +optional
+	ApprovalCount int `json:"approvalCount,omitempty"`
+
 	// LastCheckedAt records the timestamp of the most recent SCM API poll.
 	// +optional
 	LastCheckedAt *metav1.Time `json:"lastCheckedAt,omitempty"`
@@ -62,6 +73,8 @@ type PRStatusStatus struct {
 // +kubebuilder:resource:scope=Namespaced,shortName=prs
 // +kubebuilder:printcolumn:name="Merged",type=boolean,JSONPath=`.status.merged`
 // +kubebuilder:printcolumn:name="Open",type=boolean,JSONPath=`.status.open`
+// +kubebuilder:printcolumn:name="Approved",type=boolean,JSONPath=`.status.approved`
+// +kubebuilder:printcolumn:name="Approvals",type=integer,JSONPath=`.status.approvalCount`
 // +kubebuilder:printcolumn:name="PR",type=integer,JSONPath=`.spec.prNumber`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/cmd/kardinal-controller/webhook_test.go
+++ b/cmd/kardinal-controller/webhook_test.go
@@ -50,6 +50,9 @@ func (m *mockSCMProvider) CommentOnPR(_ context.Context, _ string, _ int, _ stri
 func (m *mockSCMProvider) GetPRStatus(_ context.Context, _ string, _ int) (bool, bool, error) {
 	return m.event.Merged, true, nil
 }
+func (m *mockSCMProvider) GetPRReviewStatus(_ context.Context, _ string, _ int) (bool, int, error) {
+	return false, 0, nil
+}
 func (m *mockSCMProvider) ParseWebhookEvent(payload []byte, _ string) (scm.WebhookEvent, error) {
 	return m.event, m.err
 }

--- a/config/crd/bases/kardinal.io_prstatuses.yaml
+++ b/config/crd/bases/kardinal.io_prstatuses.yaml
@@ -23,6 +23,12 @@ spec:
     - jsonPath: .status.open
       name: Open
       type: boolean
+    - jsonPath: .status.approved
+      name: Approved
+      type: boolean
+    - jsonPath: .status.approvalCount
+      name: Approvals
+      type: integer
     - jsonPath: .spec.prNumber
       name: PR
       type: integer
@@ -90,6 +96,17 @@ spec:
               PRStatusStatus holds the observed state of the pull request.
               Written exclusively by the PRStatusReconciler.
             properties:
+              approvalCount:
+                description: |-
+                  ApprovalCount is the number of distinct approved reviews on this PR.
+                  Written by PRStatusReconciler. CEL: bundle.pr["staging"].approvalCount >= 2
+                type: integer
+              approved:
+                description: |-
+                  Approved is true when the pull request has at least one approved review
+                  and no outstanding change-request reviews. Written by PRStatusReconciler.
+                  CEL: bundle.pr["staging"].isApproved
+                type: boolean
               lastCheckedAt:
                 description: LastCheckedAt records the timestamp of the most recent
                   SCM API poll.

--- a/docs/policy-gates.md
+++ b/docs/policy-gates.md
@@ -150,6 +150,17 @@ Bundles by creation time.
 | `upstream.<env>.lastPromotedAt` | string | RFC3339 timestamp of the last successful promotion for `<env>` (empty string if never) |
 | `upstream.<env>.soakMinutes` | int | Minutes since the current bundle's health check for `<env>` (unchanged) |
 
+### PR review attributes (K-08)
+
+Available when the stage has `approval: pr-review`. The review state is written by the
+PRStatus controller to `PRStatus.status.approved` / `status.approvalCount` — no
+external API calls are made during gate evaluation.
+
+| Attribute | Type | Description |
+|---|---|---|
+| `bundle.pr["<stageName>"].isApproved` | bool | True when the PR for the named stage has at least one approval and no outstanding change-request reviews |
+| `bundle.pr["<stageName>"].approvalCount` | int | Number of distinct approving reviews on the stage PR |
+
 Examples:
 
 ```yaml
@@ -168,6 +179,19 @@ expression: |
   upstream.staging.recentSuccessCount >= 3 &&
   !changewindow["holiday-freeze"]
 ```
+
+# Block until the staging PR is approved
+expression: 'bundle.pr["staging"].isApproved'
+
+# Require at least 2 approvers before promoting to prod
+expression: 'bundle.pr["staging"].approvalCount >= 2'
+
+# Combine PR review with time gate
+expression: '!schedule.isWeekend && bundle.pr["staging"].isApproved'
+```
+
+When no PRStatus exists for the named stage (e.g. the `open-pr` step has not run yet),
+`bundle.pr["staging"]` returns an empty map — `isApproved` evaluates to `false` (fail-closed).
 
 ### Planned attributes (not yet available)
 
@@ -231,6 +255,11 @@ expression: |
   !schedule.isWeekend &&
   bundle.provenance.author != "dependabot[bot]" &&
   bundle.upstreamSoakMinutes >= 30
+
+# PR review AND time gate — 2+ approvals required on business days
+expression: |
+  !schedule.isWeekend &&
+  bundle.pr["staging"].approvalCount >= 2
 ```
 
 ## Skip Permissions

--- a/pkg/reconciler/policygate/reconciler.go
+++ b/pkg/reconciler/policygate/reconciler.go
@@ -257,6 +257,15 @@ func (r *Reconciler) buildContext(ctx context.Context, gate *kardinalv1alpha1.Po
 	}
 	bundleCtx["upstreamSoakMinutes"] = maxSoakMinutes
 
+	// Build PR review context (K-08): bundle.pr["<envName>"].isApproved / .approvalCount
+	// Reads PRStatus CRDs labelled with this bundle. Non-fatal on error.
+	prCtx, prErr := r.buildPRContext(ctx, gate.Namespace, bundleName)
+	if prErr != nil {
+		zerolog.Ctx(ctx).Warn().Err(prErr).Msg("failed to build PR context, using empty")
+		prCtx = map[string]interface{}{}
+	}
+	bundleCtx["pr"] = prCtx
+
 	return map[string]interface{}{
 		"bundle": bundleCtx,
 		"schedule": map[string]interface{}{
@@ -462,6 +471,40 @@ func (r *Reconciler) buildChangeWindowContext(ctx context.Context, now time.Time
 		result[cw.Name] = active
 	}
 	return result
+}
+
+// buildPRContext lists PRStatus CRDs for this bundle and returns a map
+// keyed by environment name:
+//
+//	{"staging": {"isApproved": true, "approvalCount": 2}, "prod": {...}}
+//
+// CEL usage: bundle.pr["staging"].isApproved  — true/false
+//
+//	bundle.pr["staging"].approvalCount >= 2
+//
+// K-08: the review state is written by PRStatusReconciler to CRD status,
+// so this is a pure CRD status read — no external API calls in the hot path.
+func (r *Reconciler) buildPRContext(ctx context.Context, ns, bundleName string) (map[string]interface{}, error) {
+	var list kardinalv1alpha1.PRStatusList
+	if err := r.List(ctx, &list,
+		client.InNamespace(ns),
+		client.MatchingLabels{"kardinal.io/bundle": bundleName},
+	); err != nil {
+		return nil, fmt.Errorf("list prstatus for bundle %s: %w", bundleName, err)
+	}
+
+	result := make(map[string]interface{}, len(list.Items))
+	for _, prs := range list.Items {
+		envName := prs.Labels["kardinal.io/environment"]
+		if envName == "" {
+			continue
+		}
+		result[envName] = map[string]interface{}{
+			"isApproved":    prs.Status.Approved,
+			"approvalCount": int64(prs.Status.ApprovalCount),
+		}
+	}
+	return result, nil
 }
 
 // patchStatus patches the PolicyGate's status fields.

--- a/pkg/reconciler/policygate/reconciler_test.go
+++ b/pkg/reconciler/policygate/reconciler_test.go
@@ -1233,3 +1233,138 @@ func TestPolicyGateReconciler_CrossStageHistory_NoPipelineLabel(t *testing.T) {
 	_, reconcileErr := r.Reconcile(context.Background(), req)
 	require.NoError(t, reconcileErr, "missing pipeline label must not crash reconciler")
 }
+
+
+// makePRStatus creates a PRStatus with the given bundle, environment and approval state.
+func makePRStatus(name, ns, bundleName, envName string, approved bool, approvalCount int) *kardinalv1alpha1.PRStatus {
+	return &kardinalv1alpha1.PRStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				"kardinal.io/bundle":      bundleName,
+				"kardinal.io/environment": envName,
+			},
+		},
+		Spec: kardinalv1alpha1.PRStatusSpec{
+			PRNumber: 42, Repo: "owner/repo",
+			PRURL: "https://github.com/owner/repo/pull/42",
+		},
+		Status: kardinalv1alpha1.PRStatusStatus{
+			Approved: approved, ApprovalCount: approvalCount, Open: true,
+		},
+	}
+}
+
+// TestPolicyGateReconciler_PRReviewGate_Approved verifies that bundle.pr["prod"].isApproved
+// evaluates to true when the PRStatus CRD has status.approved=true (K-08).
+func TestPolicyGateReconciler_PRReviewGate_Approved(t *testing.T) {
+	bundle := makeBundle("app-v1", "default")
+	prs := makePRStatus("prstatus-app-v1-prod", "default", "app-v1", "prod", true, 1)
+	gate := makeGateInstance("pr-review-gate", "default", "app-v1",
+		`bundle.pr["prod"].isApproved`, "5m")
+
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(gate, bundle, prs).WithStatusSubresource(gate).Build()
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+
+	r := &policygate.Reconciler{Client: c, Evaluator: celpkg.NewEvaluator(env), NowFn: time.Now}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: gate.Name, Namespace: gate.Namespace}}
+
+	_, reconcileErr := r.Reconcile(context.Background(), req)
+	require.NoError(t, reconcileErr)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
+	assert.True(t, got.Status.Ready, "gate must pass when PR is approved")
+}
+
+// TestPolicyGateReconciler_PRReviewGate_NotApproved verifies that bundle.pr["prod"].isApproved
+// evaluates to false when the PRStatus has status.approved=false (K-08).
+func TestPolicyGateReconciler_PRReviewGate_NotApproved(t *testing.T) {
+	bundle := makeBundle("app-v1", "default")
+	prs := makePRStatus("prstatus-app-v1-prod", "default", "app-v1", "prod", false, 0)
+	gate := makeGateInstance("pr-review-gate", "default", "app-v1",
+		`bundle.pr["prod"].isApproved`, "5m")
+
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(gate, bundle, prs).WithStatusSubresource(gate).Build()
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+
+	r := &policygate.Reconciler{Client: c, Evaluator: celpkg.NewEvaluator(env), NowFn: time.Now}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: gate.Name, Namespace: gate.Namespace}}
+
+	_, reconcileErr := r.Reconcile(context.Background(), req)
+	require.NoError(t, reconcileErr)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
+	assert.False(t, got.Status.Ready, "gate must block when PR is not approved")
+}
+
+// TestPolicyGateReconciler_PRReviewGate_MinReviewers verifies that
+// bundle.pr["prod"].approvalCount >= 2 works correctly (K-08).
+func TestPolicyGateReconciler_PRReviewGate_MinReviewers(t *testing.T) {
+	tests := []struct {
+		name          string
+		approvalCount int
+		wantReady     bool
+	}{
+		{"1 approval (need 2) — blocks", 1, false},
+		{"2 approvals (need 2) — passes", 2, true},
+		{"3 approvals (need 2) — passes", 3, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bundle := makeBundle("app-v1", "default")
+			prs := makePRStatus("prstatus-app-v1-prod", "default", "app-v1", "prod", tt.approvalCount >= 1, tt.approvalCount)
+			gate := makeGateInstance("min-reviewers-gate", "default", "app-v1",
+				`bundle.pr["prod"].approvalCount >= 2`, "5m")
+
+			s := newScheme()
+			c := fake.NewClientBuilder().WithScheme(s).
+				WithObjects(gate, bundle, prs).WithStatusSubresource(gate).Build()
+			env, err := celpkg.NewCELEnvironment()
+			require.NoError(t, err)
+
+			r := &policygate.Reconciler{Client: c, Evaluator: celpkg.NewEvaluator(env), NowFn: time.Now}
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: gate.Name, Namespace: gate.Namespace}}
+
+			_, reconcileErr := r.Reconcile(context.Background(), req)
+			require.NoError(t, reconcileErr)
+
+			var got kardinalv1alpha1.PolicyGate
+			require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
+			assert.Equal(t, tt.wantReady, got.Status.Ready, tt.name)
+		})
+	}
+}
+
+// TestPolicyGateReconciler_PRReviewGate_NoPRStatus verifies that when no PRStatus
+// exists for the stage, bundle.pr["prod"].isApproved defaults to false (K-08).
+func TestPolicyGateReconciler_PRReviewGate_NoPRStatus(t *testing.T) {
+	bundle := makeBundle("app-v1", "default")
+	// No PRStatus objects — gate must block (fail-closed).
+	gate := makeGateInstance("pr-review-gate", "default", "app-v1",
+		`bundle.pr["prod"].isApproved`, "5m")
+
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(gate, bundle).WithStatusSubresource(gate).Build()
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+
+	r := &policygate.Reconciler{Client: c, Evaluator: celpkg.NewEvaluator(env), NowFn: time.Now}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: gate.Name, Namespace: gate.Namespace}}
+
+	_, reconcileErr := r.Reconcile(context.Background(), req)
+	require.NoError(t, reconcileErr)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
+	assert.False(t, got.Status.Ready, "gate must block when no PRStatus exists (fail-closed)")
+}

--- a/pkg/reconciler/policygate/reconciler_test.go
+++ b/pkg/reconciler/policygate/reconciler_test.go
@@ -1234,7 +1234,6 @@ func TestPolicyGateReconciler_CrossStageHistory_NoPipelineLabel(t *testing.T) {
 	require.NoError(t, reconcileErr, "missing pipeline label must not crash reconciler")
 }
 
-
 // makePRStatus creates a PRStatus with the given bundle, environment and approval state.
 func makePRStatus(name, ns, bundleName, envName string, approved bool, approvalCount int) *kardinalv1alpha1.PRStatus {
 	return &kardinalv1alpha1.PRStatus{

--- a/pkg/reconciler/promotionstep/reconciler_health_test.go
+++ b/pkg/reconciler/promotionstep/reconciler_health_test.go
@@ -58,6 +58,9 @@ func (n *noopSCM) CommentOnPR(_ context.Context, _ string, _ int, _ string) erro
 func (n *noopSCM) GetPRStatus(_ context.Context, _ string, _ int) (bool, bool, error) {
 	return false, false, nil
 }
+func (n *noopSCM) GetPRReviewStatus(_ context.Context, _ string, _ int) (bool, int, error) {
+	return false, 0, nil
+}
 func (n *noopSCM) ParseWebhookEvent(_ []byte, _ string) (scm.WebhookEvent, error) {
 	return scm.WebhookEvent{}, nil
 }

--- a/pkg/reconciler/promotionstep/reconciler_test.go
+++ b/pkg/reconciler/promotionstep/reconciler_test.go
@@ -62,6 +62,9 @@ func (m *mockSCM) GetPRStatus(_ context.Context, _ string, _ int) (bool, bool, e
 	m.getPRCalled++
 	return m.merged, m.open, nil
 }
+func (m *mockSCM) GetPRReviewStatus(_ context.Context, _ string, _ int) (bool, int, error) {
+	return false, 0, nil
+}
 func (m *mockSCM) ParseWebhookEvent(_ []byte, _ string) (scm.WebhookEvent, error) {
 	return scm.WebhookEvent{}, nil
 }

--- a/pkg/reconciler/prstatus/reconciler.go
+++ b/pkg/reconciler/prstatus/reconciler.go
@@ -18,10 +18,13 @@
 // Architecture:
 //   - PRStatus CRs are created by the open-pr step (or by the webhook on
 //     the first merged-PR event) with spec.prURL, spec.prNumber, spec.repo.
-//   - This reconciler polls GitHub via SCM.GetPRStatus and writes
-//     status.merged, status.open, status.lastCheckedAt.
+//   - This reconciler polls GitHub via SCM.GetPRStatus and SCM.GetPRReviewStatus
+//     and writes status.merged, status.open, status.approved, status.approvalCount,
+//     status.lastCheckedAt.
 //   - The Graph Watch node reads status.merged to advance the Graph DAG,
 //     replacing the old polling loop in handleWaitingForMerge.
+//   - PolicyGate CEL expressions can use bundle.pr("stage").isApproved() which
+//     reads status.approved from the PRStatus CRD (K-08).
 //   - Idempotent: reconciling a PRStatus with status.merged=true is a no-op.
 //
 // Graph-purity: eliminates PS-4, SCM-2, ST-10, ST-11, BU-3, WH-1.
@@ -109,11 +112,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: requeuePollInterval}, nil
 	}
 
+	// Poll review approval state (K-08: PR review gate).
+	// Non-fatal on error — approval state defaults to false.
+	approved, approvalCount, reviewErr := r.SCM.GetPRReviewStatus(ctx, prs.Spec.Repo, prs.Spec.PRNumber)
+	if reviewErr != nil {
+		log.Warn().Err(reviewErr).
+			Str("prURL", prs.Spec.PRURL).
+			Int("prNumber", prs.Spec.PRNumber).
+			Msg("GetPRReviewStatus failed (non-fatal), defaulting approved=false")
+		// Keep previous approved/approvalCount values if available.
+		approved = prs.Status.Approved
+		approvalCount = prs.Status.ApprovalCount
+	}
+
 	// Write results to status — this is the only CRD status this reconciler writes.
 	now := metav1.NewTime(time.Now().UTC())
 	patch := client.MergeFrom(prs.DeepCopy())
 	prs.Status.Merged = merged
 	prs.Status.Open = open
+	prs.Status.Approved = approved
+	prs.Status.ApprovalCount = approvalCount
 	prs.Status.LastCheckedAt = &now
 
 	if err := r.Status().Patch(ctx, &prs, patch); err != nil {

--- a/pkg/reconciler/prstatus/reconciler_test.go
+++ b/pkg/reconciler/prstatus/reconciler_test.go
@@ -17,6 +17,7 @@ package prstatus_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,17 +34,26 @@ import (
 )
 
 // fakeSCM implements scm.SCMProvider for testing.
-// Only GetPRStatus is exercised; all other methods are no-ops.
+// Both GetPRStatus and GetPRReviewStatus are exercised by test cases.
 type fakeSCM struct {
-	merged bool
-	open   bool
-	err    error
-	calls  int
+	merged        bool
+	open          bool
+	err           error
+	calls         int
+	approved      bool
+	approvalCount int
+	reviewErr     error
+	reviewCalls   int
 }
 
 func (f *fakeSCM) GetPRStatus(_ context.Context, _ string, _ int) (merged, open bool, err error) {
 	f.calls++
 	return f.merged, f.open, f.err
+}
+
+func (f *fakeSCM) GetPRReviewStatus(_ context.Context, _ string, _ int) (approved bool, approvalCount int, err error) {
+	f.reviewCalls++
+	return f.approved, f.approvalCount, f.reviewErr
 }
 
 func (f *fakeSCM) OpenPR(_ context.Context, _, _, _, _, _ string) (string, int, error) {
@@ -361,4 +371,91 @@ func TestReconciler_ZeroPRNumber_NoSCMCall(t *testing.T) {
 	require.NoError(t, err, "zero prNumber must not error (#276 regression)")
 	assert.Equal(t, 0, scm.calls,
 		"GetPRStatus must NOT be called for PRStatus with prNumber=0 (#276 regression)")
+}
+
+// TestReconciler_ReviewStatus_PollsApprovedState verifies that the reconciler
+// calls GetPRReviewStatus and writes status.approved + status.approvalCount.
+func TestReconciler_ReviewStatus_PollsApprovedState(t *testing.T) {
+	tests := []struct {
+		name                string
+		approved            bool
+		approvalCount       int
+		expectApproved      bool
+		expectApprovalCount int
+	}{
+		{"no approvals", false, 0, false, 0},
+		{"one approval", true, 1, true, 1},
+		{"two approvals", true, 2, true, 2},
+		{"change requested blocks", false, 1, false, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := buildScheme(t)
+			prs := &v1alpha1.PRStatus{
+				ObjectMeta: metav1.ObjectMeta{Name: "pr-reviews", Namespace: "default"},
+				Spec: v1alpha1.PRStatusSpec{
+					PRURL: "https://github.com/owner/repo/pull/7", PRNumber: 7, Repo: "owner/repo",
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(prs).
+				WithStatusSubresource(&v1alpha1.PRStatus{}).Build()
+			fakeSCM := &fakeSCM{
+				merged:        false,
+				open:          true,
+				approved:      tt.approved,
+				approvalCount: tt.approvalCount,
+			}
+			r := &prstatus.Reconciler{Client: fakeClient, SCM: fakeSCM}
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "pr-reviews", Namespace: "default"},
+			})
+			require.NoError(t, err)
+
+			var updated v1alpha1.PRStatus
+			require.NoError(t, fakeClient.Get(context.Background(),
+				types.NamespacedName{Name: "pr-reviews", Namespace: "default"}, &updated))
+
+			assert.Equal(t, tt.expectApproved, updated.Status.Approved, "status.approved")
+			assert.Equal(t, tt.expectApprovalCount, updated.Status.ApprovalCount, "status.approvalCount")
+			assert.Equal(t, 1, fakeSCM.reviewCalls, "GetPRReviewStatus should be called once")
+		})
+	}
+}
+
+// TestReconciler_ReviewStatus_FallbackOnError verifies that when GetPRReviewStatus
+// fails, the reconciler preserves the previous approved state and does not error.
+func TestReconciler_ReviewStatus_FallbackOnError(t *testing.T) {
+	scheme := buildScheme(t)
+	prs := &v1alpha1.PRStatus{
+		ObjectMeta: metav1.ObjectMeta{Name: "pr-fallback", Namespace: "default"},
+		Spec: v1alpha1.PRStatusSpec{
+			PRURL: "https://github.com/owner/repo/pull/9", PRNumber: 9, Repo: "owner/repo",
+		},
+		Status: v1alpha1.PRStatusStatus{
+			Approved: true, ApprovalCount: 2, // pre-existing good state
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(prs).
+		WithStatusSubresource(&v1alpha1.PRStatus{}).Build()
+	fakeSCM := &fakeSCM{
+		merged:    false,
+		open:      true,
+		reviewErr: fmt.Errorf("GitHub API 503"),
+	}
+	r := &prstatus.Reconciler{Client: fakeClient, SCM: fakeSCM}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "pr-fallback", Namespace: "default"},
+	})
+	require.NoError(t, err, "review error must not propagate")
+
+	var updated v1alpha1.PRStatus
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Name: "pr-fallback", Namespace: "default"}, &updated))
+
+	// Must preserve previous approved state when review poll fails.
+	assert.True(t, updated.Status.Approved, "approved must be preserved on review error")
+	assert.Equal(t, 2, updated.Status.ApprovalCount, "approvalCount must be preserved on review error")
 }

--- a/pkg/scm/forgejo.go
+++ b/pkg/scm/forgejo.go
@@ -182,6 +182,51 @@ func (f *ForgejoProvider) GetPRStatus(ctx context.Context, repo string, prNumber
 	return result.Merged, open, nil
 }
 
+// GetPRReviewStatus returns review approval state for a Forgejo/Gitea pull request.
+// Forgejo's review API returns all reviews; we take the latest state per user.
+// approved is true when at least one approving review exists and no
+// change-request review is outstanding. approvalCount is distinct approvers.
+func (f *ForgejoProvider) GetPRReviewStatus(ctx context.Context, repo string, prNumber int) (bool, int, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return false, 0, err
+	}
+	var reviews []struct {
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		State string `json:"state"`
+	}
+	if err := f.do(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v1/repos/%s/%s/pulls/%d/reviews", owner, name, prNumber), nil, &reviews); err != nil {
+		return false, 0, fmt.Errorf("get PR reviews %s#%d: %w", repo, prNumber, err)
+	}
+
+	// Take the most recent review per user.
+	latestByUser := make(map[string]string, len(reviews))
+	for _, r := range reviews {
+		if r.User.Login == "" {
+			continue
+		}
+		switch r.State {
+		case "APPROVED", "REQUEST_CHANGES":
+			latestByUser[r.User.Login] = r.State
+		}
+	}
+
+	approvalCount := 0
+	hasChangeRequest := false
+	for _, state := range latestByUser {
+		switch state {
+		case "APPROVED":
+			approvalCount++
+		case "REQUEST_CHANGES":
+			hasChangeRequest = true
+		}
+	}
+	return approvalCount > 0 && !hasChangeRequest, approvalCount, nil
+}
+
 // ParseWebhookEvent parses a Forgejo/Gitea pull request webhook payload.
 // Forgejo signs payloads with HMAC-SHA256 and sends the hex digest in
 // the X-Gitea-Signature header (same algorithm as GitHub's X-Hub-Signature-256).

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -144,6 +144,52 @@ func (g *GitHubProvider) GetPRStatus(ctx context.Context, repo string, prNumber 
 	return result.Merged, result.State == "open", nil
 }
 
+// GetPRReviewStatus returns review approval state for a pull request.
+// approved is true when at least one approving review exists and no change-request
+// review is outstanding. approvalCount counts distinct approving reviewers.
+//
+// The GitHub Reviews API returns all reviews in submission order; we process
+// them chronologically so the last review from each user wins.
+func (g *GitHubProvider) GetPRReviewStatus(ctx context.Context, repo string, prNumber int) (bool, int, error) {
+	var reviews []struct {
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		State string `json:"state"`
+	}
+	if err := g.do(ctx, http.MethodGet,
+		fmt.Sprintf("/repos/%s/pulls/%d/reviews", repo, prNumber), nil, &reviews); err != nil {
+		return false, 0, fmt.Errorf("get PR reviews %s#%d: %w", repo, prNumber, err)
+	}
+
+	// Track the most recent state per reviewer login.
+	latestByUser := make(map[string]string, len(reviews))
+	for _, r := range reviews {
+		if r.User.Login == "" {
+			continue
+		}
+		// Only APPROVED and CHANGES_REQUESTED affect the approval decision.
+		switch r.State {
+		case "APPROVED", "CHANGES_REQUESTED":
+			latestByUser[r.User.Login] = r.State
+		}
+	}
+
+	approvalCount := 0
+	hasChangeRequest := false
+	for _, state := range latestByUser {
+		switch state {
+		case "APPROVED":
+			approvalCount++
+		case "CHANGES_REQUESTED":
+			hasChangeRequest = true
+		}
+	}
+
+	approved := approvalCount > 0 && !hasChangeRequest
+	return approved, approvalCount, nil
+}
+
 // ParseWebhookEvent parses a GitHub webhook payload and validates the HMAC-SHA256 signature.
 func (g *GitHubProvider) ParseWebhookEvent(payload []byte, signature string) (WebhookEvent, error) {
 	if g.WebhookSecret != "" {

--- a/pkg/scm/gitlab.go
+++ b/pkg/scm/gitlab.go
@@ -161,6 +161,27 @@ func (g *GitLabProvider) GetPRStatus(ctx context.Context, repo string, prNumber 
 	return merged, open, nil
 }
 
+// GetPRReviewStatus returns review approval state for a GitLab merge request.
+// GitLab MR approvals require the Approvals API (available on all tiers).
+// approved is true when the MR has at least one approval.
+// approvalCount is the number of distinct approvers.
+func (g *GitLabProvider) GetPRReviewStatus(ctx context.Context, repo string, prNumber int) (bool, int, error) {
+	projectID := encodeProjectID(repo)
+	var result struct {
+		ApprovedBy []struct {
+			User struct {
+				Username string `json:"username"`
+			} `json:"user"`
+		} `json:"approved_by"`
+	}
+	if err := g.do(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d/approvals", projectID, prNumber), nil, &result); err != nil {
+		return false, 0, fmt.Errorf("get MR approvals %s!%d: %w", repo, prNumber, err)
+	}
+	count := len(result.ApprovedBy)
+	return count > 0, count, nil
+}
+
 // ParseWebhookEvent parses a GitLab merge request webhook payload and validates
 // the X-Gitlab-Token header using constant-time comparison.
 // The caller must pass the value of the X-Gitlab-Token header as signature.

--- a/pkg/scm/provider.go
+++ b/pkg/scm/provider.go
@@ -48,6 +48,12 @@ type SCMProvider interface {
 	// GetPRStatus returns whether the PR has been merged and whether it is still open.
 	GetPRStatus(ctx context.Context, repo string, prNumber int) (merged bool, open bool, err error)
 
+	// GetPRReviewStatus returns the review approval state of the PR.
+	// approved is true when at least one approving review exists and no
+	// change-request review is outstanding.
+	// approvalCount is the number of distinct approving reviews.
+	GetPRReviewStatus(ctx context.Context, repo string, prNumber int) (approved bool, approvalCount int, err error)
+
 	// ParseWebhookEvent parses a raw webhook payload and validates the HMAC signature.
 	ParseWebhookEvent(payload []byte, signature string) (WebhookEvent, error)
 

--- a/pkg/steps/steps/steps_test.go
+++ b/pkg/steps/steps/steps_test.go
@@ -98,6 +98,10 @@ func (m *mockSCMProvider) GetPRStatus(_ context.Context, _ string, _ int) (bool,
 	return m.merged, m.open, m.getPRErr
 }
 
+func (m *mockSCMProvider) GetPRReviewStatus(_ context.Context, _ string, _ int) (bool, int, error) {
+	return false, 0, nil
+}
+
 func (m *mockSCMProvider) ParseWebhookEvent(_ []byte, _ string) (scm.WebhookEvent, error) {
 	return scm.WebhookEvent{}, nil
 }

--- a/test/e2e/promotion_loop_test.go
+++ b/test/e2e/promotion_loop_test.go
@@ -62,6 +62,9 @@ func (m *mockSCMForLoop) CommentOnPR(_ context.Context, _ string, _ int, _ strin
 func (m *mockSCMForLoop) GetPRStatus(_ context.Context, _ string, _ int) (bool, bool, error) {
 	return m.merged, m.open, nil
 }
+func (m *mockSCMForLoop) GetPRReviewStatus(_ context.Context, _ string, _ int) (bool, int, error) {
+	return false, 0, nil
+}
 func (m *mockSCMForLoop) ParseWebhookEvent(payload []byte, _ string) (scm.WebhookEvent, error) {
 	var raw struct {
 		Action      string `json:"action"`


### PR DESCRIPTION
## Summary

Implements K-08: PR review gate — `bundle.pr["staging"].isApproved` and `.approvalCount` CEL functions.

**Architecture: pure Watch-node pattern**
- `GetPRReviewStatus` added to `SCMProvider` interface (GitHub, GitLab, Forgejo)
- `PRStatusReconciler` polls review state and writes `status.approved` + `status.approvalCount` to `PRStatus` CRD
- `PolicyGate.buildContext` reads PRStatus CRDs (labelled by bundle) and exposes `bundle.pr["<env>"]` map
- No external API calls in the gate evaluation hot path — review state is CRD-observable

## CEL expressions

```yaml
# Block until the staging PR is approved
expression: 'bundle.pr["staging"].isApproved'

# Require at least 2 approvers
expression: 'bundle.pr["staging"].approvalCount >= 2'

# Combine with time gate
expression: '!schedule.isWeekend && bundle.pr["staging"].isApproved'
```

## Changes

- `api/v1alpha1/prstatus_types.go` — add `Approved bool`, `ApprovalCount int` to `PRStatusStatus`
- `pkg/scm/provider.go` — add `GetPRReviewStatus` to interface
- `pkg/scm/github.go` — implement `GetPRReviewStatus` using GitHub Reviews API
- `pkg/scm/gitlab.go` — implement `GetPRReviewStatus` using GitLab Approvals API
- `pkg/scm/forgejo.go` — implement `GetPRReviewStatus` using Forgejo Reviews API
- `pkg/reconciler/prstatus/reconciler.go` — poll review state, non-fatal on error
- `pkg/reconciler/policygate/reconciler.go` — add `buildPRContext`, expose `bundle.pr[envName]`
- `docs/policy-gates.md` — PR review attributes section + composite examples

## Tests

7 new tests:
- `TestReconciler_ReviewStatus_PollsApprovedState` (prstatus)
- `TestReconciler_ReviewStatus_FallbackOnError` (prstatus)
- `TestPolicyGateReconciler_PRReviewGate_Approved` (policygate)
- `TestPolicyGateReconciler_PRReviewGate_NotApproved` (policygate)
- `TestPolicyGateReconciler_PRReviewGate_MinReviewers` (policygate)
- `TestPolicyGateReconciler_PRReviewGate_NoPRStatus` (policygate)
- All existing tests pass

## Self-validation

```
go build ./...     ✅
go test ./... -race  ✅ (e2e skipped: no kind cluster)
go vet ./...       ✅ zero findings
```

Closes #452