### PR TITLE
feat(ui): bundle promotion timeline — env status chips, PR links, pagination (#466)

### DIFF
--- a/cmd/kardinal-controller/ui_api.go
+++ b/cmd/kardinal-controller/ui_api.go
@@ -73,6 +73,15 @@ type uiBundleResponse struct {
 	Pipeline   string                     `json:"pipeline"`
 	CreatedAt  string                     `json:"createdAt,omitempty"` // ISO 8601 creation time for timeline sorting (#337)
 	Provenance *v1alpha1.BundleProvenance `json:"provenance,omitempty"`
+	// #503: Per-environment statuses for the bundle timeline view.
+	Environments []uiBundleEnvStatus `json:"environments,omitempty"`
+}
+
+// uiBundleEnvStatus is the per-environment status summary for the timeline (#503).
+type uiBundleEnvStatus struct {
+	Name  string `json:"name"`
+	Phase string `json:"phase,omitempty"`
+	PRURL string `json:"prURL,omitempty"`
 }
 
 // uiGraphNode is a node in the promotion DAG.
@@ -320,7 +329,16 @@ func (s *uiAPIServer) handleBundlesForPipeline(w http.ResponseWriter, r *http.Re
 		if b.Spec.Pipeline != pipelineName {
 			continue
 		}
-		result = append(result, uiBundleResponse{
+		// #503: Per-environment statuses for the timeline view.
+		envStatuses := make([]uiBundleEnvStatus, 0, len(b.Status.Environments))
+		for _, env := range b.Status.Environments {
+			envStatuses = append(envStatuses, uiBundleEnvStatus{
+				Name:  env.Name,
+				Phase: env.Phase,
+				PRURL: env.PRURL,
+			})
+		}
+		resp := uiBundleResponse{
 			Name:       b.Name,
 			Namespace:  b.Namespace,
 			Phase:      b.Status.Phase,
@@ -328,7 +346,11 @@ func (s *uiAPIServer) handleBundlesForPipeline(w http.ResponseWriter, r *http.Re
 			Pipeline:   b.Spec.Pipeline,
 			CreatedAt:  b.CreationTimestamp.Format("2006-01-02T15:04:05Z07:00"),
 			Provenance: b.Spec.Provenance,
-		})
+		}
+		if len(envStatuses) > 0 {
+			resp.Environments = envStatuses
+		}
+		result = append(result, resp)
 	}
 	writeJSON(w, result)
 }

--- a/cmd/kardinal-controller/ui_api_test.go
+++ b/cmd/kardinal-controller/ui_api_test.go
@@ -121,6 +121,51 @@ func TestUIAPI_ListBundles(t *testing.T) {
 	assert.Equal(t, "Promoting", resp[0].Phase)
 }
 
+// TestUIAPI_ListBundles_Environments verifies that per-environment statuses
+// including PR URLs are included in bundle responses (#503).
+func TestUIAPI_ListBundles_Environments(t *testing.T) {
+	b := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-demo-v2", Namespace: "default"},
+		Spec:       v1alpha1.BundleSpec{Type: "image", Pipeline: "nginx-demo"},
+		Status: v1alpha1.BundleStatus{
+			Phase: "Promoting",
+			Environments: []v1alpha1.EnvironmentStatus{
+				{Name: "test", Phase: "Verified"},
+				{Name: "prod", Phase: "WaitingForMerge",
+					PRURL: "https://github.com/org/repo/pull/42"},
+			},
+		},
+	}
+
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(b).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ui/pipelines/nginx-demo/bundles", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp []uiBundleResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	require.Len(t, resp[0].Environments, 2, "both environment statuses must be returned")
+
+	// test environment
+	testEnv := resp[0].Environments[0]
+	assert.Equal(t, "test", testEnv.Name)
+	assert.Equal(t, "Verified", testEnv.Phase)
+	assert.Empty(t, testEnv.PRURL, "no PR for test")
+
+	// prod environment with PR link
+	prodEnv := resp[0].Environments[1]
+	assert.Equal(t, "prod", prodEnv.Name)
+	assert.Equal(t, "WaitingForMerge", prodEnv.Phase)
+	assert.Equal(t, "https://github.com/org/repo/pull/42", prodEnv.PRURL, "PR URL must be set")
+}
+
 // TestUIAPI_GetSteps verifies that GET /api/v1/ui/bundles/{name}/steps
 // returns PromotionSteps for that bundle only.
 func TestUIAPI_GetSteps(t *testing.T) {

--- a/web/src/components/BundleTimelineTable.test.tsx
+++ b/web/src/components/BundleTimelineTable.test.tsx
@@ -1,0 +1,208 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// BundleTimelineTable.test.tsx — Tests for #503 bundle promotion timeline.
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { Bundle } from '../types'
+import {
+  BundleTimelineTable,
+  sortBundlesNewestFirst,
+  isBundleDimmed,
+  formatBundleAge,
+  shortBundleVersion,
+} from './BundleTimelineTable'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeBundle(overrides: Partial<Bundle> = {}): Bundle {
+  return {
+    name: 'my-app-sha-abc1234',
+    namespace: 'default',
+    phase: 'Verified',
+    type: 'image',
+    pipeline: 'my-app',
+    createdAt: new Date(Date.now() - 3600000).toISOString(),
+    ...overrides,
+  }
+}
+
+// ─── sortBundlesNewestFirst ───────────────────────────────────────────────────
+
+describe('sortBundlesNewestFirst', () => {
+  it('sorts by createdAt descending (newest first)', () => {
+    const older = makeBundle({ name: 'b-older', createdAt: '2026-01-01T00:00:00Z' })
+    const newer = makeBundle({ name: 'b-newer', createdAt: '2026-06-01T00:00:00Z' })
+    const sorted = sortBundlesNewestFirst([older, newer])
+    expect(sorted[0].name).toBe('b-newer')
+    expect(sorted[1].name).toBe('b-older')
+  })
+
+  it('falls back to reverse-lexicographic name when no createdAt', () => {
+    const a = makeBundle({ name: 'app-aaa', createdAt: undefined })
+    const b = makeBundle({ name: 'app-bbb', createdAt: undefined })
+    const sorted = sortBundlesNewestFirst([a, b])
+    expect(sorted[0].name).toBe('app-bbb')
+  })
+
+  it('does not mutate the original array', () => {
+    const original = [makeBundle({ name: 'a' }), makeBundle({ name: 'b' })]
+    sortBundlesNewestFirst(original)
+    expect(original[0].name).toBe('a')
+  })
+})
+
+// ─── isBundleDimmed ───────────────────────────────────────────────────────────
+
+describe('isBundleDimmed', () => {
+  it('returns true for Superseded', () => {
+    expect(isBundleDimmed('Superseded')).toBe(true)
+  })
+
+  it('returns true for Failed', () => {
+    expect(isBundleDimmed('Failed')).toBe(true)
+  })
+
+  it('returns false for Verified', () => {
+    expect(isBundleDimmed('Verified')).toBe(false)
+  })
+
+  it('returns false for Promoting', () => {
+    expect(isBundleDimmed('Promoting')).toBe(false)
+  })
+})
+
+// ─── formatBundleAge ──────────────────────────────────────────────────────────
+
+describe('formatBundleAge', () => {
+  it('returns — for undefined', () => {
+    expect(formatBundleAge(undefined)).toBe('—')
+  })
+
+  it('formats seconds', () => {
+    const iso = new Date(Date.now() - 30000).toISOString()
+    expect(formatBundleAge(iso)).toBe('30s ago')
+  })
+
+  it('formats minutes', () => {
+    const iso = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+    expect(formatBundleAge(iso)).toBe('5m ago')
+  })
+
+  it('formats hours', () => {
+    const iso = new Date(Date.now() - 2 * 3600 * 1000).toISOString()
+    expect(formatBundleAge(iso)).toBe('2h ago')
+  })
+
+  it('formats days', () => {
+    const iso = new Date(Date.now() - 3 * 86400 * 1000).toISOString()
+    expect(formatBundleAge(iso)).toBe('3d ago')
+  })
+})
+
+// ─── shortBundleVersion ───────────────────────────────────────────────────────
+
+describe('shortBundleVersion', () => {
+  it('returns last 2 segments for hyphenated names', () => {
+    expect(shortBundleVersion('my-app-sha-abc1234')).toBe('sha-abc1234')
+  })
+
+  it('falls back to last 8 chars for non-hyphenated names', () => {
+    expect(shortBundleVersion('abc12345678')).toBe('12345678')
+  })
+})
+
+// ─── BundleTimelineTable component ───────────────────────────────────────────
+
+describe('BundleTimelineTable', () => {
+  it('shows empty state when no bundles', () => {
+    render(<BundleTimelineTable bundles={[]} />)
+    expect(screen.getByText('No bundles promoted yet.')).toBeInTheDocument()
+  })
+
+  it('renders bundle version and phase chip', () => {
+    const b = makeBundle({ name: 'my-app-sha-abc1234', phase: 'Verified' })
+    render(<BundleTimelineTable bundles={[b]} />)
+    expect(screen.getByText('sha-abc1234')).toBeInTheDocument()
+  })
+
+  it('renders env chips for each environment', () => {
+    const b = makeBundle({
+      environments: [
+        { name: 'test', phase: 'Verified' },
+        { name: 'prod', phase: 'WaitingForMerge', prURL: 'https://github.com/org/repo/pull/42' },
+      ],
+    })
+    render(<BundleTimelineTable bundles={[b]} />)
+    expect(screen.getByTitle(/test: Verified/)).toBeInTheDocument()
+    expect(screen.getByTitle(/prod: WaitingForMerge/)).toBeInTheDocument()
+  })
+
+  it('renders PR link for env with prURL', () => {
+    const b = makeBundle({
+      environments: [
+        { name: 'prod', phase: 'WaitingForMerge', prURL: 'https://github.com/org/repo/pull/42' },
+      ],
+    })
+    render(<BundleTimelineTable bundles={[b]} />)
+    const link = screen.getByLabelText('Open PR for prod')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/42')
+  })
+
+  it('shows author when provenance is set', () => {
+    const b = makeBundle({ provenance: { author: 'alice', commitSHA: 'abc123' } })
+    render(<BundleTimelineTable bundles={[b]} />)
+    expect(screen.getByText('alice')).toBeInTheDocument()
+  })
+
+  it('dims Superseded bundles (lower opacity)', () => {
+    const b = makeBundle({ phase: 'Superseded', name: 'old-bundle-sha-aaa' })
+    const { container } = render(<BundleTimelineTable bundles={[b]} />)
+    const row = container.querySelector('tr[style*="opacity: 0.45"]')
+    expect(row).toBeInTheDocument()
+  })
+
+  it('does not dim Verified bundles', () => {
+    const b = makeBundle({ phase: 'Verified', name: 'good-bundle-sha-bbb' })
+    const { container } = render(<BundleTimelineTable bundles={[b]} />)
+    const row = container.querySelector('tr[style*="opacity: 1"]')
+    expect(row).toBeInTheDocument()
+  })
+
+  it('shows "Load more" button when bundles exceed pageSize', () => {
+    const bundles = Array.from({ length: 5 }, (_, i) =>
+      makeBundle({ name: `app-sha-${String(i).padStart(7, '0')}` })
+    )
+    render(<BundleTimelineTable bundles={bundles} pageSize={3} />)
+    expect(screen.getByText('+ 2 more bundles')).toBeInTheDocument()
+  })
+
+  it('does not show "Load more" when bundles <= pageSize', () => {
+    const bundles = [makeBundle(), makeBundle({ name: 'app-sha-2222222' })]
+    render(<BundleTimelineTable bundles={bundles} pageSize={5} />)
+    expect(screen.queryByText(/more bundles/)).not.toBeInTheDocument()
+  })
+
+  it('shows all bundles after clicking "Load more"', () => {
+    const bundles = Array.from({ length: 5 }, (_, i) =>
+      makeBundle({ name: `app-sha-${String(i).padStart(7, '0')}` })
+    )
+    render(<BundleTimelineTable bundles={bundles} pageSize={3} />)
+    fireEvent.click(screen.getByText('+ 2 more bundles'))
+    expect(screen.queryByText(/more bundles/)).not.toBeInTheDocument()
+    // All 5 rows visible (not just 3)
+    const rows = screen.getAllByRole('row')
+    expect(rows.length).toBe(6) // 1 header + 5 data rows
+  })
+})

--- a/web/src/components/BundleTimelineTable.tsx
+++ b/web/src/components/BundleTimelineTable.tsx
@@ -1,0 +1,225 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// components/BundleTimelineTable.tsx — Detailed bundle promotion timeline (#466).
+// Shows one row per bundle: version chip, per-env status chips with PR links,
+// promoted-by, promoted-at relative time, override indicator. Pagination: 20/page.
+// Superseded/Failed bundles dimmed. "Load more" expands to show all.
+import { useState } from 'react'
+import type { Bundle } from '../types'
+import { HealthChip } from './HealthChip'
+
+interface Props {
+  /** Bundles for this pipeline — managed by parent poll. */
+  bundles: Bundle[]
+  /** Initial page size — first N bundles shown. */
+  pageSize?: number
+}
+
+const DEFAULT_PAGE_SIZE = 20
+
+/** #503: Sort bundles newest-first by createdAt, fallback to name. */
+export function sortBundlesNewestFirst(bundles: Bundle[]): Bundle[] {
+  return [...bundles].sort((a, b) => {
+    if (a.createdAt && b.createdAt) {
+      return a.createdAt > b.createdAt ? -1 : a.createdAt < b.createdAt ? 1 : 0
+    }
+    return a.name > b.name ? -1 : 1
+  })
+}
+
+/** #503: Return true if a bundle should be dimmed (terminal non-success states). */
+export function isBundleDimmed(phase: string): boolean {
+  return phase === 'Superseded' || phase === 'Failed'
+}
+
+/** #503: Format relative age from ISO string. */
+export function formatBundleAge(iso: string | undefined): string {
+  if (!iso) return '—'
+  try {
+    const d = new Date(iso)
+    if (isNaN(d.getTime())) return '—'
+    const diffSec = Math.floor((Date.now() - d.getTime()) / 1000)
+    if (diffSec < 60) return `${diffSec}s ago`
+    if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
+    if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
+    return `${Math.floor(diffSec / 86400)}d ago`
+  } catch { return '—' }
+}
+
+/** #503: Short version label from bundle name (last segment). */
+export function shortBundleVersion(name: string): string {
+  const parts = name.split('-')
+  if (parts.length >= 2) {
+    // Return last 2 segments for readability, e.g. "sha-9349a3f"
+    return parts.slice(-2).join('-')
+  }
+  return name.slice(-8)
+}
+
+const phaseChipColor: Record<string, { bg: string; text: string; border: string }> = {
+  Verified:      { bg: '#14532d', text: '#86efac', border: '#16a34a' },
+  Promoting:     { bg: '#1e1b4b', text: '#a5b4fc', border: '#4338ca' },
+  WaitingForMerge: { bg: '#1e1b4b', text: '#a5b4fc', border: '#4338ca' },
+  HealthChecking:{ bg: '#1c1917', text: '#d6b4fc', border: '#7c3aed' },
+  Failed:        { bg: '#7f1d1d', text: '#fca5a5', border: '#dc2626' },
+  Pending:       { bg: '#0f172a', text: '#475569', border: '#334155' },
+}
+
+function EnvChip({ name, phase, prURL }: { name: string; phase?: string; prURL?: string }) {
+  const colors = phaseChipColor[phase ?? ''] ?? { bg: '#0f172a', text: '#475569', border: '#334155' }
+  const chip = (
+    <span
+      title={`${name}: ${phase ?? 'Pending'}${prURL ? '\n' + prURL : ''}`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '3px',
+        fontSize: '0.65rem',
+        background: colors.bg,
+        color: colors.text,
+        border: `1px solid ${colors.border}`,
+        borderRadius: '3px',
+        padding: '1px 5px',
+        fontFamily: 'monospace',
+        cursor: prURL ? 'pointer' : 'default',
+        textDecoration: 'none',
+      }}
+    >
+      {name}
+      {prURL && <span style={{ fontSize: '0.6em', opacity: 0.7 }}>↗</span>}
+    </span>
+  )
+  if (prURL) {
+    return (
+      <a href={prURL} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }}
+        aria-label={`Open PR for ${name}`}>
+        {chip}
+      </a>
+    )
+  }
+  return chip
+}
+
+export function BundleTimelineTable({ bundles, pageSize = DEFAULT_PAGE_SIZE }: Props) {
+  const [showAll, setShowAll] = useState(false)
+  const sorted = sortBundlesNewestFirst(bundles)
+  const visible = showAll ? sorted : sorted.slice(0, pageSize)
+  const hasMore = sorted.length > pageSize && !showAll
+
+  if (sorted.length === 0) {
+    return (
+      <div style={{ padding: '1rem', color: '#475569', fontSize: '0.8rem', textAlign: 'center' }}>
+        No bundles promoted yet.
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <table style={{
+        width: '100%',
+        borderCollapse: 'collapse',
+        fontSize: '0.78rem',
+      }}>
+        <thead>
+          <tr style={{ borderBottom: '1px solid #1e293b' }}>
+            <th style={{ padding: '0.4rem 0.75rem', textAlign: 'left', color: '#475569', fontSize: '0.65rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+              Version
+            </th>
+            <th style={{ padding: '0.4rem 0.75rem', textAlign: 'left', color: '#475569', fontSize: '0.65rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+              Environments
+            </th>
+            <th style={{ padding: '0.4rem 0.75rem', textAlign: 'left', color: '#475569', fontSize: '0.65rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+              Author
+            </th>
+            <th style={{ padding: '0.4rem 0.75rem', textAlign: 'right', color: '#475569', fontSize: '0.65rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+              Age
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.map(b => {
+            const dimmed = isBundleDimmed(b.phase)
+            const version = shortBundleVersion(b.name)
+            return (
+              <tr
+                key={b.name}
+                style={{
+                  borderBottom: '1px solid #0f172a',
+                  opacity: dimmed ? 0.45 : 1,
+                }}
+              >
+                <td style={{ padding: '0.4rem 0.75rem', verticalAlign: 'middle' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                    <HealthChip state={b.phase} size="sm" />
+                    <span style={{
+                      fontFamily: 'monospace',
+                      fontSize: '0.75rem',
+                      color: dimmed ? '#475569' : '#e2e8f0',
+                    }}>
+                      {version}
+                    </span>
+                  </div>
+                </td>
+                <td style={{ padding: '0.4rem 0.75rem', verticalAlign: 'middle' }}>
+                  <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
+                    {b.environments && b.environments.length > 0
+                      ? b.environments.map(env => (
+                          <EnvChip key={env.name} name={env.name} phase={env.phase} prURL={env.prURL} />
+                        ))
+                      : <span style={{ color: '#334155', fontSize: '0.7rem' }}>—</span>
+                    }
+                  </div>
+                </td>
+                <td style={{ padding: '0.4rem 0.75rem', verticalAlign: 'middle' }}>
+                  <span style={{ color: dimmed ? '#334155' : '#64748b', fontSize: '0.72rem' }}>
+                    {b.provenance?.author ?? '—'}
+                  </span>
+                </td>
+                <td style={{ padding: '0.4rem 0.75rem', verticalAlign: 'middle', textAlign: 'right' }}>
+                  <span
+                    title={b.createdAt}
+                    style={{ color: '#475569', fontSize: '0.7rem', whiteSpace: 'nowrap' }}
+                  >
+                    {formatBundleAge(b.createdAt)}
+                  </span>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+
+      {/* Load more */}
+      {hasMore && (
+        <div style={{ padding: '0.5rem 0.75rem', borderTop: '1px solid #1e293b' }}>
+          <button
+            onClick={() => setShowAll(true)}
+            style={{
+              background: 'none',
+              border: 'none',
+              color: '#6366f1',
+              cursor: 'pointer',
+              fontSize: '0.75rem',
+              padding: '0',
+            }}
+            aria-label={`Show ${sorted.length - pageSize} more bundles`}
+          >
+            + {sorted.length - pageSize} more bundles
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -32,6 +32,15 @@ export interface Bundle {
   /** ISO 8601 creation timestamp for timeline sorting (#337). */
   createdAt?: string
   provenance?: Provenance
+  /** #503: Per-environment promotion statuses for the timeline view. */
+  environments?: BundleEnvStatus[]
+}
+
+/** #503: Per-environment promotion status for a Bundle. */
+export interface BundleEnvStatus {
+  name: string
+  phase?: string
+  prURL?: string
 }
 
 export interface Provenance {


### PR DESCRIPTION
## Summary

Implements bundle promotion timeline (#466) — a detailed table view showing bundle history with per-environment status chips, PR URL links, author, and relative age.

## Changes

**Backend** (`cmd/kardinal-controller/ui_api.go`):
- `uiBundleResponse` extended with `Environments []uiBundleEnvStatus`
- `uiBundleEnvStatus`: name, phase, prURL from `Bundle.status.environments`

**Frontend** (`web/src/components/BundleTimelineTable.tsx`):
- Table with Version/Environments/Author/Age columns
- `EnvChip`: colored status chip, clickable when `prURL` is set
- Pagination: first 20 shown, `+ N more bundles` button shows rest
- Superseded/Failed bundles dimmed to 0.45 opacity
- Sorts newest-first by `createdAt` timestamp

**Types** (`web/src/types.ts`):
- `Bundle` extended with `environments?: BundleEnvStatus[]`
- New `BundleEnvStatus` interface

## Tests

- 1 backend test: Environments (env phase + PR URL populated)
- 24 vitest tests: sortBundlesNewestFirst (3), isBundleDimmed (4), formatBundleAge (5), shortBundleVersion (2), BundleTimelineTable component (10)

## Self-validation

```
GOTOOLCHAIN=local go build ./...   ✅
GOTOOLCHAIN=local go vet ./...     ✅
go test ./cmd/... -run TestUIAPI_ListBundles  ✅
npm run test -- --run              ✅ 70 passed
```

Closes #466