### PR TITLE
feat(ui): pipeline list operations view — sortable health columns (#462)

### DIFF
--- a/.specify/specs/500-ui-pipeline-list-ops/spec.md
+++ b/.specify/specs/500-ui-pipeline-list-ops/spec.md
@@ -1,0 +1,35 @@
+# 500-ui-pipeline-list-ops — Pipeline Operations View
+
+## Summary
+Add a sortable/filterable operations table view for the pipeline list page. Closes #462.
+
+## Problem
+Current sidebar shows name + phase only. Operators cannot triage at a glance which
+pipelines need attention — stuck promotions, blocker gates, failed steps, stale inventory.
+
+## What to build
+
+### Backend (ui_api.go)
+Extend `uiPipelineResponse` with:
+- `blockerCount` int — count of pre-deploy PolicyGates with ready=false for active bundle
+- `failedStepCount` int — count of PromotionSteps with state=Failed for active bundle
+- `inventoryAgeDays` int — days since latest bundle was created (stale inventory signal)
+- `lastMergedAt` string — RFC3339 timestamp of last successful prod promotion (last env Verified)
+- `cdLevel` string — "full-cd" / "mostly-cd" / "no-cd" derived from PolicyGate count per env
+
+### Frontend (PipelineOpsTable.tsx)
+New component rendering a full-width table with:
+- Sortable columns: Name, Status, Active Bundle, Blockers, Failed Steps, Inventory Age, Last Merge
+- Default sort: Blocked first, then by Blockers descending
+- Filter bar: filter by name substring or status
+- Color coding: red for blocked/failed, amber for stale inventory (>14 days)
+- Clickable rows → select pipeline
+
+### App.tsx
+- Toggle button: "List" (current sidebar) vs "Ops Table" (new table view)
+- When table is active, main content area shows only the table (no DAG)
+
+## Architecture
+Pure frontend + API response extension.
+No new CRDs. No CEL. No reconciler changes.
+All data derived from existing Bundle + PromotionStep + PolicyGate CRD fields.

--- a/cmd/kardinal-controller/ui_api.go
+++ b/cmd/kardinal-controller/ui_api.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
@@ -46,6 +47,21 @@ type uiPipelineResponse struct {
 	// Derived from the active Bundle's status.environments.
 	// Keys are environment names, values are the promotion phase.
 	EnvironmentStates map[string]string `json:"environmentStates,omitempty"`
+
+	// Operations table columns (#462): derived from active Bundle + steps + gates.
+	// BlockerCount is the number of PolicyGates with ready=false for the active bundle.
+	BlockerCount int `json:"blockerCount,omitempty"`
+	// FailedStepCount is the number of PromotionSteps with state=Failed for the active bundle.
+	FailedStepCount int `json:"failedStepCount,omitempty"`
+	// InventoryAgeDays is the number of days since the latest bundle was created.
+	// A high value indicates stale inventory (no recent deploys).
+	InventoryAgeDays int `json:"inventoryAgeDays,omitempty"`
+	// LastMergedAt is the RFC3339 timestamp of the last env that reached Verified.
+	// Empty string when no environment has been verified yet.
+	LastMergedAt string `json:"lastMergedAt,omitempty"`
+	// CDLevel summarises how automated this pipeline is.
+	// "full-cd" = no manual gates, "mostly-cd" = 1–2 gates, "manual" = 3+ gates.
+	CDLevel string `json:"cdLevel,omitempty"`
 }
 
 // uiBundleResponse is the JSON shape for a Bundle in the UI API.
@@ -170,8 +186,10 @@ func (s *uiAPIServer) handlePipelines(w http.ResponseWriter, r *http.Request) {
 	_ = s.client.List(r.Context(), &bundleList)
 	// Index: pipelineName → active bundle (prefer Promoting > Available > Verified)
 	type activeBundleEntry struct {
-		name      string
-		envStates map[string]string
+		name         string
+		envStates    map[string]string
+		createdAt    time.Time
+		lastVerified time.Time // most recent HealthCheckedAt across all envs in this bundle
 	}
 	activeBundles := make(map[string]*activeBundleEntry)
 	phaseOrder := map[string]int{"Promoting": 3, "Available": 2, "Verified": 1, "Failed": 0, "Superseded": -1}
@@ -193,17 +211,50 @@ func (s *uiAPIServer) handlePipelines(w http.ResponseWriter, r *http.Request) {
 		}
 		if existing == nil || newScore > existingScore {
 			envStates := make(map[string]string, len(b.Status.Environments))
+			var lastVerified time.Time
 			for _, env := range b.Status.Environments {
 				if env.Phase != "" {
 					envStates[env.Name] = env.Phase
 				}
+				// Track most recent HealthCheckedAt across all envs for lastMergedAt.
+				if env.HealthCheckedAt != nil && env.HealthCheckedAt.After(lastVerified) {
+					lastVerified = env.HealthCheckedAt.Time
+				}
 			}
 			activeBundles[key] = &activeBundleEntry{
-				name:      b.Name,
-				envStates: envStates,
+				name:         b.Name,
+				envStates:    envStates,
+				createdAt:    b.CreationTimestamp.Time,
+				lastVerified: lastVerified,
 			}
 		}
 	}
+
+	// Build per-pipeline blocker count from PolicyGates (ops table #462).
+	// Index: bundleName → count of gates with ready=false.
+	var gateList v1alpha1.PolicyGateList
+	_ = s.client.List(r.Context(), &gateList)
+	blockersByBundle := make(map[string]int, len(gateList.Items))
+	for _, g := range gateList.Items {
+		if !g.Status.Ready {
+			bundleLabel := g.Labels["kardinal.io/bundle"]
+			if bundleLabel != "" {
+				blockersByBundle[bundleLabel]++
+			}
+		}
+	}
+
+	// Build per-pipeline failed step count from PromotionSteps (ops table #462).
+	var stepList v1alpha1.PromotionStepList
+	_ = s.client.List(r.Context(), &stepList)
+	failedStepsByBundle := make(map[string]int, len(stepList.Items))
+	for _, ps := range stepList.Items {
+		if ps.Status.State == "Failed" {
+			failedStepsByBundle[ps.Spec.BundleName]++
+		}
+	}
+
+	now := time.Now().UTC()
 
 	result := make([]uiPipelineResponse, 0, len(list.Items))
 	for _, p := range list.Items {
@@ -214,11 +265,27 @@ func (s *uiAPIServer) handlePipelines(w http.ResponseWriter, r *http.Request) {
 			Phase:            pipelinePhase(&p),
 			EnvironmentCount: len(p.Spec.Environments),
 			Paused:           p.Spec.Paused,
+			CDLevel:          pipelineCDLevel(&p),
 		}
 		if ab := activeBundles[key]; ab != nil {
 			resp.ActiveBundleName = ab.name
 			if len(ab.envStates) > 0 {
 				resp.EnvironmentStates = ab.envStates
+			}
+			// Ops table: blocker + failed step counts derived from active bundle.
+			if n := blockersByBundle[ab.name]; n > 0 {
+				resp.BlockerCount = n
+			}
+			if n := failedStepsByBundle[ab.name]; n > 0 {
+				resp.FailedStepCount = n
+			}
+			// Inventory age: days since the active bundle was created.
+			if !ab.createdAt.IsZero() {
+				resp.InventoryAgeDays = int(now.Sub(ab.createdAt).Hours() / 24)
+			}
+			// Last merged at: most recent HealthCheckedAt across all envs.
+			if !ab.lastVerified.IsZero() {
+				resp.LastMergedAt = ab.lastVerified.UTC().Format(time.RFC3339)
 			}
 		}
 		result = append(result, resp)
@@ -574,6 +641,21 @@ func pipelinePhase(p *v1alpha1.Pipeline) string {
 		}
 	}
 	return "Initializing"
+}
+
+// pipelineCDLevel returns a human-readable CD automation level for the pipeline (#462).
+// Derived from the number of PolicyGate references in the pipeline spec.
+// "full-cd" = 0 gates (fully automated), "mostly-cd" = 1–2 gates, "manual" = 3+ gates.
+func pipelineCDLevel(p *v1alpha1.Pipeline) string {
+	gateCount := len(p.Spec.PolicyGates)
+	switch {
+	case gateCount == 0:
+		return "full-cd"
+	case gateCount <= 2:
+		return "mostly-cd"
+	default:
+		return "manual"
+	}
 }
 
 // handlePromote handles POST /api/v1/ui/promote — creates a Bundle targeting the

