### PR TITLE
fix(controller): recreate Graph when deleted externally (#490)

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -119,6 +119,12 @@ type BundleStatus struct {
 	// Populated by the BundleReconciler when all environments reach Verified.
 	// +optional
 	Metrics *BundleMetrics `json:"metrics,omitempty"`
+
+	// GraphRef is the name of the kro Graph CR backing this Bundle's promotion DAG.
+	// Populated by the BundleReconciler when the Graph is first created.
+	// Used to detect Graph deletion and trigger recreation.
+	// +optional
+	GraphRef string `json:"graphRef,omitempty"`
 }
 
 // BundleMetrics holds deployment efficiency metrics for a single Bundle (K-05).

--- a/cmd/kardinal-controller/main.go
+++ b/cmd/kardinal-controller/main.go
@@ -167,8 +167,9 @@ func main() {
 	gitClient := scm.NewExecGitClient()
 
 	if err := (&bundlereconciler.Reconciler{
-		Client:     mgr.GetClient(),
-		Translator: newTranslator(mgr.GetConfig(), mgr.GetClient(), splitCSV(policyNamespaces), logger),
+		Client:       mgr.GetClient(),
+		Translator:   newTranslator(mgr.GetConfig(), mgr.GetClient(), splitCSV(policyNamespaces), logger),
+		GraphChecker: newGraphClient(mgr.GetConfig(), logger),
 	}).SetupWithManager(mgr); err != nil {
 		logger.Fatal().Err(err).Msg("unable to set up BundleReconciler")
 	}
@@ -405,6 +406,17 @@ func newTranslator(cfg *rest.Config, k8s sigs_client.Reader,
 	graphClient := graphpkg.NewGraphClient(dynClient, log)
 	builder := graphpkg.NewBuilder()
 	return translator.New(graphClient, builder, k8s, policyNS, log)
+}
+
+// newGraphClient constructs a GraphClient for use as a GraphChecker in the Bundle reconciler.
+// A separate dynamic client is created so the Translator and BundleReconciler each have
+// their own client handle (avoids sharing state across goroutines).
+func newGraphClient(cfg *rest.Config, log zerolog.Logger) *graphpkg.GraphClient {
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		log.Fatal().Err(err).Msg("unable to create dynamic client for graph checker")
+	}
+	return graphpkg.NewGraphClient(dynClient, log)
 }
 
 // splitCSV splits a comma-separated string into a trimmed slice.

--- a/config/crd/bases/kardinal.io_bundles.yaml
+++ b/config/crd/bases/kardinal.io_bundles.yaml
@@ -280,6 +280,12 @@ spec:
                   - name
                   type: object
                 type: array
+              graphRef:
+                description: |-
+                  GraphRef is the name of the kro Graph CR backing this Bundle's promotion DAG.
+                  Populated by the BundleReconciler when the Graph is first created.
+                  Used to detect Graph deletion and trigger recreation.
+                type: string
               metrics:
                 description: |-
                   Metrics holds deployment efficiency metrics for this Bundle (K-05).

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -709,6 +709,13 @@ func assembleGraph(pipeline *kardinalv1alpha1.Pipeline, bundle *kardinalv1alpha1
 
 // --- naming helpers ---
 
+// GraphNameFrom returns the deterministic Graph CR name for a (pipeline, bundle) pair.
+// This is exported so the Bundle reconciler can compute the expected graph name
+// without importing translator-layer code.
+func GraphNameFrom(pipeline, bundle string) string {
+	return graphNameFrom(pipeline, bundle)
+}
+
 // graphNameFrom generates a Graph name from the pipeline and bundle names.
 // Both names are slugified (lowercased, non-alphanumeric → dash).
 // Truncates to 63 chars (Kubernetes name limit).

--- a/pkg/graph/client.go
+++ b/pkg/graph/client.go
@@ -69,6 +69,20 @@ func (c *GraphClient) Get(ctx context.Context, namespace, name string) (*Graph, 
 	return g, nil
 }
 
+// GraphExists returns true if a Graph CR with the given name exists in the given namespace.
+// Returns false (not an error) when the Graph is not found (HTTP 404).
+// Used by the Bundle reconciler to detect external Graph deletions (#490).
+func (c *GraphClient) GraphExists(ctx context.Context, namespace, name string) (bool, error) {
+	_, err := c.dynamic.Resource(GraphGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if isNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("graph.GraphExists %s/%s: %w", namespace, name, err)
+	}
+	return true, nil
+}
+
 // Delete deletes a Graph CR. Returns nil if the Graph is not found.
 func (c *GraphClient) Delete(ctx context.Context, namespace, name string) error {
 	err := c.dynamic.Resource(GraphGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})

--- a/pkg/reconciler/bundle/reconciler.go
+++ b/pkg/reconciler/bundle/reconciler.go
@@ -28,18 +28,27 @@ import (
 	"github.com/rs/zerolog"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/graph"
 )
 
 // BundleTranslator is the interface the BundleReconciler uses to translate a
 // Bundle+Pipeline into a kro Graph. Abstracted as an interface for testability.
 type BundleTranslator interface {
 	Translate(ctx context.Context, pipeline *kardinalv1alpha1.Pipeline, bundle *kardinalv1alpha1.Bundle) (string, error)
+}
+
+// GraphChecker checks whether a kro Graph exists by name in a given namespace.
+// Abstracted as an interface for testability without a real Kubernetes cluster.
+type GraphChecker interface {
+	GraphExists(ctx context.Context, namespace, name string) (bool, error)
 }
 
 // Reconciler watches Bundle objects, sets Available phase, triggers translation,
@@ -50,6 +59,9 @@ type Reconciler struct {
 	// Translator creates the kro Graph for a Bundle+Pipeline pair.
 	// May be nil in test environments where translation is not needed.
 	Translator BundleTranslator
+	// GraphChecker detects whether the Graph CR still exists.
+	// When nil, graph recreation is skipped (backward-compatible).
+	GraphChecker GraphChecker
 }
 
 // Reconcile is called whenever a Bundle is created, updated, or deleted,
@@ -123,8 +135,78 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				log.Warn().Err(err).Msg("failed to check parent pipeline (non-fatal), continuing sync")
 			}
 		}
