### PR TITLE
feat(policygate): cross-stage history CEL context — upstream.<env>.recentSuccessCount (K-10, closes #453)

### DIFF
--- a/docs/policy-gates.md
+++ b/docs/policy-gates.md
@@ -137,6 +137,38 @@ All PolicyGate expressions are evaluated against the following context. All attr
 | `bundle.upstreamSoakMinutes` | int | Minutes since upstream environment was verified |
 | `previousBundle.version` | string | Previously deployed version in this environment |
 
+### Cross-stage history attributes (K-10)
+
+Available for all gates. The history is computed from Bundle CRD status across the last 10
+promotions for the pipeline — no external API calls. The lookup is scoped to the last 10
+Bundles by creation time.
+
+| Attribute | Type | Description |
+|---|---|---|
+| `upstream.<env>.recentSuccessCount` | int | Number of bundles with `Verified` status for `<env>` in the last 10 promotions |
+| `upstream.<env>.recentFailureCount` | int | Number of bundles with `Failed` status for `<env>` in the last 10 promotions |
+| `upstream.<env>.lastPromotedAt` | string | RFC3339 timestamp of the last successful promotion for `<env>` (empty string if never) |
+| `upstream.<env>.soakMinutes` | int | Minutes since the current bundle's health check for `<env>` (unchanged) |
+
+Examples:
+
+```yaml
+# Block prod until staging has been successfully promoted at least 3 times recently
+expression: 'upstream.staging.recentSuccessCount >= 3'
+
+# Block if staging recently had 2+ failures (quality gate)
+expression: 'upstream.staging.recentFailureCount < 2'
+
+# Block if staging has never been promoted
+expression: 'upstream.staging.lastPromotedAt != ""'
+
+# Composite: soak + recent success history
+expression: |
+  upstream.staging.soakMinutes >= 60 &&
+  upstream.staging.recentSuccessCount >= 3 &&
+  !changewindow["holiday-freeze"]
+```
+
 ### Planned attributes (not yet available)
 
 !!! warning "Not yet implemented"

--- a/pkg/reconciler/policygate/reconciler.go
+++ b/pkg/reconciler/policygate/reconciler.go
@@ -28,8 +28,12 @@ const (
 	labelBundle = "kardinal.io/bundle"
 	// labelEnvironment is the environment the gate is evaluated for.
 	labelEnvironment = "kardinal.io/environment"
+	// labelPipeline is the pipeline the gate is associated with.
+	labelPipeline = "kardinal.io/pipeline"
 	// defaultRecheckInterval is used when gate.Spec.RecheckInterval is empty or invalid.
 	defaultRecheckInterval = 5 * time.Minute
+	// historyLimit is the number of recent Bundles to include in history stats.
+	historyLimit = 10
 )
 
 // Reconciler evaluates PolicyGate CEL expressions and patches status.
@@ -230,9 +234,15 @@ func (r *Reconciler) buildContext(ctx context.Context, gate *kardinalv1alpha1.Po
 		metricsCtx = map[string]interface{}{}
 	}
 
-	// Build upstream soak context from bundle environment statuses.
+	// Build upstream soak context from bundle environment statuses,
+	// enriched with cross-stage history from all Bundles in the pipeline (K-10).
 	// SoakMinutes is read from Bundle.status.environments[*].soakMinutes (PG-3 fix).
-	upstreamCtx := buildUpstreamContext(&bundle)
+	pipelineName := gate.Labels[labelPipeline]
+	upstreamCtx, upstreamErr := r.buildUpstreamContextWithHistory(ctx, gate.Namespace, pipelineName, &bundle)
+	if upstreamErr != nil {
+		zerolog.Ctx(ctx).Warn().Err(upstreamErr).Msg("failed to build upstream history context, using basic soak only")
+		upstreamCtx = buildUpstreamContext(&bundle)
+	}
 
 	// bundle.upstreamSoakMinutes is the maximum soak minutes across all verified
 	// upstream environments. It is a convenience shorthand so expressions can write
@@ -295,6 +305,126 @@ func buildUpstreamContext(bundle *kardinalv1alpha1.Bundle) map[string]interface{
 		}
 	}
 	return result