--- a/cmd/kardinal-controller/ui_api_test.go
+++ b/cmd/kardinal-controller/ui_api_test.go
@@ -547,3 +547,86 @@ func TestUIAPI_ListPipelines_PausedBadge(t *testing.T) {
 	assert.True(t, resp[0].Paused, "paused pipeline must have Paused=true in API response")
 	assert.Equal(t, "my-app", resp[0].Name)
 }
+
+// TestUIAPI_ListPipelines_OpsFields verifies that the operations table fields
+// (blockerCount, failedStepCount, inventoryAgeDays, lastMergedAt, cdLevel) are
+// populated correctly from active Bundle, PolicyGate, and PromotionStep CRDs (#462).
+func TestUIAPI_ListPipelines_OpsFields(t *testing.T) {
+	now := metav1.Now()
+	p := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test"},
+				{Name: "prod"},
+			},
+			// 2 pipeline-level gates → cdLevel = "mostly-cd"
+			PolicyGates: []v1alpha1.PipelinePolicyGateRef{
+				{Name: "gate-1"},
+				{Name: "gate-2"},
+			},
+		},
+		Status: v1alpha1.PipelineStatus{Phase: "Ready"},
+	}
+
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-app-v1",
+			Namespace:         "default",
+			CreationTimestamp: now,
+		},
+		Spec:   v1alpha1.BundleSpec{Type: "image", Pipeline: "my-app"},
+		Status: v1alpha1.BundleStatus{Phase: "Promoting"},
+	}
+
+	// Two PolicyGates blocking (ready=false) for this bundle
+	gate1 := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "no-weekend", Namespace: "default",
+			Labels: map[string]string{"kardinal.io/bundle": "my-app-v1"},
+		},
+		Spec:   v1alpha1.PolicyGateSpec{Expression: "!schedule.isWeekend()"},
+		Status: v1alpha1.PolicyGateStatus{Ready: false},
+	}
+	gate2 := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "needs-approval", Namespace: "default",
+			Labels: map[string]string{"kardinal.io/bundle": "my-app-v1"},
+		},
+		Spec:   v1alpha1.PolicyGateSpec{Expression: "bundle.pr[\"prod\"].isApproved"},
+		Status: v1alpha1.PolicyGateStatus{Ready: false},
+	}
+
+	// One PromotionStep in Failed state for this bundle
+	step := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app-v1-prod", Namespace: "default"},
+		Spec:       v1alpha1.PromotionStepSpec{BundleName: "my-app-v1", Environment: "prod"},
+		Status:     v1alpha1.PromotionStepStatus{State: "Failed"},
+	}
+
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(p, bundle, gate1, gate2, step).
+		WithStatusSubresource(gate1, gate2, step).
+		Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ui/pipelines", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp []uiPipelineResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+
+	got := resp[0]
+	assert.Equal(t, "my-app", got.Name)
+	assert.Equal(t, 2, got.BlockerCount, "2 blocking PolicyGates")
+	assert.Equal(t, 1, got.FailedStepCount, "1 Failed PromotionStep")
+	assert.Equal(t, "mostly-cd", got.CDLevel, "2 pipeline-level gates → mostly-cd")
+	// InventoryAgeDays should be 0 (bundle just created)
+	assert.Equal(t, 0, got.InventoryAgeDays, "just-created bundle → 0 days inventory age")
+}

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -11,15 +11,27 @@
         "reactflow": "^11.11.4",
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@vitejs/plugin-react": "^4.3.4",
+        "@vitejs/plugin-react": "^4.7.0",
+        "jsdom": "^29.0.2",
         "typescript": "~5.7.2",
         "vite": "^6.2.0",