+		// For Promoting bundles: ensure the Graph still exists and recreate if needed.
+		// Fixes issue #490: manual Graph deletion left bundles stuck in Promoting.
+		if b.Status.Phase == "Promoting" {
+			if err := r.ensureGraphExists(ctx, log, &b); err != nil {
+				log.Error().Err(err).Msg("graph recreation failed — requeuing")
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
+		}
 		return r.handleSyncEvidence(ctx, log, &b)
 	}
+}
+
+// ensureGraphExists checks whether the Graph for a Promoting Bundle still exists,
+// and recreates it via the Translator if it has been deleted.
+//
+// This fixes issue #490: manual `kubectl delete graph <name>` left Bundles stuck
+// in Promoting indefinitely. Graph CR deletion now triggers re-reconciliation
+// (via the Graph Watch in SetupWithManager) and this method handles recreation.
+//
+// Graph-first: we only write to our own CRD status (GraphRef). The Translator
+// is idempotent — if the Graph already exists it returns nil without creating again.
+func (r *Reconciler) ensureGraphExists(ctx context.Context, log zerolog.Logger,
+	b *kardinalv1alpha1.Bundle) error {
+	if r.Translator == nil || r.GraphChecker == nil {
+		return nil // no-op in test environments without real translator
+	}
+
+	// Compute expected graph name — deterministic from (pipeline, bundle).
+	expectedName := b.Status.GraphRef
+	if expectedName == "" {
+		// Fallback: recompute from known naming convention.
+		expectedName = graph.GraphNameFrom(b.Spec.Pipeline, b.Name)
+	}
+
+	exists, err := r.GraphChecker.GraphExists(ctx, b.Namespace, expectedName)
+	if err != nil {
+		// Non-fatal: log and continue. Graph check failure should not block evidence sync.
+		log.Warn().Err(err).Str("graph", expectedName).Msg("failed to check graph existence (non-fatal)")
+		return nil
+	}
+	if exists {
+		return nil // nothing to do
+	}
+
+	// Graph is missing — look up the Pipeline and recreate.
+	log.Info().Str("graph", expectedName).Msg("graph deleted externally — recreating")
+
+	var pipeline kardinalv1alpha1.Pipeline
+	if err := r.Get(ctx, client.ObjectKey{Name: b.Spec.Pipeline, Namespace: b.Namespace}, &pipeline); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Pipeline deleted — Bundle orphan guard will handle cleanup on next reconcile.
+			return nil
+		}
+		return fmt.Errorf("ensureGraphExists: get pipeline: %w", err)
+	}
+
+	graphName, err := r.Translator.Translate(ctx, &pipeline, b)
+	if err != nil {
+		return fmt.Errorf("ensureGraphExists: recreate graph: %w", err)
+	}
+
+	// Update GraphRef if it changed (shouldn't happen, but keep it current).
+	if b.Status.GraphRef != graphName {
+		patch := client.MergeFrom(b.DeepCopy())
+		b.Status.GraphRef = graphName
+		if patchErr := r.Status().Patch(ctx, b, patch); patchErr != nil {
+			log.Warn().Err(patchErr).Msg("failed to update GraphRef after recreation (non-fatal)")
+		}
+	}
+
+	log.Info().Str("graph", graphName).Msg("graph recreated after external deletion")
+	return nil
 }
 
 // handleNew sets the phase to Available on a newly-created Bundle.