+}
+
+// buildUpstreamContextWithHistory extends buildUpstreamContext with cross-stage
+// promotion history (K-10). It lists the last historyLimit Bundles for the same
+// pipeline and computes per-environment history stats:
+//
+//   - soakMinutes         — contiguous healthy minutes (from current bundle)
+//   - recentSuccessCount  — number of Verified bundles in last historyLimit
+//   - recentFailureCount  — number of Failed bundles in last historyLimit
+//   - lastPromotedAt      — RFC3339 timestamp of last verified promotion (or "")
+//
+// CEL usage:
+//
+//	upstream.staging.recentSuccessCount >= 3    # last 3 staging promotions succeeded
+//	upstream.staging.lastPromotedAt != ""       # staging was ever promoted
+//
+// Graph-purity: reads Bundle CRD status only. No external API calls.
+// Non-fatal: on List error, falls back to basic soakMinutes-only context.
+func (r *Reconciler) buildUpstreamContextWithHistory(
+	ctx context.Context, ns, pipelineName string,
+	currentBundle *kardinalv1alpha1.Bundle,
+) (map[string]interface{}, error) {
+	// Start with current bundle's soak data (always available).
+	result := buildUpstreamContext(currentBundle)
+
+	if pipelineName == "" {
+		// No pipeline label — cannot query history. Return soak-only context.
+		return result, nil
+	}
+
+	// List all Bundles for this pipeline in the same namespace.
+	var list kardinalv1alpha1.BundleList
+	if err := r.List(ctx, &list, client.InNamespace(ns)); err != nil {
+		return nil, fmt.Errorf("list bundles in namespace %s: %w", ns, err)
+	}
+
+	// Filter to this pipeline only (in-memory filter — no field indexer required).
+	var pipelineBundles []kardinalv1alpha1.Bundle
+	for _, b := range list.Items {
+		if b.Spec.Pipeline == pipelineName {
+			pipelineBundles = append(pipelineBundles, b)
+		}
+	}
+
+	// Sort by creation time (newest first) to take the last historyLimit.
+	sorted := sortBundlesByCreationDesc(pipelineBundles)
+	if len(sorted) > historyLimit {
+		sorted = sorted[:historyLimit]
+	}
+
+	// Per-environment stats across the last historyLimit bundles.
+	type envStats struct {
+		successCount int64
+		failureCount int64
+		lastAt       string // RFC3339 or ""
+	}
+	stats := make(map[string]*envStats)
+
+	for _, b := range sorted {
+		for _, env := range b.Status.Environments {
+			if _, ok := stats[env.Name]; !ok {
+				stats[env.Name] = &envStats{}
+			}
+			st := stats[env.Name]
+			switch env.Phase {
+			case "Verified":
+				st.successCount++
+				// Track latest verified timestamp.
+				if env.HealthCheckedAt != nil {
+					ts := env.HealthCheckedAt.UTC().Format(time.RFC3339)
+					if st.lastAt == "" || ts > st.lastAt {
+						st.lastAt = ts
+					}
+				}
+			case "Failed":
+				st.failureCount++
+			}
+		}
+	}
+
+	// Merge history stats into the upstream context.
+	for envName, st := range stats {
+		existing, ok := result[envName].(map[string]interface{})
+		if !ok {
+			existing = map[string]interface{}{"soakMinutes": int64(0)}
+		}
+		existing["recentSuccessCount"] = st.successCount
+		existing["recentFailureCount"] = st.failureCount
+		existing["lastPromotedAt"] = st.lastAt
+		result[envName] = existing
+	}
+
+	// Ensure current bundle's env entries have history fields (zero-valued).
+	for _, env := range currentBundle.Status.Environments {
+		entry, ok := result[env.Name].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if _, ok := entry["recentSuccessCount"]; !ok {
+			entry["recentSuccessCount"] = int64(0)
+			entry["recentFailureCount"] = int64(0)
+			entry["lastPromotedAt"] = ""
+		}
+		result[env.Name] = entry
+	}
+
+	return result, nil
+}
+
+// sortBundlesByCreationDesc sorts bundles newest-first by CreationTimestamp.
+// Returns a new slice; does not modify the original.
+func sortBundlesByCreationDesc(bundles []kardinalv1alpha1.Bundle) []kardinalv1alpha1.Bundle {
+	out := make([]kardinalv1alpha1.Bundle, len(bundles))
+	copy(out, bundles)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j].CreationTimestamp.After(out[j-1].CreationTimestamp.Time); j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
 }
 
 // buildChangeWindowContext lists all ChangeWindow objects cluster-wide and