+        "vitest": "^4.1.4",
       },
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.10", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.9", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -52,11 +64,27 @@
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.0", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@1.1.8", "", { "dependencies": { "@dagrejs/graphlib": "2.2.4" } }, "sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw=="],
 
@@ -113,6 +141,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -188,6 +218,16 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -195,6 +235,8 @@
     "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -258,6 +300,8 @@
 
     "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
 
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
@@ -268,15 +312,45 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.4", "", { "dependencies": { "@vitest/spy": "4.1.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.4", "", { "dependencies": { "@vitest/utils": "4.1.4", "pathe": "^2.0.3" } }, "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "@vitest/utils": "4.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.17", "", { "bin": "dist/cli.cjs" }, "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001787", "", {}, "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -298,13 +372,29 @@
 
     "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
 
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.335", "", {}, "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": "bin/esbuild" }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -312,13 +402,29 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": "bin/jsesc" }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -326,31 +432,75 @@
 
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
     "reactflow": ["reactflow@11.11.4", "", { "dependencies": { "@reactflow/background": "11.3.14", "@reactflow/controls": "11.2.14", "@reactflow/core": "11.11.4", "@reactflow/minimap": "11.7.14", "@reactflow/node-resizer": "2.2.14", "@reactflow/node-toolbar": "1.3.14" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og=="],
 
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
+
+    "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
+
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+
+    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
@@ -358,8 +508,30 @@
 
     "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
+    "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["immer"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@
 // sibling of DAGView rather than a position:fixed overlay.
 import { useState, useCallback, useMemo, useRef } from 'react'
 import { PipelineList } from './components/PipelineList'
+import { PipelineOpsTable } from './components/PipelineOpsTable'
 import { DAGView } from './components/DAGView'
 import { NodeDetail } from './components/NodeDetail'
 import { HealthChip } from './components/HealthChip'
@@ -61,6 +62,9 @@ export function App() {
 
   // Blocked gate filter state.
   const [showBlockedOnly, setShowBlockedOnly] = useState(false)
+
+  // #462: view mode toggle — 'list' (sidebar) | 'ops-table' (full-width operations table).
+  const [viewMode, setViewMode] = useState<'list' | 'ops-table'>('list')
 
   // Shared fetch function — called by both interval poll and manual refresh.
   const doFetchAll = useCallback(async () => {
@@ -259,33 +263,64 @@ export function App() {
         </div>
         <div style={{ padding: '0.75rem 1rem', fontSize: '0.75rem', color: '#475569', fontWeight: 600, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <span>PIPELINES</span>
-          {currentNamespace && (
-            <span style={{
-              fontSize: '0.65rem',
-              color: '#334155',
-              background: '#1e293b',
-              borderRadius: '4px',
-              padding: '1px 5px',
-              fontWeight: 400,
-              fontFamily: 'monospace',
-            }} title={`Namespace: ${currentNamespace}`}>
-              {currentNamespace}
-            </span>
-          )}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            {/* #462: view mode toggle — list sidebar vs ops table */}
+            <button
+              onClick={() => setViewMode(v => v === 'list' ? 'ops-table' : 'list')}
+              title={viewMode === 'list' ? 'Switch to Operations Table' : 'Switch to List View'}
+              aria-label={viewMode === 'list' ? 'Switch to Operations Table' : 'Switch to List View'}
+              style={{
+                background: viewMode === 'ops-table' ? '#1e293b' : 'none',
+                border: '1px solid ' + (viewMode === 'ops-table' ? '#6366f1' : '#334155'),
+                borderRadius: '4px',
+                cursor: 'pointer',
+                padding: '1px 5px',
+                fontSize: '0.65rem',
+                color: viewMode === 'ops-table' ? '#a5b4fc' : '#475569',
+              }}
+            >
+              {viewMode === 'list' ? '⊞ Ops' : '☰ List'}
+            </button>
+            {currentNamespace && (
+              <span style={{
+                fontSize: '0.65rem',
+                color: '#334155',
+                background: '#1e293b',
+                borderRadius: '4px',
+                padding: '1px 5px',
+                fontWeight: 400,
+                fontFamily: 'monospace',
+              }} title={`Namespace: ${currentNamespace}`}>
+                {currentNamespace}
+              </span>
+            )}
+          </div>
         </div>
         <div style={{ overflowY: 'auto', flex: 1 }}>
           <PipelineList
             pipelines={pipelines}
             selected={selectedPipeline}
-            onSelect={handleSelectPipeline}
+            onSelect={name => { handleSelectPipeline(name); if (viewMode === 'ops-table') setViewMode('list') }}
             loading={pipelinesLoading}
             error={pipelinesError}
           />
         </div>
       </aside>
 
-      {/* Main area — column layout for header + content row */}
-      <main style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', background: '#0f172a' }}>
+      {/* Ops table mode — full-width table replaces the main content area */}
+      {viewMode === 'ops-table' ? (
+        <main style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', background: '#050d1a' }}>
+          <PipelineOpsTable
+            pipelines={pipelines}
+            selected={selectedPipeline}
+            onSelect={name => { handleSelectPipeline(name); setViewMode('list') }}
+            loading={pipelinesLoading}
+            error={pipelinesError}
+          />
+        </main>
+      ) : (
+        <>{/* Main area — column layout for header + content row */}
+        <main style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', background: '#0f172a' }}>
         {!selectedPipeline ? (
           <div style={{ color: '#475569', padding: '3rem 2rem', textAlign: 'center' }}>
             {pipelines.length > 0 ? (
@@ -540,6 +575,8 @@ export function App() {
           </>
         )}
       </main>
+        </>
+      )}
     </div>
   )
 }

--- a/web/src/components/PipelineOpsTable.test.tsx
+++ b/web/src/components/PipelineOpsTable.test.tsx
@@ -1,0 +1,207 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { PipelineOpsTable } from './PipelineOpsTable'
+import type { Pipeline } from '../types'
+
+function makePipeline(overrides: Partial<Pipeline> = {}): Pipeline {
+  return {
+    name: 'test-pipeline',
+    namespace: 'default',
+    phase: 'Ready',
+    environmentCount: 3,
+    activeBundleName: 'test-app-v1',
+    blockerCount: 0,
+    failedStepCount: 0,
+    inventoryAgeDays: 2,
+    lastMergedAt: new Date(Date.now() - 86400000).toISOString(), // 1 day ago
+    cdLevel: 'full-cd',
+    ...overrides,
+  }
+}
+
+describe('PipelineOpsTable', () => {
+  it('renders column headers', () => {
+    render(
+      <PipelineOpsTable
+        pipelines={[makePipeline()]}
+        onSelect={() => {}}
+      />
+    )
+    expect(screen.getByText('Pipeline')).toBeTruthy()
+    expect(screen.getByText('Status')).toBeTruthy()
+    expect(screen.getByText('Blockers')).toBeTruthy()
+    expect(screen.getByText('Failed Steps')).toBeTruthy()
+    expect(screen.getByText('Inventory Age')).toBeTruthy()
+    expect(screen.getByText('Last Merge')).toBeTruthy()
+    expect(screen.getByText('CD Level')).toBeTruthy()
+  })
+
+  it('renders pipeline name and bundle', () => {
+    render(
+      <PipelineOpsTable
+        pipelines={[makePipeline({ name: 'my-pipeline', activeBundleName: 'my-bundle-v2' })]}
+        onSelect={() => {}}
+      />
+    )
+    expect(screen.getByText('my-pipeline')).toBeTruthy()
+    expect(screen.getByText('my-bundle-v2')).toBeTruthy()
+  })
+
+  it('shows blocker count in red when > 0', () => {
+    const { container } = render(
+      <PipelineOpsTable
+        pipelines={[makePipeline({ blockerCount: 3 })]}
+        onSelect={() => {}}
+      />
+    )
+    const blockerCell = container.querySelector('td:nth-child(3)')
+    expect(blockerCell?.textContent).toContain('3')
+    // JSDOM normalizes hex to rgb — check for the red color in either format
+    const style = blockerCell?.getAttribute('style') ?? ''
+    expect(
+      style.includes('#ef4444') || style.includes('rgb(239, 68, 68)')
+    ).toBe(true)
+  })
+
+  it('shows green when no blockers', () => {
+    const { container } = render(
+      <PipelineOpsTable
+        pipelines={[makePipeline({ blockerCount: 0 })]}
+        onSelect={() => {}}
+      />
+    )
+    const blockerCell = container.querySelector('td:nth-child(3)')
+    const style = blockerCell?.getAttribute('style') ?? ''
+    expect(
+      style.includes('#22c55e') || style.includes('rgb(34, 197, 94)')
+    ).toBe(true)
+  })
+
+  it('shows stale inventory warning when > 14 days', () => {
+    render(
+      <PipelineOpsTable
+        pipelines={[makePipeline({ inventoryAgeDays: 20 })]}
+        onSelect={() => {}}
+      />
+    )
+    // Warning icon should be present in the inventory age cell
+    expect(screen.getByTitle('20 days since last bundle')).toBeTruthy()
+  })
+
+  it('calls onSelect when row is clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <PipelineOpsTable
+        pipelines={[makePipeline({ name: 'click-me' })]}
+        onSelect={onSelect}
+      />
+    )
+    const row = screen.getByRole('button')
+    fireEvent.click(row)
+    expect(onSelect).toHaveBeenCalledWith('click-me')
+  })
+
+  it('calls onSelect on Enter key', () => {
+    const onSelect = vi.fn()
+    render(
+      <PipelineOpsTable
+        pipelines={[makePipeline({ name: 'keyboard-select' })]}
+        onSelect={onSelect}
+      />
+    )
+    const row = screen.getByRole('button')
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledWith('keyboard-select')
+  })
+
+  it('filters pipelines by name substring', () => {
+    const pipelines = [
+      makePipeline({ name: 'frontend-pipeline' }),
+      makePipeline({ name: 'backend-pipeline' }),
+    ]
+    render(<PipelineOpsTable pipelines={pipelines} onSelect={() => {}} />)
+    const filterInput = screen.getByRole('textbox')
+    fireEvent.change(filterInput, { target: { value: 'front' } })
+    expect(screen.getByText('frontend-pipeline')).toBeTruthy()
+    expect(screen.queryByText('backend-pipeline')).toBeNull()
+  })
+
+  it('shows empty state when filter matches nothing', () => {
+    render(
+      <PipelineOpsTable
+        pipelines={[makePipeline({ name: 'nginx' })]}
+        onSelect={() => {}}
+      />
+    )
+    const filterInput = screen.getByRole('textbox')
+    fireEvent.change(filterInput, { target: { value: 'xyznotfound' } })
+    expect(screen.getByText('No pipelines match "xyznotfound"')).toBeTruthy()
+  })
+
+  it('sorts by blockerCount descending by default', () => {
+    const pipelines = [
+      makePipeline({ name: 'no-blockers', blockerCount: 0 }),
+      makePipeline({ name: 'two-blockers', blockerCount: 2 }),
+      makePipeline({ name: 'one-blocker', blockerCount: 1 }),
+    ]
+    const { container } = render(
+      <PipelineOpsTable pipelines={pipelines} onSelect={() => {}} />
+    )
+    const rows = container.querySelectorAll('tbody tr')
+    // Default sort is blockerCount desc → two-blockers first
+    expect(rows[0].textContent).toContain('two-blockers')
+  })
+
+  it('shows PAUSED badge for paused pipelines', () => {
+    render(
+      <PipelineOpsTable
+        pipelines={[makePipeline({ paused: true, name: 'paused-pipe' })]}
+        onSelect={() => {}}
+      />
+    )
+    expect(screen.getByText('PAUSED')).toBeTruthy()
+  })
+
+  it('renders loading state', () => {
+    render(<PipelineOpsTable pipelines={[]} onSelect={() => {}} loading />)
+    expect(screen.getByText('Loading pipelines…')).toBeTruthy()
+  })
+
+  it('renders error state', () => {
+    render(<PipelineOpsTable pipelines={[]} onSelect={() => {}} error="connection refused" />)
+    expect(screen.getByText(/connection refused/)).toBeTruthy()
+  })
+
+  it('shows Full CD badge for full-cd pipeline', () => {
+    render(
+      <PipelineOpsTable
+        pipelines={[makePipeline({ cdLevel: 'full-cd' })]}
+        onSelect={() => {}}
+      />
+    )
+    expect(screen.getByText('Full CD')).toBeTruthy()
+  })
+
+  it('shows Manual badge for manual pipeline', () => {
+    render(
+      <PipelineOpsTable
+        pipelines={[makePipeline({ cdLevel: 'manual' })]}
+        onSelect={() => {}}
+      />
+    )
+    expect(screen.getByText('Manual')).toBeTruthy()
+  })
+})

--- a/web/src/components/PipelineOpsTable.tsx
+++ b/web/src/components/PipelineOpsTable.tsx
@@ -1,0 +1,362 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// components/PipelineOpsTable.tsx — Sortable/filterable operations table for
+// the pipeline list page (#462). Shows operators the signals they need to triage
+// at a glance: blocked gates, failed steps, stale inventory, last merge time.
+
+import { useState, useMemo } from 'react'
+import type { Pipeline } from '../types'
+import { HealthChip } from './HealthChip'
+
+type SortColumn =
+  | 'name'
+  | 'phase'
+  | 'blockerCount'
+  | 'failedStepCount'
+  | 'inventoryAgeDays'
+  | 'lastMergedAt'
+  | 'cdLevel'
+
+type SortDir = 'asc' | 'desc'
+
+interface Props {
+  pipelines: Pipeline[]
+  selected?: string
+  onSelect: (name: string) => void
+  loading?: boolean
+  error?: string
+}
+
+/** Format a relative time string from an ISO timestamp. */
+function relativeTime(iso: string | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '—'
+  const diffMs = Date.now() - d.getTime()
+  const diffDays = Math.floor(diffMs / 86400000)
+  if (diffDays === 0) return 'today'
+  if (diffDays === 1) return '1d ago'
+  if (diffDays < 30) return `${diffDays}d ago`
+  const diffMonths = Math.floor(diffDays / 30)
+  return `${diffMonths}mo ago`
+}
+
+/** Red/amber/green staleness color for inventory age. */
+function inventoryColor(days: number | undefined): string {
+  if (days === undefined) return '#64748b'
+  if (days > 30) return '#ef4444'
+  if (days > 14) return '#f59e0b'
+  return '#22c55e'
+}
+
+/** CD level label with color. */
+function cdLevelBadge(level: string | undefined) {
+  const map: Record<string, { label: string; color: string }> = {
+    'full-cd': { label: 'Full CD', color: '#22c55e' },
+    'mostly-cd': { label: 'Mostly CD', color: '#6366f1' },
+    'manual': { label: 'Manual', color: '#f59e0b' },
+  }
+  const { label, color } = map[level ?? ''] ?? { label: '—', color: '#64748b' }
+  return (
+    <span style={{ color, fontSize: '0.75rem', fontWeight: 600 }}>{label}</span>
+  )
+}
+
+const CELL: React.CSSProperties = {
+  padding: '0.45rem 0.75rem',
+  borderBottom: '1px solid #1e293b',
+  fontSize: '0.82rem',
+  color: '#e2e8f0',
+  whiteSpace: 'nowrap',
+  verticalAlign: 'middle',
+}
+
+const HEADER_CELL: React.CSSProperties = {
+  ...CELL,
+  color: '#94a3b8',
+  fontSize: '0.72rem',
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.05em',
+  background: '#0a1628',
+  borderBottom: '1px solid #334155',
+  cursor: 'pointer',
+  userSelect: 'none' as const,
+}
+
+interface Column {
+  key: SortColumn
+  label: string
+  title?: string
+}
+
+const COLUMNS: Column[] = [
+  { key: 'name', label: 'Pipeline' },
+  { key: 'phase', label: 'Status' },
+  { key: 'blockerCount', label: 'Blockers', title: 'PolicyGates currently blocking this pipeline' },
+  { key: 'failedStepCount', label: 'Failed Steps', title: 'PromotionSteps in Failed state' },
+  { key: 'inventoryAgeDays', label: 'Inventory Age', title: 'Days since latest bundle was created' },
+  { key: 'lastMergedAt', label: 'Last Merge', title: 'When the last environment reached Verified' },
+  { key: 'cdLevel', label: 'CD Level', title: 'Automation level based on number of policy gates' },
+]
+
+export function PipelineOpsTable({ pipelines, selected, onSelect, loading, error }: Props) {
+  const [sortCol, setSortCol] = useState<SortColumn>('blockerCount')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [filter, setFilter] = useState('')
+
+  const handleSort = (col: SortColumn) => {
+    if (sortCol === col) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortCol(col)
+      setSortDir('desc')
+    }
+  }
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    return q
+      ? pipelines.filter(p =>
+          p.name.toLowerCase().includes(q) ||
+          p.namespace.toLowerCase().includes(q) ||
+          p.phase.toLowerCase().includes(q)
+        )
+      : pipelines
+  }, [pipelines, filter])
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      let cmp = 0
+      switch (sortCol) {
+        case 'name':
+          cmp = a.name.localeCompare(b.name)
+          break
+        case 'phase':
+          cmp = (a.phase ?? '').localeCompare(b.phase ?? '')
+          break
+        case 'blockerCount':
+          cmp = (a.blockerCount ?? 0) - (b.blockerCount ?? 0)
+          break
+        case 'failedStepCount':
+          cmp = (a.failedStepCount ?? 0) - (b.failedStepCount ?? 0)
+          break
+        case 'inventoryAgeDays':
+          cmp = (a.inventoryAgeDays ?? 0) - (b.inventoryAgeDays ?? 0)
+          break
+        case 'lastMergedAt':
+          cmp = (a.lastMergedAt ?? '').localeCompare(b.lastMergedAt ?? '')
+          break
+        case 'cdLevel': {
+          const cdOrder: Record<string, number> = { 'full-cd': 0, 'mostly-cd': 1, 'manual': 2 }
+          cmp = (cdOrder[a.cdLevel ?? ''] ?? 99) - (cdOrder[b.cdLevel ?? ''] ?? 99)
+          break
+        }
+      }
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+  }, [filtered, sortCol, sortDir])
+
+  if (loading) {
+    return (
+      <div style={{ padding: '1.5rem', color: '#64748b', fontSize: '0.85rem' }}>
+        Loading pipelines…
+      </div>
+    )
+  }
+  if (error) {
+    return (
+      <div style={{ padding: '1rem', color: '#ef4444', fontSize: '0.82rem' }}>
+        Error: {error}
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Filter bar */}
+      <div style={{
+        padding: '0.6rem 1rem',
+        borderBottom: '1px solid #1e293b',
+        background: '#050d1a',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+      }}>
+        <input
+          type="text"
+          placeholder="Filter pipelines…"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          aria-label="Filter pipelines"
+          style={{
+            background: '#1e293b',
+            border: '1px solid #334155',
+            borderRadius: '4px',
+            padding: '0.3rem 0.6rem',
+            fontSize: '0.8rem',
+            color: '#e2e8f0',
+            outline: 'none',
+            width: '220px',
+          }}
+        />
+        <span style={{ fontSize: '0.75rem', color: '#475569' }}>
+          {sorted.length} pipeline{sorted.length !== 1 ? 's' : ''}
+          {filter ? ` matching "${filter}"` : ''}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div style={{ flex: 1, overflow: 'auto' }}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: 'inherit',
+          }}
+          aria-label="Pipeline operations table"
+        >
+          <thead>
+            <tr>
+              {COLUMNS.map(col => (
+                <th
+                  key={col.key}
+                  title={col.title}
+                  onClick={() => handleSort(col.key)}
+                  style={HEADER_CELL}
+                  aria-sort={
+                    sortCol === col.key
+                      ? sortDir === 'asc' ? 'ascending' : 'descending'
+                      : 'none'
+                  }
+                >
+                  {col.label}
+                  {sortCol === col.key && (
+                    <span style={{ marginLeft: '0.3rem' }}>
+                      {sortDir === 'asc' ? '↑' : '↓'}
+                    </span>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.length === 0 && (
+              <tr>
+                <td
+                  colSpan={COLUMNS.length}
+                  style={{ ...CELL, color: '#475569', textAlign: 'center', padding: '2rem' }}
+                >
+                  {filter ? `No pipelines match "${filter}"` : 'No pipelines found.'}
+                </td>
+              </tr>
+            )}
+            {sorted.map(p => {
+              const isSelected = selected === p.name
+              const hasBlockers = (p.blockerCount ?? 0) > 0
+              const hasFailed = (p.failedStepCount ?? 0) > 0
+              const isStale = (p.inventoryAgeDays ?? 0) > 14
+
+              return (
+                <tr
+                  key={`${p.namespace}/${p.name}`}
+                  onClick={() => onSelect(p.name)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && onSelect(p.name)}
+                  aria-selected={isSelected}
+                  style={{
+                    cursor: 'pointer',
+                    background: isSelected ? '#1e293b' : 'transparent',
+                    borderLeft: isSelected ? '3px solid #6366f1' : '3px solid transparent',
+                  }}
+                >
+                  {/* Pipeline name */}
+                  <td style={CELL}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                      <span style={{ fontWeight: isSelected ? 600 : 400 }}>{p.name}</span>
+                      {p.paused && (
+                        <span style={{
+                          fontSize: '0.6rem',
+                          background: '#1e1b4b',
+                          color: '#a5b4fc',
+                          border: '1px solid #4338ca',
+                          borderRadius: '3px',
+                          padding: '0px 4px',
+                          fontWeight: 700,
+                        }}>
+                          PAUSED
+                        </span>
+                      )}
+                    </div>
+                    {p.activeBundleName && (
+                      <div style={{
+                        fontSize: '0.68rem',
+                        color: '#475569',
+                        fontFamily: 'monospace',
+                        marginTop: '0.15rem',
+                      }}>
+                        {p.activeBundleName.length > 20
+                          ? p.activeBundleName.slice(0, 18) + '…'
+                          : p.activeBundleName}
+                      </div>
+                    )}
+                  </td>
+
+                  {/* Status */}
+                  <td style={CELL}>
+                    <HealthChip state={p.paused ? 'Paused' : p.phase} size="sm" />
+                  </td>
+
+                  {/* Blockers */}
+                  <td style={{ ...CELL, color: hasBlockers ? '#ef4444' : '#22c55e' }}>
+                    {hasBlockers ? (
+                      <span title={`${p.blockerCount} gate${p.blockerCount === 1 ? '' : 's'} blocking`}>
+                        ⛔ {p.blockerCount}
+                      </span>
+                    ) : (
+                      <span title="No blockers">0</span>
+                    )}
+                  </td>
+
+                  {/* Failed steps */}
+                  <td style={{ ...CELL, color: hasFailed ? '#ef4444' : '#22c55e' }}>
+                    {hasFailed ? (
+                      <span title={`${p.failedStepCount} failed step${p.failedStepCount === 1 ? '' : 's'}`}>
+                        ✗ {p.failedStepCount}
+                      </span>
+                    ) : (
+                      <span>0</span>
+                    )}
+                  </td>
+
+                  {/* Inventory age */}
+                  <td style={{ ...CELL, color: inventoryColor(p.inventoryAgeDays) }}>
+                    {p.inventoryAgeDays !== undefined ? (
+                      <span title={`${p.inventoryAgeDays} day${p.inventoryAgeDays === 1 ? '' : 's'} since last bundle`}>
+                        {p.inventoryAgeDays === 0 ? 'today' : `${p.inventoryAgeDays}d`}
+                        {isStale && <span style={{ marginLeft: '0.3rem' }}>⚠</span>}
+                      </span>
+                    ) : '—'}
+                  </td>
+
+                  {/* Last merge */}
+                  <td style={CELL}>
+                    <span title={p.lastMergedAt ?? 'Never merged'} style={{ color: '#94a3b8' }}>
+                      {relativeTime(p.lastMergedAt)}
+                    </span>
+                  </td>
+
+                  {/* CD level */}
+                  <td style={CELL}>
+                    {cdLevelBadge(p.cdLevel)}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -11,6 +11,16 @@ export interface Pipeline {
   /** #342: per-environment promotion phases from active Bundle status.
    * Keys are environment names, values are the promotion phase (Promoting, Verified, etc.) */
   environmentStates?: Record<string, string>
+  /** #462: number of PolicyGates with ready=false for the active bundle. */
+  blockerCount?: number
+  /** #462: number of PromotionSteps with state=Failed for the active bundle. */
+  failedStepCount?: number
+  /** #462: days since the active bundle was created (stale inventory indicator). */
+  inventoryAgeDays?: number
+  /** #462: RFC3339 timestamp of the last environment that reached Verified. */
+  lastMergedAt?: string
+  /** #462: CD automation level derived from PolicyGate count. */
+  cdLevel?: 'full-cd' | 'mostly-cd' | 'manual'
 }
 
 export interface Bundle {


### PR DESCRIPTION
## Summary

Add a full-width sortable/filterable **operations table view** for the pipeline list page, giving operators the signals they need to triage at a glance. Closes #462.

## What changed

### Backend (`ui_api.go`)
Extends `uiPipelineResponse` with new ops fields populated from existing CRDs — no new CRDs, no external calls:
- `blockerCount` — PolicyGates with `ready=false` for the active bundle
- `failedStepCount` — PromotionSteps with `state=Failed` for the active bundle  
- `inventoryAgeDays` — days since the active bundle was created
- `lastMergedAt` — RFC3339 of last env `HealthCheckedAt`
- `cdLevel` — `full-cd` / `mostly-cd` / `manual` from PolicyGate count

### Frontend
- **`PipelineOpsTable.tsx`** — sortable table with all ops columns, default sort: blockerCount desc (stuck pipelines first), filter bar
- **Color coding** — red for blockers/failed steps, amber for stale inventory (>14d)
- **View toggle** — `⊞ Ops` / `☰ List` button in sidebar header; selecting a row auto-switches back to List for DAG detail

## Tests
- 15 new frontend vitest tests (`PipelineOpsTable.test.tsx`)
- 1 new backend test (`TestUIAPI_ListPipelines_OpsFields`)
- All existing 46 frontend + 549 backend tests pass

## Architecture
Pure read path — all data derived from existing Bundle/PromotionStep/PolicyGate CRD fields. No new CRDs, no reconcilers, no external calls.