@@ -261,7 +343,7 @@ func (r *Reconciler) handleAvailable(ctx context.Context, log zerolog.Logger,
 	// Advance to Promoting
 	patch := client.MergeFrom(b.DeepCopy())
 	b.Status.Phase = "Promoting"
-	_ = graphName // GraphRef will be stored in BundleStatus in a future stage
+	b.Status.GraphRef = graphName // store for recreation detection (#490)
 
 	if err := r.Status().Patch(ctx, b, patch); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -454,9 +536,11 @@ func (r *Reconciler) Start(ctx context.Context) error {
 // It also registers the reconciler as a Runnable so that Start() is called after
 // cache sync to perform startup reconciliation.
 //
-// It adds a Watch on PromotionStep objects: when any PromotionStep for a Bundle
-// changes state (e.g. Verified, Failed), the Bundle is re-queued to sync evidence.
-// This replaces the PromotionStep reconciler's cross-CRD copyEvidenceToBundle write.
+// It adds Watches for:
+//   - PromotionStep changes: when a PromotionStep state changes, re-queue the Bundle
+//     to sync evidence. Replaces the old cross-CRD copyEvidenceToBundle.
+//   - Graph deletion: when the kro Graph backing a Bundle is deleted externally,
+//     re-queue the Bundle so it can recreate the Graph (#490).
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.Add(r); err != nil {
 		return fmt.Errorf("add reconciler as runnable: %w", err)
@@ -477,9 +561,37 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}
 
+	// graphMapper maps a kro Graph change event to a Bundle reconcile request.
+	// When a Graph is deleted externally (kubectl delete graph <name>), the owning
+	// Bundle is re-queued so ensureGraphExists can recreate it (#490).
+	// Reads the kardinal.io/bundle label set by the Graph builder.
+	graphMapper := func(ctx context.Context, obj client.Object) []reconcile.Request {
+		bundleName := obj.GetLabels()["kardinal.io/bundle"]
+		if bundleName == "" {
+			return nil
+		}
+		return []reconcile.Request{
+			{NamespacedName: client.ObjectKey{
+				Name:      bundleName,
+				Namespace: obj.GetNamespace(),
+			}},
+		}
+	}
+
+	// graphObject is an unstructured placeholder for the kro Graph CRD.
+	// We use unstructured to avoid a compile-time dependency on the kro module.
+	graphObject := &unstructured.Unstructured{}
+	graphObject.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "experimental.kro.run",
+		Version: "v1alpha1",
+		Kind:    "Graph",
+	})
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kardinalv1alpha1.Bundle{}).
 		// Watch PromotionSteps: evidence sync when PS state changes.
 		Watches(&kardinalv1alpha1.PromotionStep{}, handler.EnqueueRequestsFromMapFunc(promotionStepMapper)).
+		// Watch Graphs: recreate when Graph is deleted externally (#490).
+		Watches(graphObject, handler.EnqueueRequestsFromMapFunc(graphMapper)).
 		Complete(r)
 }

--- a/pkg/reconciler/bundle/reconciler_test.go
+++ b/pkg/reconciler/bundle/reconciler_test.go
@@ -1154,3 +1154,167 @@ func TestBundleReconciler_MetricsComputedOnVerified(t *testing.T) {
 			"commitToProductionMinutes must be < 200 (should be ~120-130m)")
 	}
 }