--- a/pkg/reconciler/policygate/reconciler_test.go
+++ b/pkg/reconciler/policygate/reconciler_test.go
@@ -5,6 +5,7 @@ package policygate_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
@@ -1041,4 +1043,193 @@ func TestReconciler_OverrideWrongStage(t *testing.T) {
 	var got kardinalv1alpha1.PolicyGate
 	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
 	assert.False(t, got.Status.Ready, "override for 'uat' must not affect 'prod' gate")
+}
+
+// makeBundleWithHistory creates a Bundle with per-environment phase set, for history testing.
+// pipelineName is set so the history lookup can find it.
+func makeBundleWithHistory(name, ns, pipelineName string, envPhases map[string]string, createdAt metav1.Time) *kardinalv1alpha1.Bundle {
+	envStatuses := make([]kardinalv1alpha1.EnvironmentStatus, 0, len(envPhases))
+	for envName, phase := range envPhases {
+		es := kardinalv1alpha1.EnvironmentStatus{Name: envName, Phase: phase}
+		if phase == "Verified" {
+			t := metav1.NewTime(createdAt.Time)
+			es.HealthCheckedAt = &t
+		}
+		envStatuses = append(envStatuses, es)
+	}
+	return &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         ns,
+			CreationTimestamp: createdAt,
+		},
+		Spec: kardinalv1alpha1.BundleSpec{
+			Type:     "image",
+			Pipeline: pipelineName,
+		},
+		Status: kardinalv1alpha1.BundleStatus{
+			Environments: envStatuses,
+		},
+	}
+}
+
+// TestPolicyGateReconciler_CrossStageHistory_RecentSuccessCount verifies that
+// upstream.staging.recentSuccessCount counts Verified bundles correctly (K-10).
+func TestPolicyGateReconciler_CrossStageHistory_RecentSuccessCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		expr      string
+		bundles   []map[string]string // per-bundle envPhase maps
+		wantReady bool
+	}{
+		{
+			name:      "3 successes required, 3 verified (current + 2 hist) — passes",
+			expr:      `upstream.staging.recentSuccessCount >= 3`,
+			bundles:   []map[string]string{{"staging": "Verified"}, {"staging": "Verified"}},
+			wantReady: true,
+		},
+		{
+			name:      "3 successes required, only current verified + 1 hist failed — blocks",
+			expr:      `upstream.staging.recentSuccessCount >= 3`,
+			bundles:   []map[string]string{{"staging": "Failed"}, {"staging": "Failed"}},
+			wantReady: false,
+		},
+		{
+			name:      "no historical bundles — current bundle counts as 1 success — blocks for >= 2",
+			expr:      `upstream.staging.recentSuccessCount >= 2`,
+			bundles:   nil,
+			wantReady: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now()
+			allObjects := []client.Object{}
+
+			// Current bundle being promoted
+			currentBundle := makeBundleWithHistory("current", "default", "test-pipeline",
+				map[string]string{"staging": "Verified"}, metav1.NewTime(now))
+			currentBundle.Status.Environments = []kardinalv1alpha1.EnvironmentStatus{
+				{Name: "staging", Phase: "Verified", SoakMinutes: 10},
+			}
+			allObjects = append(allObjects, currentBundle)
+
+			// Historical bundles
+			for i, phases := range tt.bundles {
+				b := makeBundleWithHistory(
+					fmt.Sprintf("hist-%d", i), "default", "test-pipeline",
+					phases, metav1.NewTime(now.Add(-time.Duration(i+1)*time.Hour)),
+				)
+				allObjects = append(allObjects, b)
+			}
+
+			gate := makeGateInstance("history-gate", "default", "current", tt.expr, "5m")
+			gate.Labels["kardinal.io/pipeline"] = "test-pipeline"
+			allObjects = append(allObjects, gate)
+
+			s := newScheme()
+			c := fake.NewClientBuilder().WithScheme(s).
+				WithObjects(allObjects...).WithStatusSubresource(gate).Build()
+			env, err := celpkg.NewCELEnvironment()
+			require.NoError(t, err)
+
+			r := &policygate.Reconciler{Client: c, Evaluator: celpkg.NewEvaluator(env), NowFn: time.Now}
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: gate.Name, Namespace: gate.Namespace}}
+
+			_, reconcileErr := r.Reconcile(context.Background(), req)
+			require.NoError(t, reconcileErr)
+
+			var got kardinalv1alpha1.PolicyGate
+			require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
+			assert.Equal(t, tt.wantReady, got.Status.Ready, tt.name)
+		})
+	}
+}
+
+// TestPolicyGateReconciler_CrossStageHistory_RecentFailureCount verifies that
+// upstream.staging.recentFailureCount is correctly populated (K-10).
+func TestPolicyGateReconciler_CrossStageHistory_RecentFailureCount(t *testing.T) {
+	now := time.Now()
+	currentBundle := makeBundleWithHistory("current", "default", "my-pipeline",
+		map[string]string{}, metav1.NewTime(now))
+	hist1 := makeBundleWithHistory("hist-1", "default", "my-pipeline",
+		map[string]string{"staging": "Failed"}, metav1.NewTime(now.Add(-1*time.Hour)))
+	hist2 := makeBundleWithHistory("hist-2", "default", "my-pipeline",
+		map[string]string{"staging": "Failed"}, metav1.NewTime(now.Add(-2*time.Hour)))
+
+	// Gate blocks if more than 1 recent failure
+	gate := makeGateInstance("failure-gate", "default", "current",
+		`upstream.staging.recentFailureCount < 2`, "5m")
+	gate.Labels["kardinal.io/pipeline"] = "my-pipeline"
+
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(gate, currentBundle, hist1, hist2).WithStatusSubresource(gate).Build()
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+
+	r := &policygate.Reconciler{Client: c, Evaluator: celpkg.NewEvaluator(env), NowFn: time.Now}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: gate.Name, Namespace: gate.Namespace}}
+
+	_, reconcileErr := r.Reconcile(context.Background(), req)
+	require.NoError(t, reconcileErr)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
+	assert.False(t, got.Status.Ready, "gate must block when recentFailureCount >= 2")
+}
+
+// TestPolicyGateReconciler_CrossStageHistory_LastPromotedAt verifies that
+// upstream.staging.lastPromotedAt is non-empty after a successful promotion (K-10).
+func TestPolicyGateReconciler_CrossStageHistory_LastPromotedAt(t *testing.T) {
+	now := time.Now()
+	currentBundle := makeBundleWithHistory("current", "default", "my-pipeline",
+		map[string]string{"staging": "Verified"}, metav1.NewTime(now))
+	currentBundle.Status.Environments = []kardinalv1alpha1.EnvironmentStatus{
+		{Name: "staging", Phase: "Verified", SoakMinutes: 5,
+			HealthCheckedAt: func() *metav1.Time { t := metav1.NewTime(now); return &t }()},
+	}
+
+	// Gate passes only if staging was ever promoted
+	gate := makeGateInstance("history-gate", "default", "current",
+		`upstream.staging.lastPromotedAt != ""`, "5m")
+	gate.Labels["kardinal.io/pipeline"] = "my-pipeline"
+
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(gate, currentBundle).WithStatusSubresource(gate).Build()
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+
+	r := &policygate.Reconciler{Client: c, Evaluator: celpkg.NewEvaluator(env), NowFn: time.Now}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: gate.Name, Namespace: gate.Namespace}}
+
+	_, reconcileErr := r.Reconcile(context.Background(), req)
+	require.NoError(t, reconcileErr)
+
+	var got kardinalv1alpha1.PolicyGate
+	require.NoError(t, c.Get(context.Background(), req.NamespacedName, &got))
+	assert.True(t, got.Status.Ready, "gate must pass when staging was promoted")
+}
+
+// TestPolicyGateReconciler_CrossStageHistory_NoPipelineLabel verifies that when
+// the gate has no pipeline label, the reconciler falls back gracefully (K-10).
+func TestPolicyGateReconciler_CrossStageHistory_NoPipelineLabel(t *testing.T) {
+	bundle := makeBundle("app-v1", "default")
+	// Gate without pipeline label — should not crash
+	gate := makeGateInstance("soak-gate", "default", "app-v1", `upstream.staging.soakMinutes >= 0`, "5m")
+	delete(gate.Labels, "kardinal.io/pipeline")
+
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(gate, bundle).WithStatusSubresource(gate).Build()
+	env, err := celpkg.NewCELEnvironment()
+	require.NoError(t, err)
+
+	r := &policygate.Reconciler{Client: c, Evaluator: celpkg.NewEvaluator(env), NowFn: time.Now}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: gate.Name, Namespace: gate.Namespace}}
+
+	_, reconcileErr := r.Reconcile(context.Background(), req)
+	require.NoError(t, reconcileErr, "missing pipeline label must not crash reconciler")
 }


