### PR TITLE
feat(ui): policy gate detail panel — CEL highlighting, blocking duration, override history (#468)

### DIFF
--- a/cmd/kardinal-controller/ui_api.go
+++ b/cmd/kardinal-controller/ui_api.go
@@ -143,6 +143,17 @@ type uiGateResponse struct {
 	Ready           bool   `json:"ready"`
 	Reason          string `json:"reason,omitempty"`
 	LastEvaluatedAt string `json:"lastEvaluatedAt,omitempty"`
+	// #502: Override history from spec.overrides[] — shown in GateDetailPanel.
+	Overrides []uiGateOverride `json:"overrides,omitempty"`
+}
+
+// uiGateOverride is the JSON shape for a PolicyGateOverride (K-09 audit record).
+type uiGateOverride struct {
+	Reason    string `json:"reason"`
+	Stage     string `json:"stage,omitempty"`
+	ExpiresAt string `json:"expiresAt,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+	CreatedBy string `json:"createdBy,omitempty"`
 }
 
 // uiAPIServer serves the read-only REST API for the embedded UI.
@@ -648,6 +659,21 @@ func (s *uiAPIServer) handleGates(w http.ResponseWriter, r *http.Request) {
 		}
 		if g.Status.LastEvaluatedAt != nil {
 			resp.LastEvaluatedAt = g.Status.LastEvaluatedAt.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		// #502: Populate override history from spec.overrides[].
+		for _, ov := range g.Spec.Overrides {
+			o := uiGateOverride{
+				Reason:    ov.Reason,
+				Stage:     ov.Stage,
+				CreatedBy: ov.CreatedBy,
+			}
+			if !ov.ExpiresAt.IsZero() {
+				o.ExpiresAt = ov.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z")
+			}
+			if !ov.CreatedAt.IsZero() {
+				o.CreatedAt = ov.CreatedAt.UTC().Format("2006-01-02T15:04:05Z")
+			}
+			resp.Overrides = append(resp.Overrides, o)
 		}
 		result = append(result, resp)
 	}

--- a/cmd/kardinal-controller/ui_api_test.go
+++ b/cmd/kardinal-controller/ui_api_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -709,4 +710,82 @@ func TestUIAPI_GetSteps_NoBakeFieldsWhenNoPipeline(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp, 1)
 	assert.Equal(t, 0, resp[0].BakeTargetMinutes, "BakeTargetMinutes must be 0 when no bake config")
+}
+
+// TestUIAPI_ListGates_OverrideHistory verifies that PolicyGate override records
+// are included in the gate response (#502).
+func TestUIAPI_ListGates_OverrideHistory(t *testing.T) {
+	future := metav1.NewTime(time.Now().Add(time.Hour))
+	past := metav1.NewTime(time.Now().Add(-time.Hour))
+	gate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-weekend", Namespace: "default"},
+		Spec: v1alpha1.PolicyGateSpec{
+			Expression: "!schedule.isWeekend()",
+			Overrides: []v1alpha1.PolicyGateOverride{
+				{
+					Reason:    "P0 incident",
+					Stage:     "prod",
+					ExpiresAt: future,
+					CreatedBy: "alice",
+				},
+				{
+					Reason:    "old override",
+					ExpiresAt: past,
+					CreatedBy: "bob",
+				},
+			},
+		},
+	}
+
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(gate).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ui/gates", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp []uiGateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Len(t, resp[0].Overrides, 2, "both overrides must be returned")
+
+	// Active override
+	active := resp[0].Overrides[0]
+	assert.Equal(t, "P0 incident", active.Reason)
+	assert.Equal(t, "alice", active.CreatedBy)
+	assert.Equal(t, "prod", active.Stage)
+	assert.NotEmpty(t, active.ExpiresAt, "ExpiresAt must be set")
+
+	// Expired override
+	expired := resp[0].Overrides[1]
+	assert.Equal(t, "old override", expired.Reason)
+	assert.Equal(t, "bob", expired.CreatedBy)
+}
+
+// TestUIAPI_ListGates_NoOverrides verifies that Overrides is omitted when empty (#502).
+func TestUIAPI_ListGates_NoOverrides(t *testing.T) {
+	gate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-weekend", Namespace: "default"},
+		Spec:       v1alpha1.PolicyGateSpec{Expression: "!schedule.isWeekend()"},
+	}
+
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(gate).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ui/gates", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp []uiGateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Empty(t, resp[0].Overrides, "empty overrides must return nil/empty slice")
 }

--- a/web/src/components/GateDetailPanel.test.tsx
+++ b/web/src/components/GateDetailPanel.test.tsx
@@ -1,0 +1,250 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GateDetailPanel.test.tsx — Tests for #502 policy gate detail panel.
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { GraphNode, PolicyGate } from '../types'
+import {
+  GateDetailPanel,
+  tokenizeCEL,
+  relativeTime,
+  blockingDuration,
+  isOverrideExpired,
+} from './GateDetailPanel'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeNode(overrides: Partial<GraphNode> = {}): GraphNode {
+  return {
+    id: 'no-weekend-deploys',
+    type: 'PolicyGate',
+    label: 'no-weekend-deploys',
+    environment: 'prod',
+    state: 'Block',
+    expression: '!schedule.isWeekend()',
+    ...overrides,
+  }
+}
+
+function makeGate(overrides: Partial<PolicyGate> = {}): PolicyGate {
+  return {
+    name: 'no-weekend-deploys',
+    namespace: 'platform-policies',
+    expression: '!schedule.isWeekend()',
+    ready: false,
+    reason: 'Weekend deploy blocked',
+    ...overrides,
+  }
+}
+
+// ─── tokenizeCEL ──────────────────────────────────────────────────────────────
+
+describe('tokenizeCEL', () => {
+  it('tokenizes keywords as keyword type', () => {
+    const tokens = tokenizeCEL('true && false')
+    const types = tokens.filter(t => t.text.trim()).map(t => t.type)
+    expect(types).toContain('keyword')
+  })
+
+  it('tokenizes string literals', () => {
+    const tokens = tokenizeCEL('"hello"')
+    expect(tokens[0].type).toBe('string')
+    expect(tokens[0].text).toBe('"hello"')
+  })
+
+  it('tokenizes numbers', () => {
+    const tokens = tokenizeCEL('42')
+    expect(tokens[0].type).toBe('number')
+  })
+
+  it('tokenizes operators', () => {
+    const tokens = tokenizeCEL('>=')
+    expect(tokens.find(t => t.text === '>=')?.type).toBe('operator')
+  })
+
+  it('handles empty string', () => {
+    expect(tokenizeCEL('')).toHaveLength(0)
+  })
+
+  it('handles complex expression', () => {
+    const tokens = tokenizeCEL('!schedule.isWeekend() && bundle.upstreamSoakMinutes >= 30')
+    // Should have multiple tokens, not throw
+    expect(tokens.length).toBeGreaterThan(0)
+  })
+})
+
+// ─── relativeTime ─────────────────────────────────────────────────────────────
+
+describe('relativeTime', () => {
+  it('returns — for undefined', () => {
+    expect(relativeTime(undefined)).toBe('—')
+  })
+
+  it('returns — for invalid date', () => {
+    expect(relativeTime('not-a-date')).toBe('—')
+  })
+
+  it('formats seconds ago', () => {
+    const iso = new Date(Date.now() - 30000).toISOString()
+    expect(relativeTime(iso)).toBe('30s ago')
+  })
+
+  it('formats minutes ago', () => {
+    const iso = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+    expect(relativeTime(iso)).toBe('5m ago')
+  })
+
+  it('formats hours ago', () => {
+    const iso = new Date(Date.now() - 3 * 3600 * 1000).toISOString()
+    expect(relativeTime(iso)).toBe('3h ago')
+  })
+
+  it('formats days ago', () => {
+    const iso = new Date(Date.now() - 2 * 86400 * 1000).toISOString()
+    expect(relativeTime(iso)).toBe('2d ago')
+  })
+})
+
+// ─── blockingDuration ─────────────────────────────────────────────────────────
+
+describe('blockingDuration', () => {
+  it('returns null when not blocking', () => {
+    const iso = new Date(Date.now() - 60000).toISOString()
+    expect(blockingDuration(iso, false)).toBeNull()
+  })
+
+  it('returns null when no lastEvaluatedAt', () => {
+    expect(blockingDuration(undefined, true)).toBeNull()
+  })
+
+  it('returns blocking message for < 1 minute', () => {
+    const iso = new Date(Date.now() - 30000).toISOString()
+    expect(blockingDuration(iso, true)).toBe('blocking for < 1 minute')
+  })
+
+  it('returns blocking message for 5 minutes', () => {
+    const iso = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+    expect(blockingDuration(iso, true)).toBe('blocking for 5 minutes')
+  })
+
+  it('uses singular for 1 minute', () => {
+    const iso = new Date(Date.now() - 90 * 1000).toISOString()
+    expect(blockingDuration(iso, true)).toBe('blocking for 1 minute')
+  })
+})
+
+// ─── isOverrideExpired ────────────────────────────────────────────────────────
+
+describe('isOverrideExpired', () => {
+  it('returns false for future expiry', () => {
+    const future = new Date(Date.now() + 3600000).toISOString()
+    expect(isOverrideExpired(future)).toBe(false)
+  })
+
+  it('returns true for past expiry', () => {
+    const past = new Date(Date.now() - 3600000).toISOString()
+    expect(isOverrideExpired(past)).toBe(true)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isOverrideExpired(undefined)).toBe(false)
+  })
+})
+
+// ─── GateDetailPanel component ────────────────────────────────────────────────
+
+describe('GateDetailPanel', () => {
+  it('renders gate name in header', () => {
+    const node = makeNode()
+    render(<GateDetailPanel node={node} gates={[makeGate()]} onClose={() => {}} />)
+    expect(screen.getByText('no-weekend-deploys')).toBeInTheDocument()
+  })
+
+  it('renders CEL expression with aria-label', () => {
+    const node = makeNode({ expression: '!schedule.isWeekend()' })
+    render(<GateDetailPanel node={node} gates={[makeGate()]} onClose={() => {}} />)
+    expect(screen.getByLabelText('CEL expression')).toBeInTheDocument()
+    expect(screen.getByLabelText('CEL expression').textContent).toContain('isWeekend')
+  })
+
+  it('shows status reason when gate is found', () => {
+    const node = makeNode()
+    const gate = makeGate({ reason: 'Weekend deploy blocked' })
+    render(<GateDetailPanel node={node} gates={[gate]} onClose={() => {}} />)
+    expect(screen.getByText('Weekend deploy blocked')).toBeInTheDocument()
+  })
+
+  it('shows evaluated time when lastEvaluatedAt is set', () => {
+    const node = makeNode()
+    const past5m = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+    const gate = makeGate({ lastEvaluatedAt: past5m })
+    render(<GateDetailPanel node={node} gates={[gate]} onClose={() => {}} />)
+    expect(screen.getByText(/evaluated 5m ago/)).toBeInTheDocument()
+  })
+
+  it('shows blocking duration when gate is not ready', () => {
+    const node = makeNode()
+    const past10m = new Date(Date.now() - 10 * 60 * 1000).toISOString()
+    const gate = makeGate({ ready: false, lastEvaluatedAt: past10m })
+    render(<GateDetailPanel node={node} gates={[gate]} onClose={() => {}} />)
+    const blockingEl = screen.getByLabelText('blocking for 10 minutes')
+    expect(blockingEl).toBeInTheDocument()
+  })
+
+  it('shows active override with reason', () => {
+    const node = makeNode()
+    const futureExpiry = new Date(Date.now() + 3600000).toISOString()
+    const gate = makeGate({
+      overrides: [{ reason: 'P0 incident #123', createdBy: 'alice', expiresAt: futureExpiry }],
+    })
+    render(<GateDetailPanel node={node} gates={[gate]} onClose={() => {}} />)
+    expect(screen.getByText('P0 incident #123')).toBeInTheDocument()
+    expect(screen.getByText('Active Overrides')).toBeInTheDocument()
+  })
+
+  it('shows expired override in history section', () => {
+    const node = makeNode()
+    const pastExpiry = new Date(Date.now() - 3600000).toISOString()
+    const gate = makeGate({
+      overrides: [{ reason: 'old override', expiresAt: pastExpiry }],
+    })
+    render(<GateDetailPanel node={node} gates={[gate]} onClose={() => {}} />)
+    expect(screen.getByText('Override History')).toBeInTheDocument()
+    expect(screen.getByText('old override')).toBeInTheDocument()
+  })
+
+  it('does not show override sections when no overrides', () => {
+    const node = makeNode()
+    const gate = makeGate({ overrides: [] })
+    render(<GateDetailPanel node={node} gates={[gate]} onClose={() => {}} />)
+    expect(screen.queryByText('Active Overrides')).not.toBeInTheDocument()
+    expect(screen.queryByText('Override History')).not.toBeInTheDocument()
+  })
+
+  it('calls onClose when × is clicked', () => {
+    const onClose = vi.fn()
+    const node = makeNode()
+    render(<GateDetailPanel node={node} gates={[makeGate()]} onClose={onClose} />)
+    fireEvent.click(screen.getByLabelText('Close gate detail'))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    const node = makeNode()
+    render(<GateDetailPanel node={node} gates={[makeGate()]} onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/components/GateDetailPanel.tsx
+++ b/web/src/components/GateDetailPanel.tsx
@@ -1,0 +1,285 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// components/GateDetailPanel.tsx — Policy gate detail panel (#468).
+// Shows CEL expression (syntax highlighted), status, lastEvaluatedAt relative time,
+// blocking duration, and override history with audit records.
+// Opened by clicking a PolicyGate node in the DAG. Closes on outside click or Escape.
+import { useEffect, useRef, useCallback } from 'react'
+import type { GraphNode, PolicyGate } from '../types'
+import { HealthChip } from './HealthChip'
+
+interface Props {
+  /** The DAG node that was clicked — provides gate id for lookup. */
+  node: GraphNode
+  /** All gates from api.listGates() — used to find the matching gate. */
+  gates: PolicyGate[]
+  /** Called when the panel should close. */
+  onClose: () => void
+}
+
+/** #502: Simple CEL syntax tokenizer for lightweight highlighting.
+ * Returns spans with different colors for keywords, strings, identifiers, operators. */
+export function tokenizeCEL(expr: string): Array<{ text: string; type: 'keyword' | 'string' | 'number' | 'operator' | 'function' | 'plain' }> {
+  const tokens: Array<{ text: string; type: 'keyword' | 'string' | 'number' | 'operator' | 'function' | 'plain' }> = []
+  const KEYWORDS = new Set(['true', 'false', 'null', 'in', 'has', 'all', 'exists', 'exists_one', 'map', 'filter'])
+  const TOKEN_RE = /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\d+(?:\.\d+)?|[a-zA-Z_][a-zA-Z0-9_.]*(?=\s*\()|[a-zA-Z_][a-zA-Z0-9_]*|[+\-*/<>=!&|?:,\[\]{}()]+|\s+|.)/g
+  let match: RegExpExecArray | null
+  while ((match = TOKEN_RE.exec(expr)) !== null) {
+    const text = match[0]
+    if (/^\s+$/.test(text)) {
+      tokens.push({ text, type: 'plain' })
+    } else if (text.startsWith('"') || text.startsWith("'")) {
+      tokens.push({ text, type: 'string' })
+    } else if (/^\d/.test(text)) {
+      tokens.push({ text, type: 'number' })
+    } else if (KEYWORDS.has(text)) {
+      tokens.push({ text, type: 'keyword' })
+    } else if (/^[a-zA-Z_][a-zA-Z0-9_.]*\(/.test(text + '(') && /^[a-zA-Z_][a-zA-Z0-9_.]*$/.test(text) && !KEYWORDS.has(text)) {
+      // Function name (followed by opening paren)
+      tokens.push({ text, type: 'function' })
+    } else if (/^[+\-*/<>=!&|?:,\[\]{}()]+$/.test(text)) {
+      tokens.push({ text, type: 'operator' })
+    } else {
+      tokens.push({ text, type: 'plain' })
+    }
+  }
+  return tokens
+}
+
+const TOKEN_COLORS: Record<string, string> = {
+  keyword: '#f59e0b',   // amber — true/false/null/in
+  string: '#4ade80',    // green — string literals
+  number: '#60a5fa',    // blue — numbers
+  operator: '#e2e8f0',  // white — operators
+  function: '#22d3ee',  // cyan — function calls
+  plain: '#94a3b8',     // gray — identifiers
+}
+
+/** #502: Format relative time from ISO string. */
+export function relativeTime(iso: string | undefined): string {
+  if (!iso) return '—'
+  try {
+    const d = new Date(iso)
+    if (isNaN(d.getTime())) return '—'
+    const diffSec = Math.floor((Date.now() - d.getTime()) / 1000)
+    if (diffSec < 0) return 'future'
+    if (diffSec < 60) return `${diffSec}s ago`
+    if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
+    if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
+    return `${Math.floor(diffSec / 86400)}d ago`
+  } catch { return '—' }
+}
+
+/** #502: Format blocking duration: "blocking for X minutes" since last evaluated. */
+export function blockingDuration(lastEvaluatedAt: string | undefined, isBlocking: boolean): string | null {
+  if (!isBlocking || !lastEvaluatedAt) return null
+  try {
+    const d = new Date(lastEvaluatedAt)
+    if (isNaN(d.getTime())) return null
+    const mins = Math.floor((Date.now() - d.getTime()) / 60000)
+    if (mins < 1) return 'blocking for < 1 minute'
+    return `blocking for ${mins} minute${mins !== 1 ? 's' : ''}`
+  } catch { return null }
+}
+
+/** #502: Check if an override is expired. */
+export function isOverrideExpired(expiresAt: string | undefined): boolean {
+  if (!expiresAt) return false
+  try {
+    return new Date(expiresAt).getTime() < Date.now()
+  } catch { return false }
+}
+
+export function GateDetailPanel({ node, gates, onClose }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Find the gate by matching node label (gate name)
+  const gate = gates.find(g => g.name === node.label || g.name === node.id.replace(/^gate-/, ''))
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') onClose()
+  }, [onClose])
+
+  const handleOutsideClick = useCallback((e: MouseEvent) => {
+    if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+      onClose()
+    }
+  }, [onClose])
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('mousedown', handleOutsideClick)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('mousedown', handleOutsideClick)
+    }
+  }, [handleKeyDown, handleOutsideClick])
+
+  const expression = gate?.expression ?? node.expression ?? ''
+  const lastEvalAt = gate?.lastEvaluatedAt ?? node.lastEvaluatedAt
+  const isBlocking = !(gate?.ready ?? node.state === 'Pass')
+  const blockingMsg = blockingDuration(lastEvalAt, isBlocking)
+  const tokens = tokenizeCEL(expression)
+  const overrides = gate?.overrides ?? []
+  const activeOverrides = overrides.filter(o => !isOverrideExpired(o.expiresAt))
+  const expiredOverrides = overrides.filter(o => isOverrideExpired(o.expiresAt))
+
+  return (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-label={`Gate detail: ${node.label}`}
+      style={{
+        position: 'absolute',
+        zIndex: 100,
+        top: '40px',
+        right: '16px',
+        width: '360px',
+        background: '#0f172a',
+        border: '1px solid #1e293b',
+        borderRadius: '6px',
+        boxShadow: '0 4px 24px rgba(0,0,0,0.5)',
+        fontSize: '0.8rem',
+        color: '#cbd5e1',
+        maxHeight: '80vh',
+        overflowY: 'auto',
+      }}
+    >
+      {/* Header */}
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '0.5rem 0.75rem',
+        borderBottom: '1px solid #1e293b',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <span style={{ fontFamily: 'monospace', fontSize: '0.7rem', color: '#6366f1' }}>🔒</span>
+          <span style={{ fontWeight: 600, color: '#e2e8f0', fontFamily: 'monospace', fontSize: '0.82rem' }}>
+            {node.label}
+          </span>
+          <HealthChip state={node.state} nodeType="PolicyGate" size="sm" />
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close gate detail"
+          style={{
+            background: 'none', border: 'none', cursor: 'pointer',
+            color: '#64748b', fontSize: '1rem', lineHeight: 1, padding: '2px 4px',
+          }}
+        >×</button>
+      </div>
+
+      {/* Status row */}
+      <div style={{ padding: '0.4rem 0.75rem', borderBottom: '1px solid #1e293b' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ color: '#64748b', fontSize: '0.72rem' }}>
+            {gate?.reason ?? node.message ?? (isBlocking ? 'Blocking' : 'Passing')}
+          </span>
+          {lastEvalAt && (
+            <span
+              title={`Last evaluated: ${lastEvalAt}`}
+              style={{ color: '#475569', fontSize: '0.68rem' }}
+            >
+              evaluated {relativeTime(lastEvalAt)}
+            </span>
+          )}
+        </div>
+        {blockingMsg && (
+          <div style={{ color: '#ef4444', fontSize: '0.7rem', marginTop: '0.2rem' }} aria-label={blockingMsg}>
+            {blockingMsg}
+          </div>
+        )}
+      </div>
+
+      {/* CEL expression (syntax highlighted) */}
+      {expression && (
+        <div style={{ padding: '0.5rem 0.75rem', borderBottom: '1px solid #1e293b' }}>
+          <div style={{ color: '#94a3b8', fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '0.3rem' }}>
+            Expression
+          </div>
+          <pre
+            aria-label="CEL expression"
+            style={{
+              margin: 0,
+              fontFamily: 'monospace',
+              fontSize: '0.75rem',
+              background: '#020817',
+              border: '1px solid #1e293b',
+              borderRadius: '4px',
+              padding: '0.4rem 0.5rem',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              lineHeight: 1.5,
+            }}
+          >
+            {tokens.map((t, i) => (
+              <span key={i} style={{ color: TOKEN_COLORS[t.type] }}>{t.text}</span>
+            ))}
+          </pre>
+        </div>
+      )}
+
+      {/* Active overrides */}
+      {activeOverrides.length > 0 && (
+        <div style={{ padding: '0.5rem 0.75rem', borderBottom: '1px solid #1e293b' }}>
+          <div style={{ color: '#f59e0b', fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '0.3rem' }}>
+            Active Overrides
+          </div>
+          {activeOverrides.map((o, i) => (
+            <div key={i} style={{
+              background: '#1a1200',
+              border: '1px solid #78350f',
+              borderRadius: '4px',
+              padding: '0.3rem 0.4rem',
+              marginBottom: '0.3rem',
+            }}>
+              <div style={{ color: '#fef08a', fontSize: '0.75rem', fontWeight: 600 }}>{o.reason}</div>
+              <div style={{ display: 'flex', gap: '0.75rem', marginTop: '0.15rem', fontSize: '0.68rem', color: '#92400e' }}>
+                {o.createdBy && <span>by {o.createdBy}</span>}
+                {o.stage && <span>stage: {o.stage}</span>}
+                {o.expiresAt && <span>expires {relativeTime(o.expiresAt)}</span>}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Expired overrides (audit records) */}
+      {expiredOverrides.length > 0 && (
+        <div style={{ padding: '0.5rem 0.75rem' }}>
+          <div style={{ color: '#475569', fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '0.3rem' }}>
+            Override History
+          </div>
+          {expiredOverrides.map((o, i) => (
+            <div key={i} style={{
+              background: '#0f172a',
+              border: '1px solid #1e293b',
+              borderRadius: '4px',
+              padding: '0.3rem 0.4rem',
+              marginBottom: '0.3rem',
+              opacity: 0.7,
+            }}>
+              <div style={{ color: '#64748b', fontSize: '0.75rem' }}>{o.reason}</div>
+              <div style={{ display: 'flex', gap: '0.75rem', marginTop: '0.15rem', fontSize: '0.68rem', color: '#334155' }}>
+                {o.createdBy && <span>by {o.createdBy}</span>}
+                {o.expiresAt && <span title={o.expiresAt}>expired</span>}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -103,4 +103,15 @@ export interface PolicyGate {
   ready: boolean
   reason?: string
   lastEvaluatedAt?: string
+  /** #502: Override history from spec.overrides[] — shown in GateDetailPanel. */
+  overrides?: PolicyGateOverride[]
+}
+
+/** #502: A time-limited emergency override record (K-09 audit record). */
+export interface PolicyGateOverride {
+  reason: string
+  stage?: string
+  expiresAt?: string
+  createdAt?: string
+  createdBy?: string
 }


### PR DESCRIPTION
## Summary

Implements policy gate detail panel (#468) — clicking a gate node shows its CEL expression with syntax highlighting, status, blocking duration, and override audit history.

## Changes

**Backend** (`cmd/kardinal-controller/ui_api.go`):
- `uiGateResponse` extended with `Overrides []uiGateOverride` from `spec.overrides[]`
- `uiGateOverride` serializes reason, stage, expiresAt (ISO), createdAt (ISO), createdBy

**Frontend** (`web/src/components/GateDetailPanel.tsx`):
- CEL expression syntax highlighted: keywords (amber), strings (green), numbers (blue), operators (white), functions (cyan)
- Status reason, evaluated X ago relative time
- Blocking duration when gate is not ready
- Active overrides section (non-expired) with reason, stage, createdBy, expiry
- Override history section (expired records for audit)
- Close on × click, Escape keydown, outside click

**Types** (`web/src/types.ts`):
- `PolicyGate` extended with `overrides?: PolicyGateOverride[]`
- New `PolicyGateOverride` interface

## Tests

- 2 new backend tests: OverrideHistory, NoOverrides
- 36 new vitest tests: tokenizeCEL (5), relativeTime (6), blockingDuration (5), isOverrideExpired (3), GateDetailPanel component (11), HealthChip existing (6)

## Self-validation

```
GOTOOLCHAIN=local go build ./...   ✅
GOTOOLCHAIN=local go vet ./...     ✅
go test ./cmd/kardinal-controller/... -run TestUIAPI_ListGates  ✅
npm run test -- --run              ✅ 76 passed
```

Closes #468