+
+// --- GraphChecker mock ---
+
+// mockGraphChecker is a test double for bundle.GraphChecker.
+type mockGraphChecker struct {
+	exists    bool
+	err       error
+	callCount int
+}
+
+func (m *mockGraphChecker) GraphExists(_ context.Context, _, _ string) (bool, error) {
+	m.callCount++
+	return m.exists, m.err
+}
+
+// TestBundleReconciler_GraphRefStoredOnPromotion verifies that Bundle.status.graphRef
+// is set when the bundle transitions to Promoting (fixes #490 prerequisite).
+func TestBundleReconciler_GraphRefStoredOnPromotion(t *testing.T) {
+	pipeline := &kardinalv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default"},
+		Spec: kardinalv1alpha1.PipelineSpec{
+			Environments: []kardinalv1alpha1.EnvironmentSpec{{Name: "test"}},
+		},
+	}
+	b := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app-v1", Namespace: "default"},
+		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "my-app"},
+		Status:     kardinalv1alpha1.BundleStatus{Phase: "Available"},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(pipeline, b).
+		WithStatusSubresource(b).
+		Build()
+
+	translator := &mockTranslator{graphName: "my-app-my-app-v1"}
+	r := &bundle.Reconciler{Client: c, Translator: translator}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-app-v1", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	require.True(t, translator.called, "translator must be called")
+
+	var got kardinalv1alpha1.Bundle
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: "my-app-v1", Namespace: "default"}, &got))
+	assert.Equal(t, "Promoting", got.Status.Phase)
+	assert.Equal(t, "my-app-my-app-v1", got.Status.GraphRef,
+		"GraphRef must be set in Bundle.status when advancing to Promoting")
+}
+
+// TestBundleReconciler_GraphRecreatedAfterDeletion verifies that when a Promoting
+// Bundle's Graph is deleted externally, the reconciler detects this via GraphChecker
+// and calls Translate to recreate it (#490).
+func TestBundleReconciler_GraphRecreatedAfterDeletion(t *testing.T) {
+	pipeline := &kardinalv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default"},
+		Spec: kardinalv1alpha1.PipelineSpec{
+			Environments: []kardinalv1alpha1.EnvironmentSpec{{Name: "test"}},
+		},
+	}
+	b := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app-v1", Namespace: "default"},
+		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "my-app"},
+		Status: kardinalv1alpha1.BundleStatus{
+			Phase:    "Promoting",
+			GraphRef: "my-app-my-app-v1",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(pipeline, b).
+		WithStatusSubresource(b).
+		Build()
+
+	// Graph does NOT exist — simulates manual kubectl delete graph.
+	checker := &mockGraphChecker{exists: false}
+	translator := &mockTranslator{graphName: "my-app-my-app-v1"}
+	r := &bundle.Reconciler{Client: c, Translator: translator, GraphChecker: checker}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-app-v1", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, checker.callCount, "GraphChecker.GraphExists must be called once")
+	assert.True(t, translator.called,
+		"Translator.Translate must be called when graph is missing")
+}
+
+// TestBundleReconciler_GraphNotRecreatedWhenPresent verifies that when the Graph
+// exists, the translator is NOT called again (idempotency).
+func TestBundleReconciler_GraphNotRecreatedWhenPresent(t *testing.T) {
+	pipeline := &kardinalv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default"},
+		Spec: kardinalv1alpha1.PipelineSpec{
+			Environments: []kardinalv1alpha1.EnvironmentSpec{{Name: "test"}},
+		},
+	}
+	b := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app-v1", Namespace: "default"},
+		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "my-app"},
+		Status: kardinalv1alpha1.BundleStatus{
+			Phase:    "Promoting",
+			GraphRef: "my-app-my-app-v1",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(pipeline, b).
+		WithStatusSubresource(b).
+		Build()
+
+	// Graph EXISTS — normal operating condition.
+	checker := &mockGraphChecker{exists: true}
+	translator := &mockTranslator{graphName: "my-app-my-app-v1"}
+	r := &bundle.Reconciler{Client: c, Translator: translator, GraphChecker: checker}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-app-v1", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, checker.callCount, "GraphChecker must be called once")
+	assert.False(t, translator.called,
+		"Translator must NOT be called when graph already exists")
+}
+
+// TestBundleReconciler_GraphCheckerErrorIsNonFatal verifies that a GraphChecker
+// error does not fail the reconcile — evidence sync still proceeds.
+func TestBundleReconciler_GraphCheckerErrorIsNonFatal(t *testing.T) {
+	pipeline := &kardinalv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default"},
+	}
+	b := &kardinalv1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app-v1", Namespace: "default"},
+		Spec:       kardinalv1alpha1.BundleSpec{Type: "image", Pipeline: "my-app"},
+		Status: kardinalv1alpha1.BundleStatus{
+			Phase:    "Promoting",
+			GraphRef: "my-app-my-app-v1",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithObjects(pipeline, b).
+		WithStatusSubresource(b).
+		Build()
+
+	// GraphChecker returns an error — must not propagate.
+	checker := &mockGraphChecker{exists: false, err: fmt.Errorf("connection refused")}
+	r := &bundle.Reconciler{Client: c, GraphChecker: checker}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-app-v1", Namespace: "default"},
+	})
+	// Error should NOT propagate — GraphChecker failures are non-fatal.
+	require.NoError(t, err,
+		"GraphChecker error must be non-fatal — reconcile should not return error")
+}