### PR DESCRIPTION
## Summary

Implements K-10: cross-stage history CEL functions for PolicyGate expressions.

**Architecture: pure CRD status read**
- `buildUpstreamContextWithHistory()` lists all Bundles for the pipeline in-namespace
- Sorts by creation time, takes last 10, computes per-environment history stats
- No external API calls, no time.Now() outside reconciler status write
- On error or missing pipeline label: falls back to basic soakMinutes context

## New CEL attributes

```yaml
# Block prod until staging has been successfully promoted 3+ times
expression: 'upstream.staging.recentSuccessCount >= 3'

# Block if recent failure rate is too high
expression: 'upstream.staging.recentFailureCount < 2'

# Block if staging has never been promoted
expression: 'upstream.staging.lastPromotedAt != ""'

# Composite moat expression
expression: |
  upstream.staging.soakMinutes >= 60 &&
  upstream.staging.recentSuccessCount >= 3 &&
  !changewindow["holiday-freeze"]
```

## Changes

- `pkg/reconciler/policygate/reconciler.go` — add `buildUpstreamContextWithHistory`, `sortBundlesByCreationDesc`, `historyLimit`, `labelPipeline` constant
- `docs/policy-gates.md` — §Cross-stage history attributes with examples

## Tests

4 new tests:
- `TestPolicyGateReconciler_CrossStageHistory_RecentSuccessCount` (3 cases)
- `TestPolicyGateReconciler_CrossStageHistory_RecentFailureCount`
- `TestPolicyGateReconciler_CrossStageHistory_LastPromotedAt`
- `TestPolicyGateReconciler_CrossStageHistory_NoPipelineLabel` (fallback safety)

## Self-validation

```
go build ./...     ✅
go test ./... -race  ✅ (e2e skipped: no kind cluster)
go vet ./...       ✅ zero findings
```

Closes #453