### PR TITLE
feat(ui): per-stage approval workflow detail — step list, bake countdown (#463)

### DIFF
--- a/cmd/kardinal-controller/ui_api.go
+++ b/cmd/kardinal-controller/ui_api.go
@@ -117,6 +117,14 @@ type uiStepResponse struct {
 	CurrentStepIndex int               `json:"currentStepIndex"` // index into step sequence (#359)
 	// #341: Kubernetes conditions — shown in NodeDetail conditions panel.
 	Conditions []uiCondition `json:"conditions,omitempty"`
+	// #501: Bake countdown fields — shown in StageDetailPanel.
+	// BakeElapsedMinutes is contiguous healthy minutes so far in the current bake window.
+	BakeElapsedMinutes int64 `json:"bakeElapsedMinutes,omitempty"`
+	// BakeTargetMinutes is the required contiguous healthy duration from Pipeline spec.
+	// Zero means no bake is configured for this environment.
+	BakeTargetMinutes int `json:"bakeTargetMinutes,omitempty"`
+	// BakeResets is the number of times the bake timer was reset due to a health alarm.
+	BakeResets int `json:"bakeResets,omitempty"`
 }
 
 // uiCondition is the JSON shape for a Kubernetes condition.
@@ -571,24 +579,48 @@ func (s *uiAPIServer) handleBundleSteps(w http.ResponseWriter, r *http.Request, 
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
+
+	// Build a bake target index: pipelineName+envName → bake minutes.
+	// Populated lazily from the first step's Pipeline reference (#501).
+	bakeTarget := make(map[string]int) // key: "pipelineName/envName"
+	pipelinesLoaded := make(map[string]bool)
+
 	result := make([]uiStepResponse, 0)
 	for _, ps := range list.Items {
 		if ps.Spec.BundleName != bundleName {
 			continue
 		}
+		// Load bake target minutes from Pipeline spec (once per pipeline) (#501).
+		plKey := ps.Namespace + "/" + ps.Spec.PipelineName
+		if !pipelinesLoaded[plKey] {
+			pipelinesLoaded[plKey] = true
+			var pl v1alpha1.Pipeline
+			if err := s.client.Get(r.Context(),
+				client.ObjectKey{Name: ps.Spec.PipelineName, Namespace: ps.Namespace}, &pl); err == nil {
+				for _, env := range pl.Spec.Environments {
+					if env.Bake != nil {
+						bakeTarget[ps.Spec.PipelineName+"/"+env.Name] = env.Bake.Minutes
+					}
+				}
+			}
+		}
+		bakeMinutes := bakeTarget[ps.Spec.PipelineName+"/"+ps.Spec.Environment]
 		result = append(result, uiStepResponse{
-			Name:             ps.Name,
-			Namespace:        ps.Namespace,
-			Pipeline:         ps.Spec.PipelineName,
-			Bundle:           ps.Spec.BundleName,
-			Environment:      ps.Spec.Environment,
-			StepType:         ps.Spec.StepType,
-			State:            ps.Status.State,
-			Message:          ps.Status.Message,
-			PRURL:            ps.Status.PRURL,
-			Outputs:          ps.Status.Outputs,
-			CurrentStepIndex: ps.Status.CurrentStepIndex,
-			Conditions:       buildUIConditions(ps.Status.Conditions),
+			Name:               ps.Name,
+			Namespace:          ps.Namespace,
+			Pipeline:           ps.Spec.PipelineName,
+			Bundle:             ps.Spec.BundleName,
+			Environment:        ps.Spec.Environment,
+			StepType:           ps.Spec.StepType,
+			State:              ps.Status.State,
+			Message:            ps.Status.Message,
+			PRURL:              ps.Status.PRURL,
+			Outputs:            ps.Status.Outputs,
+			CurrentStepIndex:   ps.Status.CurrentStepIndex,
+			Conditions:         buildUIConditions(ps.Status.Conditions),
+			BakeElapsedMinutes: ps.Status.BakeElapsedMinutes,
+			BakeTargetMinutes:  bakeMinutes,
+			BakeResets:         ps.Status.BakeResets,
 		})
 	}
 	writeJSON(w, result)

--- a/cmd/kardinal-controller/ui_api_test.go
+++ b/cmd/kardinal-controller/ui_api_test.go
@@ -630,3 +630,83 @@ func TestUIAPI_ListPipelines_OpsFields(t *testing.T) {
 	// InventoryAgeDays should be 0 (bundle just created)
 	assert.Equal(t, 0, got.InventoryAgeDays, "just-created bundle → 0 days inventory age")
 }
+
+// TestUIAPI_GetSteps_BakeFields verifies that bake countdown fields are populated
+// from PromotionStep.status and Pipeline spec (#501).
+func TestUIAPI_GetSteps_BakeFields(t *testing.T) {
+	pl := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default"},
+		Spec: v1alpha1.PipelineSpec{
+			Environments: []v1alpha1.EnvironmentSpec{
+				{
+					Name: "prod",
+					Bake: &v1alpha1.BakeConfig{Minutes: 30},
+				},
+			},
+		},
+	}
+	ps := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app-v1-prod", Namespace: "default"},
+		Spec: v1alpha1.PromotionStepSpec{
+			PipelineName: "my-app",
+			BundleName:   "my-app-v1",
+			Environment:  "prod",
+			StepType:     "health-check",
+		},
+		Status: v1alpha1.PromotionStepStatus{
+			State:              "HealthChecking",
+			BakeElapsedMinutes: 15,
+			BakeResets:         1,
+		},
+	}
+
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pl, ps).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ui/bundles/my-app-v1/steps", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp []uiStepResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, int64(15), resp[0].BakeElapsedMinutes, "BakeElapsedMinutes from step status")
+	assert.Equal(t, 30, resp[0].BakeTargetMinutes, "BakeTargetMinutes from pipeline spec")
+	assert.Equal(t, 1, resp[0].BakeResets, "BakeResets from step status")
+}
+
+// TestUIAPI_GetSteps_NoBakeFieldsWhenNoPipeline verifies that bake target is 0
+// when the Pipeline spec has no bake configuration (#501).
+func TestUIAPI_GetSteps_NoBakeFieldsWhenNoPipeline(t *testing.T) {
+	ps := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app-v1-test", Namespace: "default"},
+		Spec: v1alpha1.PromotionStepSpec{
+			PipelineName: "my-app",
+			BundleName:   "my-app-v1",
+			Environment:  "test",
+			StepType:     "health-check",
+		},
+		Status: v1alpha1.PromotionStepStatus{State: "HealthChecking"},
+	}
+	// No Pipeline object created — bake target should default to 0
+
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ps).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ui/bundles/my-app-v1/steps", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp []uiStepResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, 0, resp[0].BakeTargetMinutes, "BakeTargetMinutes must be 0 when no bake config")
+}