### PR DESCRIPTION
[🔨 ENG]

## Summary

Fixes #490: when a Bundle is in `Promoting` state and the kro Graph backing it is deleted externally (`kubectl delete graph <name>`), the Bundle now detects the missing Graph and recreates it.

## Problem

`BundleReconciler.SetupWithManager` only watched `Bundle` and `PromotionStep` objects. It had no Watch on Graph objects. When a Graph was deleted:
- No watch event triggered Bundle reconciliation
- The Bundle stayed in `Promoting` forever with no promotion progressing
- The only workaround was to delete and recreate the Bundle itself

## Solution

### 1. `Bundle.status.graphRef` — store graph name on creation

When `handleAvailable` advances a Bundle to Promoting, it now stores the Graph name in `Bundle.status.GraphRef`. This is the canonical source of truth for "which Graph does this Bundle expect".

### 2. `graph.GraphClient.GraphExists()` — non-destructive check

New method that returns `(bool, error)` without fetching/unmarshalling the full Graph. Used by the Bundle reconciler to detect deletion.

### 3. `graph.GraphNameFrom()` — exported naming function

The graph name is deterministic from `(pipeline, bundle)`. Now exported so the Bundle reconciler can fall back to computing the expected name if `GraphRef` is not yet set.

### 4. `bundle.GraphChecker` interface — mockable graph existence check

New interface injected into `Reconciler`. The real implementation delegates to `graph.GraphClient.GraphExists()`. Test double: `mockGraphChecker`.

### 5. Watch on Graph objects

`SetupWithManager` now adds an unstructured Watch on `experimental.kro.run/v1alpha1/Graph`. When any Graph is deleted, the `kardinal.io/bundle` label is read and the owning Bundle is re-queued.

### 6. `ensureGraphExists()` in Promoting state handler

For every reconcile of a Promoting Bundle:
- Call `GraphChecker.GraphExists(graphRef)`
- If missing: look up Pipeline, call `Translator.Translate()` (idempotent — no-op if already exists)
- If `GraphChecker` returns error: log warning, continue with evidence sync (non-fatal)
- If `GraphChecker` is nil (test mode): skip check

## Tests (4 new)

| Test | What it verifies |
|---|---|
| `TestBundleReconciler_GraphRefStoredOnPromotion` | `status.graphRef` set when advancing to Promoting |
| `TestBundleReconciler_GraphRecreatedAfterDeletion` | Translator called when graph is missing |
| `TestBundleReconciler_GraphNotRecreatedWhenPresent` | Translator NOT called when graph exists (idempotency) |
| `TestBundleReconciler_GraphCheckerErrorIsNonFatal` | GraphChecker error does not fail reconcile |

## QA Checklist

- [x] No new logic leaks (GraphChecker only reads CRD existence; recreation delegates to existing Translator)
- [x] Idempotent: `Translator.Translate()` is already idempotent (returns nil on AlreadyExists)
- [x] `time.Now()` not introduced
- [x] No cross-CRD mutations — Bundle reconciler writes only to Bundle.status
- [x] All existing tests pass
- [x] 4 new tests covering the happy path, idempotency, and error handling