--- a/web/src/components/StageDetailPanel.test.tsx
+++ b/web/src/components/StageDetailPanel.test.tsx
@@ -170,7 +170,7 @@ describe('StageDetailPanel', () => {
   it('shows step list with 8 steps', () => {
     const node = makeNode()
     const step = makeStep()
-    const { getAllByRole } = render(<StageDetailPanel node={node} steps={[step]} onClose={() => {}} />)
+    render(<StageDetailPanel node={node} steps={[step]} onClose={() => {}} />)
     // 8 step rows in the list plus the close button and optional PR link
     const listItems = screen.queryAllByText(/Git clone|Set image|Git commit|Git push|Open PR|Wait for merge|Health check/)
     expect(listItems.length).toBeGreaterThanOrEqual(1)

--- a/web/src/components/StageDetailPanel.test.tsx
+++ b/web/src/components/StageDetailPanel.test.tsx
@@ -1,0 +1,201 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// StageDetailPanel.test.tsx — Tests for #501 per-stage approval workflow detail:
+// bake countdown, step icons, panel open/close.
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { GraphNode, PromotionStep } from '../types'
+import { StageDetailPanel, bakePct, formatBakeCountdown, stepIconFor } from './StageDetailPanel'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeNode(overrides: Partial<GraphNode> = {}): GraphNode {
+  return {
+    id: 'prod-step',
+    type: 'PromotionStep',
+    label: 'prod',
+    environment: 'prod',
+    state: 'HealthChecking',
+    ...overrides,
+  }
+}
+
+function makeStep(overrides: Partial<PromotionStep> = {}): PromotionStep {
+  return {
+    name: 'prod-step',
+    namespace: 'default',
+    pipeline: 'my-app',
+    bundle: 'v1.0',
+    environment: 'prod',
+    stepType: 'health-check',
+    state: 'HealthChecking',
+    currentStepIndex: 7,
+    ...overrides,
+  }
+}
+
+// ─── bakePct ──────────────────────────────────────────────────────────────────
+
+describe('bakePct', () => {
+  it('returns 0 for target=0', () => {
+    expect(bakePct(10, 0)).toBe(0)
+  })
+
+  it('computes percentage correctly', () => {
+    expect(bakePct(15, 30)).toBe(50)
+    expect(bakePct(30, 30)).toBe(100)
+    expect(bakePct(0, 30)).toBe(0)
+  })
+
+  it('caps at 100% even when elapsed > target', () => {
+    expect(bakePct(45, 30)).toBe(100)
+  })
+
+  it('rounds to integer', () => {
+    expect(bakePct(10, 30)).toBe(33) // 33.33... → 33
+  })
+})
+
+// ─── formatBakeCountdown ──────────────────────────────────────────────────────
+
+describe('formatBakeCountdown', () => {
+  it('returns empty string when target=0', () => {
+    expect(formatBakeCountdown(10, 0)).toBe('')
+  })
+
+  it('formats countdown correctly', () => {
+    expect(formatBakeCountdown(15, 30)).toBe('15m / 30m (50%)')
+    expect(formatBakeCountdown(0, 30)).toBe('0m / 30m (0%)')
+    expect(formatBakeCountdown(30, 30)).toBe('30m / 30m (100%)')
+  })
+})
+
+// ─── stepIconFor ─────────────────────────────────────────────────────────────
+
+describe('stepIconFor', () => {
+  it('returns green check for completed step (index < currentIndex)', () => {
+    const result = stepIconFor(0, 3, true)
+    expect(result.icon).toBe('✓')
+    expect(result.color).toBe('#22c55e')
+  })
+
+  it('returns play icon for active current step', () => {
+    const result = stepIconFor(3, 3, true)
+    expect(result.icon).toBe('▶')
+    expect(result.color).toBe('#f59e0b')
+  })
+
+  it('returns circle for inactive current step', () => {
+    const result = stepIconFor(3, 3, false)
+    expect(result.icon).toBe('○')
+    expect(result.color).toBe('#475569')
+  })
+
+  it('returns dark circle for future step', () => {
+    const result = stepIconFor(5, 3, true)
+    expect(result.icon).toBe('○')
+    expect(result.color).toBe('#334155')
+  })
+})
+
+// ─── StageDetailPanel component ───────────────────────────────────────────────
+
+describe('StageDetailPanel', () => {
+  it('renders environment name in header', () => {
+    const node = makeNode({ environment: 'production', state: 'HealthChecking' })
+    render(<StageDetailPanel node={node} steps={[makeStep({ environment: 'production' })]} onClose={() => {}} />)
+    expect(screen.getByText('production')).toBeInTheDocument()
+  })
+
+  it('shows bake countdown when bakeTargetMinutes > 0', () => {
+    const node = makeNode()
+    const step = makeStep({ bakeElapsedMinutes: 15, bakeTargetMinutes: 30 })
+    render(<StageDetailPanel node={node} steps={[step]} onClose={() => {}} />)
+    expect(screen.getByTitle('Bake progress: 15m of 30m elapsed')).toBeInTheDocument()
+    expect(screen.getByText('15m / 30m (50%)')).toBeInTheDocument()
+  })
+
+  it('does not show bake section when bakeTargetMinutes is 0 or absent', () => {
+    const node = makeNode()
+    const step = makeStep({ bakeTargetMinutes: 0 })
+    render(<StageDetailPanel node={node} steps={[step]} onClose={() => {}} />)
+    expect(screen.queryByText(/Bake/i)).not.toBeInTheDocument()
+  })
+
+  it('shows bake reset warning when bakeResets > 0', () => {
+    const node = makeNode()
+    const step = makeStep({ bakeElapsedMinutes: 10, bakeTargetMinutes: 30, bakeResets: 2 })
+    render(<StageDetailPanel node={node} steps={[step]} onClose={() => {}} />)
+    expect(screen.getByText(/Timer reset 2 times/)).toBeInTheDocument()
+  })
+
+  it('shows progress bar with correct aria attributes', () => {
+    const node = makeNode()
+    const step = makeStep({ bakeElapsedMinutes: 15, bakeTargetMinutes: 30 })
+    render(<StageDetailPanel node={node} steps={[step]} onClose={() => {}} />)
+    const progressBar = screen.getByRole('progressbar')
+    expect(progressBar).toBeInTheDocument()
+    expect(progressBar).toHaveAttribute('aria-valuenow', '15')
+    expect(progressBar).toHaveAttribute('aria-valuemax', '30')
+  })
+
+  it('shows PR link when step has prURL', () => {
+    const node = makeNode()
+    const step = makeStep({ prURL: 'https://github.com/org/repo/pull/42' })
+    render(<StageDetailPanel node={node} steps={[step]} onClose={() => {}} />)
+    const link = screen.getByLabelText('Open pull request')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/42')
+  })
+
+  it('shows PR link from node.prURL when step has no prURL', () => {
+    const node = makeNode({ prURL: 'https://github.com/org/repo/pull/99' })
+    const step = makeStep({ prURL: undefined })
+    render(<StageDetailPanel node={node} steps={[step]} onClose={() => {}} />)
+    const link = screen.getByLabelText('Open pull request')
+    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/99')
+  })
+
+  it('shows step list with 8 steps', () => {
+    const node = makeNode()
+    const step = makeStep()
+    const { getAllByRole } = render(<StageDetailPanel node={node} steps={[step]} onClose={() => {}} />)
+    // 8 step rows in the list plus the close button and optional PR link
+    const listItems = screen.queryAllByText(/Git clone|Set image|Git commit|Git push|Open PR|Wait for merge|Health check/)
+    expect(listItems.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('calls onClose when × button is clicked', () => {
+    const onClose = vi.fn()
+    const node = makeNode()
+    render(<StageDetailPanel node={node} steps={[makeStep()]} onClose={onClose} />)
+    fireEvent.click(screen.getByLabelText('Close stage detail'))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when Escape key is pressed', () => {
+    const onClose = vi.fn()
+    const node = makeNode()
+    render(<StageDetailPanel node={node} steps={[makeStep()]} onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('shows no-step message when steps array has no match for environment', () => {
+    const node = makeNode({ environment: 'prod' })
+    const step = makeStep({ environment: 'staging' }) // different env
+    render(<StageDetailPanel node={node} steps={[step]} onClose={() => {}} />)
+    expect(screen.getByText('No active promotion step for this environment.')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/StageDetailPanel.tsx
+++ b/web/src/components/StageDetailPanel.tsx
@@ -1,0 +1,263 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// components/StageDetailPanel.tsx — Per-stage approval workflow detail (#463).
+// Shows step states, bake countdown timer, PR URL, and integration test pass rates.
+// Opened by clicking a PromotionStep node in the DAG. Closes on outside click or Escape.
+import { useEffect, useRef, useCallback } from 'react'
+import type { GraphNode, PromotionStep } from '../types'
+import { HealthChip } from './HealthChip'
+
+interface Props {
+  /** The DAG node that was clicked — provides environment and state context. */
+  node: GraphNode
+  /** Steps for the active bundle scoped to this stage's environment. */
+  steps: PromotionStep[]
+  /** Called when the panel should close. */
+  onClose: () => void
+}
+
+/** #501: Format bake progress as a percentage string for the progress bar. */
+export function bakePct(elapsed: number, target: number): number {
+  if (target <= 0) return 0
+  return Math.min(100, Math.round((elapsed / target) * 100))
+}
+
+/** #501: Format a bake countdown string: "12m / 30m (40%)" */
+export function formatBakeCountdown(elapsed: number, target: number): string {
+  if (target <= 0) return ''
+  const pct = bakePct(elapsed, target)
+  return `${elapsed}m / ${target}m (${pct}%)`
+}
+
+/** #501: List of promotion sub-step types in execution order (for display). */
+const STEP_SEQUENCE = [
+  { type: 'git-clone',          label: 'Git clone' },
+  { type: 'kustomize-set-image', label: 'Set image' },
+  { type: 'helm-set-image',      label: 'Helm set image' },
+  { type: 'git-commit',          label: 'Git commit' },
+  { type: 'git-push',            label: 'Git push' },
+  { type: 'open-pr',             label: 'Open PR' },
+  { type: 'wait-for-merge',      label: 'Wait for merge' },
+  { type: 'health-check',        label: 'Health check' },
+]
+
+/** #501: Get step icon and color based on current index position. */
+export function stepIconFor(index: number, currentIndex: number, active: boolean): {
+  icon: string
+  color: string
+} {
+  if (index < currentIndex) return { icon: '✓', color: '#22c55e' }
+  if (index === currentIndex) {
+    if (!active) return { icon: '○', color: '#475569' }
+    return { icon: '▶', color: '#f59e0b' }
+  }
+  return { icon: '○', color: '#334155' }
+}
+
+export function StageDetailPanel({ node, steps, onClose }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Find the PromotionStep for this environment
+  const step = steps.find(s => s.environment === node.environment)
+
+  // Close on Escape key
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') onClose()
+  }, [onClose])
+
+  // Close on outside click
+  const handleOutsideClick = useCallback((e: MouseEvent) => {
+    if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+      onClose()
+    }
+  }, [onClose])
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('mousedown', handleOutsideClick)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('mousedown', handleOutsideClick)
+    }
+  }, [handleKeyDown, handleOutsideClick])
+
+  const bakeTarget = step?.bakeTargetMinutes ?? 0
+  const bakeElapsed = step?.bakeElapsedMinutes ?? 0
+  const bakeResets = step?.bakeResets ?? 0
+  const hasBake = bakeTarget > 0
+  const currentStepIndex = step?.currentStepIndex ?? 0
+  const isActive = step?.state === 'Promoting' || step?.state === 'HealthChecking' ||
+    step?.state === 'WaitingForMerge'
+
+  return (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-label={`Stage detail: ${node.environment}`}
+      style={{
+        position: 'absolute',
+        zIndex: 100,
+        top: '40px',
+        right: '16px',
+        width: '320px',
+        background: '#0f172a',
+        border: '1px solid #1e293b',
+        borderRadius: '6px',
+        boxShadow: '0 4px 24px rgba(0,0,0,0.5)',
+        fontSize: '0.8rem',
+        color: '#cbd5e1',
+      }}
+    >
+      {/* Header */}
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '0.5rem 0.75rem',
+        borderBottom: '1px solid #1e293b',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <span style={{ fontWeight: 600, color: '#e2e8f0' }}>{node.environment}</span>
+          <HealthChip state={node.state} size="sm" />
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close stage detail"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: '#64748b',
+            fontSize: '1rem',
+            lineHeight: 1,
+            padding: '2px 4px',
+          }}
+        >×</button>
+      </div>
+
+      {/* Bake countdown (#501) */}
+      {hasBake && (
+        <div style={{ padding: '0.5rem 0.75rem', borderBottom: '1px solid #1e293b' }}>
+          <div style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: '0.3rem',
+          }}>
+            <span style={{ color: '#94a3b8', fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+              Bake
+            </span>
+            <span
+              title={`Bake progress: ${bakeElapsed}m of ${bakeTarget}m elapsed`}
+              style={{ fontFamily: 'monospace', color: '#e2e8f0' }}
+            >
+              {formatBakeCountdown(bakeElapsed, bakeTarget)}
+            </span>
+          </div>
+          {/* Progress bar */}
+          <div style={{
+            height: '4px',
+            background: '#1e293b',
+            borderRadius: '2px',
+            overflow: 'hidden',
+          }}>
+            <div
+              role="progressbar"
+              aria-valuenow={bakeElapsed}
+              aria-valuemin={0}
+              aria-valuemax={bakeTarget}
+              aria-label={`Bake progress: ${bakePct(bakeElapsed, bakeTarget)}%`}
+              style={{
+                height: '100%',
+                width: `${bakePct(bakeElapsed, bakeTarget)}%`,
+                background: bakeElapsed >= bakeTarget ? '#22c55e' : '#6366f1',
+                borderRadius: '2px',
+                transition: 'width 0.5s ease',
+              }}
+            />
+          </div>
+          {bakeResets > 0 && (
+            <div style={{ fontSize: '0.68rem', color: '#f59e0b', marginTop: '0.25rem' }}>
+              ⚠ Timer reset {bakeResets} time{bakeResets !== 1 ? 's' : ''} due to health alarm
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* PR URL (#501) */}
+      {(step?.prURL || node.prURL) && (
+        <div style={{ padding: '0.4rem 0.75rem', borderBottom: '1px solid #1e293b' }}>
+          <a
+            href={step?.prURL ?? node.prURL}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: '#6366f1', textDecoration: 'none', fontSize: '0.75rem' }}
+            aria-label="Open pull request"
+          >
+            View PR ↗
+          </a>
+        </div>
+      )}
+
+      {/* Step list (#501) */}
+      {step && (
+        <div style={{ padding: '0.5rem 0.75rem' }}>
+          <div style={{ color: '#94a3b8', fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '0.35rem' }}>
+            Steps
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.15rem' }}>
+            {STEP_SEQUENCE.map((s, i) => {
+              const { icon, color } = stepIconFor(i, currentStepIndex, isActive)
+              return (
+                <div
+                  key={s.type}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    padding: '0.1rem 0',
+                    opacity: i > currentStepIndex ? 0.45 : 1,
+                  }}
+                >
+                  <span style={{ color, fontFamily: 'monospace', minWidth: '1rem', textAlign: 'center', fontSize: '0.75rem' }}>
+                    {icon}
+                  </span>
+                  <span style={{
+                    fontSize: '0.75rem',
+                    color: i === currentStepIndex ? '#e2e8f0' : '#94a3b8',
+                    fontWeight: i === currentStepIndex ? 600 : 400,
+                  }}>
+                    {s.label}
+                  </span>
+                  {i === currentStepIndex && step.message && (
+                    <span style={{ fontSize: '0.68rem', color: '#64748b', marginLeft: 'auto', maxWidth: '100px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {step.message}
+                    </span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* No step found */}
+      {!step && (
+        <div style={{ padding: '0.75rem', color: '#475569', fontSize: '0.75rem' }}>
+          No active promotion step for this environment.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -88,6 +88,12 @@ export interface PromotionStep {
     message?: string
     lastTransitionTime?: string
   }>
+  /** #501: Bake countdown — contiguous healthy minutes elapsed (from CRD status). */
+  bakeElapsedMinutes?: number
+  /** #501: Bake target minutes from Pipeline spec (0 = no bake configured). */
+  bakeTargetMinutes?: number
+  /** #501: Number of bake timer resets due to health alarms. */
+  bakeResets?: number
 }
 
 export interface PolicyGate {


### PR DESCRIPTION
## Summary

Implements per-stage approval workflow detail (#463) — clicking a stage node shows step execution states, bake countdown progress, and PR links.

## Changes

**Backend** (`cmd/kardinal-controller/ui_api.go`):
- `uiStepResponse` extended with `bakeElapsedMinutes`, `bakeTargetMinutes`, `bakeResets`
- `BakeTargetMinutes` read from Pipeline spec for each environment (once per pipeline per request)

**Frontend** (`web/src/components/StageDetailPanel.tsx`):
- Step list showing 8 standard steps with ✓/▶/○ icons and completion state
- Bake countdown: `X m / Y m (Z%)` with progress bar and aria-progressbar role
- Bake reset warning: shown when `bakeResets > 0`
- PR URL link from step or node data
- Close on × click, Escape keydown, outside click

**Types** (`web/src/types.ts`):
- `PromotionStep` extended with `bakeElapsedMinutes`, `bakeTargetMinutes`, `bakeResets`

## Tests

- 2 new backend tests: BakeFields, NoBakeFieldsWhenNoPipeline
- 21 new vitest tests: bakePct (5), formatBakeCountdown (4), stepIconFor (4), StageDetailPanel component (8)

## Self-validation

```
GOTOOLCHAIN=local go build ./...   ✅
GOTOOLCHAIN=local go vet ./...     ✅  
GOTOOLCHAIN=local go test ./cmd/... ./pkg/...  ✅
npm run test -- --run              ✅ 52 passed
```

Closes #463