### PR TITLE
feat(scm): implement OCIWatcher and GitWatcher — Subscription source polling (#491 #493)

### DIFF
--- a/cmd/kardinal-controller/main.go
+++ b/cmd/kardinal-controller/main.go
@@ -235,19 +235,12 @@ func main() {
 				if sub.Spec.Image == nil {
 					return nil, fmt.Errorf("image subscription missing spec.image")
 				}
-				return &source.OCIWatcher{
-					Registry:  sub.Spec.Image.Registry,
-					TagFilter: sub.Spec.Image.TagFilter,
-				}, nil
+				return source.NewOCIWatcher(sub.Spec.Image.Registry, sub.Spec.Image.TagFilter), nil
 			case kardinalv1alpha1.SubscriptionTypeGit:
 				if sub.Spec.Git == nil {
 					return nil, fmt.Errorf("git subscription missing spec.git")
 				}
-				return &source.GitWatcher{
-					RepoURL:  sub.Spec.Git.RepoURL,
-					Branch:   sub.Spec.Git.Branch,
-					PathGlob: sub.Spec.Git.PathGlob,
-				}, nil
+				return source.NewGitWatcher(sub.Spec.Git.RepoURL, sub.Spec.Git.Branch, sub.Spec.Git.PathGlob), nil
 			default:
 				return nil, fmt.Errorf("unknown subscription type %q", sub.Spec.Type)
 			}

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -312,9 +312,6 @@ health:
 
 A Subscription watches external sources and auto-creates Bundles. This is an alternative to the CI webhook for teams that want fully passive promotion triggers.
 
-!!! warning "Source watchers in active development"
-    The OCI image watcher (`type: image`) and Git watcher (`type: git`) are currently stubs that always return `Changed: false`. A Subscription will enter `status.phase = Watching` but will not trigger Bundle creation until the real polling is implemented. See [subscription.md](subscription.md) for details.
-
 **Image Subscription** (watches OCI registries for new image tags):
 
 ```yaml

--- a/docs/subscription.md
+++ b/docs/subscription.md
@@ -3,16 +3,6 @@
 The `Subscription` CRD automatically creates Bundle CRDs when new artifacts are detected
 in an OCI registry or Git repository. This removes the CI dependency for artifact discovery.
 
-!!! warning "Source watchers in active development"
-    The OCI image watcher (`type: image`) and Git watcher (`type: git`) are currently stubs.
-    A Subscription can be created and will enter `status.phase = Watching`, but it will not
-    discover new tags or commits yet — `Changed: false` is always returned.
-
-    Real polling is being implemented (GitHub issues
-    [#491](https://github.com/pnz1990/kardinal-promoter/issues/491) for OCI,
-    [#493](https://github.com/pnz1990/kardinal-promoter/issues/493) for Git).
-    Until those land, create Bundles manually with `kardinal create bundle` or the CI webhook.
-
 ## Overview
 
 Without a Subscription, Bundles must be created manually (`kardinal create bundle`) or

--- a/pkg/source/git.go
+++ b/pkg/source/git.go
@@ -16,35 +16,248 @@
 package source
 
 import (
+	"bufio"
 	"context"
+	"encoding/hex"
 	"fmt"
+	"net/http"
+	"path"
+	"strings"
 )
 
-// GitWatcher watches a Git repository for new commits.
-// Phase 1: stub implementation that always returns "not changed".
-// Real implementation will use go-git.
+// GitWatcher watches a Git repository for new commits on a branch.
+//
+// It uses the Git Smart HTTP protocol (info/refs?service=git-upload-pack)
+// to read the current HEAD of a branch without cloning. This works for
+// GitHub, GitLab, Gitea/Forgejo, and any standard HTTPS git server.
+//
+// PathGlob filtering is not applied at the reference-discovery level:
+// the watcher returns Changed=true on any new commit to the branch.
+// Path-level filtering is a client-side concern handled by the Subscription
+// reconciler when deciding whether to create a Bundle.
 type GitWatcher struct {
-	// RepoURL is the HTTPS Git repository URL.
+	// RepoURL is the HTTPS Git repository URL (e.g. "https://github.com/myorg/myapp").
 	RepoURL string
-	// Branch is the branch to watch.
+	// Branch is the branch to watch. Defaults to "main".
 	Branch string
 	// PathGlob is the optional file glob to filter commits.
+	// Currently recorded in the Watcher for future use when go-git is available.
+	// Today the watcher returns Changed=true on any new commit (#495 tracks go-git migration).
 	PathGlob string
+	// httpClient is the HTTP client used for requests. Defaults to http.DefaultClient.
+	httpClient *http.Client
 }
 
-// Watch polls the Git repository for the latest commit on the watched branch.
-// Phase 1 stub: returns not-changed for all requests to avoid
-// requiring Git network access in unit tests.
-// Real implementation: clone/fetch → walk commits → filter by PathGlob → return latest SHA.
-func (w *GitWatcher) Watch(_ context.Context, lastDigest string) (*WatchResult, error) {
+// NewGitWatcher creates a GitWatcher with the default HTTP client.
+func NewGitWatcher(repoURL, branch, pathGlob string) *GitWatcher {
+	b := branch
+	if b == "" {
+		b = "main"
+	}
+	return &GitWatcher{
+		RepoURL:    repoURL,
+		Branch:     b,
+		PathGlob:   pathGlob,
+		httpClient: http.DefaultClient,
+	}
+}
+
+// Watch polls the Git repository for the latest commit SHA on the watched branch.
+//
+// Uses the Git Smart HTTP protocol endpoint:
+//
+//	GET <repoURL>/info/refs?service=git-upload-pack
+//
+// The response body contains pkt-line encoded reference advertisements.
+// We parse the response to find the SHA for refs/heads/<branch>.
+//
+// Returns Changed=true when the latest SHA differs from lastDigest.
+// First-run (lastDigest=="") returns Changed=false to avoid creating a Bundle
+// on every Subscription creation at controller startup.
+func (w *GitWatcher) Watch(ctx context.Context, lastDigest string) (*WatchResult, error) {
 	if w.RepoURL == "" {
 		return nil, fmt.Errorf("GitWatcher: repoURL must not be empty")
 	}
-	// Phase 1 stub: no real polling yet.
-	// w.Branch (default "main") and w.PathGlob will be used by the real implementation.
+
+	branch := w.Branch
+	if branch == "" {
+		branch = "main"
+	}
+
+	sha, err := w.fetchLatestSHA(ctx, branch)
+	if err != nil {
+		return nil, fmt.Errorf("GitWatcher: fetch latest SHA for %s@%s: %w", w.RepoURL, branch, err)
+	}
+
+	if sha == "" {
+		// Branch not found in advertisement — return not-changed.
+		return &WatchResult{Digest: lastDigest, Tag: "", Changed: false}, nil
+	}
+
+	// First-run (lastDigest=="") is not considered a change to avoid creating
+	// a Bundle for every Subscription on controller startup.
+	changed := lastDigest != "" && sha != lastDigest
+
+	shortSHA := sha
+	if len(shortSHA) > 7 {
+		shortSHA = shortSHA[:7]
+	}
+
 	return &WatchResult{
-		Digest:  lastDigest,
-		Tag:     "",
-		Changed: false,
+		Digest:  sha,
+		Tag:     shortSHA,
+		Changed: changed,
 	}, nil
+}
+
+// fetchLatestSHA fetches the current HEAD SHA for the given branch using
+// the Git Smart HTTP protocol.
+func (w *GitWatcher) fetchLatestSHA(ctx context.Context, branch string) (string, error) {
+	refsURL := strings.TrimRight(w.RepoURL, "/") + "/info/refs?service=git-upload-pack"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, refsURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Git-Protocol", "version=2")
+	req.Header.Set("User-Agent", "kardinal-promoter/subscription-watcher")
+
+	httpClient := w.httpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GET %s: %w", refsURL, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return "", fmt.Errorf("repository not found: %s (HTTP 404)", w.RepoURL)
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return "", fmt.Errorf("authentication required for %s (HTTP %d)", w.RepoURL, resp.StatusCode)
+	case http.StatusOK:
+		// continue
+	default:
+		return "", fmt.Errorf("unexpected HTTP %d from %s", resp.StatusCode, refsURL)
+	}
+
+	return parsePktLineRefs(bufio.NewReader(resp.Body), "refs/heads/"+branch)
+}
+
+// parsePktLineRefs parses the Git pkt-line format used in Smart HTTP responses
+// and returns the SHA for the given refName. Returns "" if the ref is not found.
+//
+// Pkt-line format: each line is prefixed with a 4-hex-digit length (including
+// the 4-byte prefix itself). A line starting with "0000" is a flush packet.
+// The git Smart HTTP response has two sections separated by a flush packet:
+//
+//  1. Service announcement: "# service=git-upload-pack" + 0000 (flush)
+//  2. Ref advertisement: each ref + 0000 (flush at end)
+//
+// Each ref line is: "<sha> <refname>[NUL capabilities]"
+func parsePktLineRefs(r *bufio.Reader, refName string) (string, error) {
+	flushCount := 0
+	for {
+		// Read 4-byte hex length prefix.
+		lenHex := make([]byte, 4)
+		if _, err := r.Read(lenHex); err != nil {
+			break
+		}
+		lenBytes, err := hex.DecodeString(string(lenHex))
+		if err != nil {
+			// Not a valid pkt-line — may be plain text (older git servers).
+			// Fall back to line-by-line parsing.
+			return parsePlainRefs(r, refName, string(lenHex))
+		}
+		lineLen := int(lenBytes[0])<<8 | int(lenBytes[1])
+		if lineLen == 0 {
+			// Flush packet — end of current section.
+			flushCount++
+			if flushCount >= 2 {
+				// Second flush ends the ref advertisement section.
+				break
+			}
+			// First flush separates service announcement from refs — continue.
+			continue
+		}
+		if lineLen < 4 {
+			break
+		}
+		payload := make([]byte, lineLen-4)
+		if _, err := r.Read(payload); err != nil {
+			break
+		}
+		line := strings.TrimRight(string(payload), "\n\x00")
+		// Strip capability advertisement (after NUL byte on the first ref line).
+		if idx := strings.IndexByte(line, '\x00'); idx >= 0 {
+			line = line[:idx]
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) == 2 && parts[1] == refName {
+			return parts[0], nil
+		}
+	}
+	return "", nil
+}
+
+// parsePlainRefs is a fallback parser for git servers that respond with
+// plain text (non-pkt-line format). Line format: "<sha>\t<refname>"
+func parsePlainRefs(r *bufio.Reader, refName, alreadyRead string) (string, error) {
+	// Reconstruct the first line from alreadyRead + rest of current line.
+	rest, _ := r.ReadString('\n')
+	firstLine := alreadyRead + rest
+	if sha := extractSHAFromLine(firstLine, refName); sha != "" {
+		return sha, nil
+	}
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if sha := extractSHAFromLine(scanner.Text(), refName); sha != "" {
+			return sha, nil
+		}
+	}
+	return "", nil
+}
+
+// extractSHAFromLine extracts the SHA from a line if it references refName.
+// Handles both "sha ref\n" (pkt-line) and "sha\tref" (plain text) formats.
+func extractSHAFromLine(line, refName string) string {
+	line = strings.TrimRight(line, "\n\r\x00")
+	// Try space separator (pkt-line body).
+	parts := strings.SplitN(line, " ", 2)
+	if len(parts) == 2 && parts[1] == refName && looksLikeSHA(parts[0]) {
+		return parts[0]
+	}
+	// Try tab separator (ls-remote plain output).
+	parts = strings.SplitN(line, "\t", 2)
+	if len(parts) == 2 && parts[1] == refName && looksLikeSHA(parts[0]) {
+		return parts[0]
+	}
+	// Try trailing full ref match (some server variants include full path).
+	if !strings.HasSuffix(line, "\t"+path.Base(refName)) {
+		return ""
+	}
+	if len(line) < 40 {
+		return ""
+	}
+	sha := line[:40]
+	if looksLikeSHA(sha) {
+		return sha
+	}
+	return ""
+}
+
+// looksLikeSHA returns true if s looks like a 40-character hex string (full SHA).
+func looksLikeSHA(s string) bool {
+	if len(s) < 40 {
+		return false
+	}
+	for _, c := range s[:40] {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/source/git.go
+++ b/pkg/source/git.go
@@ -255,7 +255,7 @@ func looksLikeSHA(s string) bool {
 		return false
 	}
 	for _, c := range s[:40] {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 			return false
 		}
 	}

--- a/pkg/source/oci.go
+++ b/pkg/source/oci.go
@@ -17,32 +17,231 @@ package source
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
 )
 
 // OCIWatcher watches an OCI registry for new image tags.
-// Phase 1: stub implementation that always returns "not changed".
-// Real implementation will use google/go-containerregistry.
+// It uses the OCI Distribution Specification API (no external dependencies):
+//   - GET /v2/<name>/tags/list to list tags
+//   - HEAD /v2/<name>/manifests/<tag> to read the digest
+//
+// The watcher is safe for concurrent use.
 type OCIWatcher struct {
-	// Registry is the OCI registry URL (e.g. "ghcr.io/myorg/myapp").
+	// Registry is the OCI image repository (e.g. "ghcr.io/myorg/myapp").
+	// For a local/test registry include the scheme: "http://localhost:5000/myapp".
 	Registry string
-	// TagFilter is an optional regex that tags must match.
+	// TagFilter is an optional regex that tags must match. When empty, all tags match.
 	TagFilter string
+	// httpClient is the HTTP client used for requests. Defaults to http.DefaultClient.
+	// Set to a custom client for testing or for private registries requiring authentication.
+	httpClient *http.Client
 }
 
-// Watch polls the OCI registry for the latest tag.
-// Phase 1 stub: returns not-changed for all requests to avoid
-// requiring OCI registry access in unit tests.
-// Real implementation: list tags → filter by TagFilter → return newest by pushed_at.
-func (w *OCIWatcher) Watch(_ context.Context, lastDigest string) (*WatchResult, error) {
+// NewOCIWatcher creates an OCIWatcher with the default HTTP client.
+func NewOCIWatcher(registry, tagFilter string) *OCIWatcher {
+	return &OCIWatcher{
+		Registry:   registry,
+		TagFilter:  tagFilter,
+		httpClient: http.DefaultClient,
+	}
+}
+
+// ociTagsListResponse is the JSON response from /v2/<name>/tags/list.
+type ociTagsListResponse struct {
+	Tags []string `json:"tags"`
+}
+
+// Watch polls the OCI registry for the latest tag matching TagFilter.
+//
+// Algorithm:
+//  1. GET /v2/<name>/tags/list to list all tags
+//  2. Filter tags by TagFilter regex (if set)
+//  3. Sort tags lexicographically; pick the last (lexicographically "newest")
+//  4. HEAD /v2/<name>/manifests/<tag> to get the Docker-Content-Digest header
+//  5. Return Changed=true if the digest differs from lastDigest
+//
+// First-run (lastDigest=="") returns Changed=false to avoid creating a Bundle
+// on every Subscription creation at controller startup.
+func (w *OCIWatcher) Watch(ctx context.Context, lastDigest string) (*WatchResult, error) {
 	if w.Registry == "" {
 		return nil, fmt.Errorf("OCIWatcher: registry must not be empty")
 	}
-	// Phase 1 stub: no real polling yet.
-	// The reconciler handles nil/empty result gracefully (sets phase=Watching, no Bundle created).
+
+	host, name, err := parseRegistryRef(w.Registry)
+	if err != nil {
+		return nil, fmt.Errorf("OCIWatcher: parse registry ref %q: %w", w.Registry, err)
+	}
+
+	// List all tags.
+	tags, err := w.listTags(ctx, host, name)
+	if err != nil {
+		return nil, fmt.Errorf("OCIWatcher: list tags for %q: %w", w.Registry, err)
+	}
+
+	// Filter by TagFilter regex.
+	filtered, err := filterTags(tags, w.TagFilter)
+	if err != nil {
+		return nil, fmt.Errorf("OCIWatcher: filter tags: %w", err)
+	}
+	if len(filtered) == 0 {
+		return &WatchResult{Digest: lastDigest, Tag: "", Changed: false}, nil
+	}
+
+	// Sort lexicographically descending: pick "newest" tag.
+	sort.Strings(filtered)
+	newestTag := filtered[len(filtered)-1]
+
+	// HEAD the manifest to get the digest.
+	digest, err := w.headManifest(ctx, host, name, newestTag)
+	if err != nil {
+		return nil, fmt.Errorf("OCIWatcher: head manifest for %q:%q: %w", w.Registry, newestTag, err)
+	}
+
+	// First-run is not considered a change.
+	changed := lastDigest != "" && digest != lastDigest
+
 	return &WatchResult{
-		Digest:  lastDigest,
-		Tag:     "",
-		Changed: false,
+		Digest:  digest,
+		Tag:     newestTag,
+		Changed: changed,
 	}, nil
+}
+
+// listTags fetches the tag list from the OCI Distribution API.
+func (w *OCIWatcher) listTags(ctx context.Context, host, name string) ([]string, error) {
+	url := host + "/v2/" + name + "/tags/list"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := w.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	var result ociTagsListResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode tags/list response: %w", err)
+	}
+	return result.Tags, nil
+}
+
+// headManifest fetches the content digest of the given tag.
+func (w *OCIWatcher) headManifest(ctx context.Context, host, name, tag string) (string, error) {
+	url := host + "/v2/" + name + "/manifests/" + tag
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	// Accept both OCI and Docker manifest schemas for broad registry compatibility.
+	req.Header.Set("Accept",
+		"application/vnd.docker.distribution.manifest.v2+json,"+
+			"application/vnd.oci.image.manifest.v1+json")
+
+	resp, err := w.doRequest(req)
+	if err != nil {
+		return "", err
+	}
+	resp.Body.Close() //nolint:errcheck
+
+	digest := resp.Header.Get("Docker-Content-Digest")
+	if digest == "" {
+		// Some registries use OCI header name.
+		digest = resp.Header.Get("Content-Digest")
+	}
+	if digest == "" {
+		return "", fmt.Errorf("registry did not return a content digest for %s:%s", name, tag)
+	}
+	return digest, nil
+}
+
+// doRequest executes an HTTP request and validates the status code.
+func (w *OCIWatcher) doRequest(req *http.Request) (*http.Response, error) {
+	client := w.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP %s %s: %w", req.Method, req.URL, err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusNoContent:
+		return resp, nil
+	case http.StatusNotFound:
+		resp.Body.Close() //nolint:errcheck
+		return nil, fmt.Errorf("not found: %s (HTTP 404)", req.URL)
+	case http.StatusUnauthorized, http.StatusForbidden:
+		resp.Body.Close() //nolint:errcheck
+		return nil, fmt.Errorf("authentication required for %s (HTTP %d)", req.URL, resp.StatusCode)
+	default:
+		resp.Body.Close() //nolint:errcheck
+		return nil, fmt.Errorf("unexpected HTTP %d from %s", resp.StatusCode, req.URL)
+	}
+}
+
+// parseRegistryRef splits a registry reference into (scheme+host, name).
+// Examples:
+//
+//	"ghcr.io/myorg/myapp"          → ("https://ghcr.io", "myorg/myapp")
+//	"http://localhost:5000/myapp"   → ("http://localhost:5000", "myapp")
+//	"my.registry:5000/ns/app"      → ("https://my.registry:5000", "ns/app")
+func parseRegistryRef(ref string) (host, imageName string, err error) {
+	if ref == "" {
+		return "", "", fmt.Errorf("empty registry reference")
+	}
+
+	// If ref has an explicit scheme, use it as-is.
+	if strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") {
+		// Find the first "/" after the scheme.
+		withoutScheme := ref[strings.Index(ref, "//")+2:]
+		slashIdx := strings.Index(withoutScheme, "/")
+		if slashIdx < 0 {
+			return "", "", fmt.Errorf("registry reference %q must include image name", ref)
+		}
+		scheme := ref[:strings.Index(ref, "//")+2]
+		return scheme + withoutScheme[:slashIdx], withoutScheme[slashIdx+1:], nil
+	}
+
+	// No scheme — assume HTTPS.
+	slashIdx := strings.Index(ref, "/")
+	if slashIdx < 0 {
+		return "", "", fmt.Errorf("registry reference %q must include image name (e.g. ghcr.io/myorg/myapp)", ref)
+	}
+	return "https://" + ref[:slashIdx], ref[slashIdx+1:], nil
+}
+
+// filterTags returns tags that match the given regex pattern.
+// If pattern is empty, all tags are returned.
+func filterTags(tags []string, pattern string) ([]string, error) {
+	if pattern == "" {
+		return tags, nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tagFilter regex %q: %w", pattern, err)
+	}
+	result := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if re.MatchString(t) {
+			result = append(result, t)
+		}
+	}
+	return result, nil
 }

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -1,0 +1,371 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/source"
+)
+
+// --- Git Watcher Tests ---
+
+// makePktLine returns a git pkt-line encoded message.
+// Format: 4 hex chars of (length + 4) + payload + newline.
+func makePktLine(s string) string {
+	length := len(s) + 4 + 1 // +4 for prefix, +1 for newline
+	return fmt.Sprintf("%04x%s\n", length, s)
+}
+
+// makeGitRefsResponse constructs a minimal git Smart HTTP info/refs response
+// with the given refs map (refName → sha).
+func makeGitRefsResponse(refs map[string]string) string {
+	var sb string
+	// Service announcement
+	sb += makePktLine("# service=git-upload-pack")
+	sb += "0000" // flush
+
+	first := true
+	for ref, sha := range refs {
+		if first {
+			// First ref line includes capability advertisement after NUL byte.
+			sb += makePktLine(sha + " " + ref + "\x00 side-band-64k")
+			first = false
+		} else {
+			sb += makePktLine(sha + " " + ref)
+		}
+	}
+	sb += "0000" // flush
+	return sb
+}
+
+// TestGitWatcher_DetectsNewCommit verifies that Watch returns Changed=true
+// when the SHA differs from the last known digest.
+func TestGitWatcher_DetectsNewCommit(t *testing.T) {
+	const newSHA = "abc1234567890123456789012345678901234567a"
+	const oldSHA = "def0000000000000000000000000000000000000"
+
+	body := makeGitRefsResponse(map[string]string{
+		"refs/heads/main": newSHA,
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.RawQuery, "service=git-upload-pack")
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		fmt.Fprint(w, body) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	watcher := source.NewGitWatcher(srv.URL, "main", "")
+	result, err := watcher.Watch(context.Background(), oldSHA)
+	require.NoError(t, err)
+
+	assert.True(t, result.Changed, "Changed must be true when SHA differs")
+	assert.Equal(t, newSHA, result.Digest)
+	assert.Equal(t, "abc1234", result.Tag, "Tag must be the short SHA (7 chars)")
+}
+
+// TestGitWatcher_NoChangeWhenSHAUnchanged verifies that Watch returns Changed=false
+// when the repo SHA is the same as lastDigest.
+func TestGitWatcher_NoChangeWhenSHAUnchanged(t *testing.T) {
+	const sha = "abc1234567890123456789012345678901234567a"
+
+	body := makeGitRefsResponse(map[string]string{
+		"refs/heads/main": sha,
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	watcher := source.NewGitWatcher(srv.URL, "main", "")
+	result, err := watcher.Watch(context.Background(), sha)
+	require.NoError(t, err)
+
+	assert.False(t, result.Changed, "Changed must be false when SHA is unchanged")
+	assert.Equal(t, sha, result.Digest)
+}
+
+// TestGitWatcher_FirstRunNotChanged verifies that first-run (lastDigest="")
+// does NOT return Changed=true to avoid spurious Bundle creation on startup.
+func TestGitWatcher_FirstRunNotChanged(t *testing.T) {
+	const sha = "abc1234567890123456789012345678901234567a"
+
+	body := makeGitRefsResponse(map[string]string{
+		"refs/heads/main": sha,
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	watcher := source.NewGitWatcher(srv.URL, "main", "")
+	result, err := watcher.Watch(context.Background(), "") // first run
+	require.NoError(t, err)
+
+	assert.False(t, result.Changed, "First run must not return Changed=true")
+	assert.Equal(t, sha, result.Digest, "Digest must be set even on first run")
+}
+
+// TestGitWatcher_BranchNotFound verifies that Watch returns Changed=false
+// with the previous digest when the branch is not in the refs advertisement.
+func TestGitWatcher_BranchNotFound(t *testing.T) {
+	const oldSHA = "def0000000000000000000000000000000000000"
+
+	// Only "refs/heads/other" is advertised, not "refs/heads/main".
+	body := makeGitRefsResponse(map[string]string{
+		"refs/heads/other": "aaa0000000000000000000000000000000000000",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	watcher := source.NewGitWatcher(srv.URL, "main", "")
+	result, err := watcher.Watch(context.Background(), oldSHA)
+	require.NoError(t, err)
+
+	assert.False(t, result.Changed, "Changed must be false when branch not found")
+	assert.Equal(t, oldSHA, result.Digest, "Digest must be previous value when branch not found")
+}
+
+// TestGitWatcher_ServerError verifies that Watch returns an error on HTTP failure.
+func TestGitWatcher_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	watcher := source.NewGitWatcher(srv.URL, "main", "")
+	_, err := watcher.Watch(context.Background(), "")
+	assert.Error(t, err, "Watch must return error on server error")
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestGitWatcher_EmptyRepoURL verifies validation.
+func TestGitWatcher_EmptyRepoURL(t *testing.T) {
+	watcher := source.NewGitWatcher("", "main", "")
+	_, err := watcher.Watch(context.Background(), "")
+	assert.Error(t, err)
+}
+
+// --- OCI Watcher Tests ---
+// OCI watcher tests use httptest to mock the OCI registry API.
+
+// fakeRegistry creates a test HTTP server simulating an OCI registry.
+// It serves:
+//   - GET /v2/<name>/tags/list — returns the given tags
+//   - HEAD /v2/<name>/manifests/<tag> — returns a fake digest header
+func fakeRegistry(t *testing.T, imageName string, tags []string, tagToDigest map[string]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/"+imageName+"/tags/list":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"name":%q,"tags":%s}`, imageName, toJSONArray(tags)) //nolint:errcheck
+		case r.Method == http.MethodHead:
+			// Extract tag from path: /v2/<name>/manifests/<tag>
+			parts := splitPath(r.URL.Path)
+			tag := parts[len(parts)-1]
+			digest, ok := tagToDigest[tag]
+			if !ok {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Docker-Content-Digest", digest)
+			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected request: "+r.Method+" "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	return srv
+}
+
+func toJSONArray(ss []string) string {
+	if len(ss) == 0 {
+		return "[]"
+	}
+	out := "["
+	for i, s := range ss {
+		if i > 0 {
+			out += ","
+		}
+		out += fmt.Sprintf("%q", s)
+	}
+	out += "]"
+	return out
+}
+
+func splitPath(p string) []string {
+	var parts []string
+	for _, seg := range splitSlash(p) {
+		if seg != "" {
+			parts = append(parts, seg)
+		}
+	}
+	return parts
+}
+
+func splitSlash(s string) []string {
+	var result []string
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == '/' {
+			result = append(result, s[start:i])
+			start = i + 1
+		}
+	}
+	return result
+}
+
+// TestOCIWatcher_DetectsNewTag verifies that Watch returns Changed=true
+// when the registry has a new tag with a different digest.
+func TestOCIWatcher_DetectsNewTag(t *testing.T) {
+	const imageName = "myorg/myapp"
+	const newDigest = "sha256:abc1234567890abcdef"
+	const oldDigest = "sha256:000000000000000000"
+
+	srv := fakeRegistry(t, imageName, []string{"sha-aaa111", "sha-bbb222"}, map[string]string{
+		"sha-aaa111": "sha256:old111",
+		"sha-bbb222": newDigest,
+	})
+	defer srv.Close()
+
+	// The registry host is srv.URL (without https://).
+	// go-containerregistry expects "host/name" format for non-default registries.
+	registryRef := srv.URL + "/" + imageName
+
+	watcher := source.NewOCIWatcher(registryRef, "^sha-")
+	result, err := watcher.Watch(context.Background(), oldDigest)
+	require.NoError(t, err)
+
+	// sha-bbb222 sorts after sha-aaa111, so it's the "newest".
+	assert.True(t, result.Changed, "Changed must be true when digest differs")
+	assert.Equal(t, newDigest, result.Digest)
+	assert.Equal(t, "sha-bbb222", result.Tag)
+}
+
+// TestOCIWatcher_NoChangeWhenDigestUnchanged verifies that Watch returns
+// Changed=false when the newest tag digest matches lastDigest.
+func TestOCIWatcher_NoChangeWhenDigestUnchanged(t *testing.T) {
+	const imageName = "myorg/myapp"
+	const digest = "sha256:abc1234567890abcdef"
+
+	srv := fakeRegistry(t, imageName, []string{"sha-aaa111"}, map[string]string{
+		"sha-aaa111": digest,
+	})
+	defer srv.Close()
+
+	registryRef := srv.URL + "/" + imageName
+	watcher := source.NewOCIWatcher(registryRef, "")
+	result, err := watcher.Watch(context.Background(), digest)
+	require.NoError(t, err)
+
+	assert.False(t, result.Changed)
+	assert.Equal(t, digest, result.Digest)
+}
+
+// TestOCIWatcher_FirstRunNotChanged verifies that first-run (lastDigest="")
+// does NOT return Changed=true.
+func TestOCIWatcher_FirstRunNotChanged(t *testing.T) {
+	const imageName = "myorg/myapp"
+	const digest = "sha256:abc1234567890abcdef"
+
+	srv := fakeRegistry(t, imageName, []string{"latest"}, map[string]string{
+		"latest": digest,
+	})
+	defer srv.Close()
+
+	registryRef := srv.URL + "/" + imageName
+	watcher := source.NewOCIWatcher(registryRef, "")
+	result, err := watcher.Watch(context.Background(), "")
+	require.NoError(t, err)
+
+	assert.False(t, result.Changed, "First run must not return Changed=true")
+	assert.Equal(t, digest, result.Digest)
+}
+
+// TestOCIWatcher_TagFilterApplied verifies that only tags matching TagFilter are considered.
+func TestOCIWatcher_TagFilterApplied(t *testing.T) {
+	const imageName = "myorg/myapp"
+
+	srv := fakeRegistry(t, imageName, []string{"latest", "sha-aaa111", "sha-bbb222"}, map[string]string{
+		"latest":     "sha256:old-latest",
+		"sha-aaa111": "sha256:sha-aaa-digest",
+		"sha-bbb222": "sha256:sha-bbb-digest",
+	})
+	defer srv.Close()
+
+	registryRef := srv.URL + "/" + imageName
+	// TagFilter matches only sha-* tags.
+	watcher := source.NewOCIWatcher(registryRef, "^sha-")
+	result, err := watcher.Watch(context.Background(), "sha256:old")
+	require.NoError(t, err)
+
+	// "latest" must be excluded by filter.
+	// sha-bbb222 sorts after sha-aaa111.
+	assert.Equal(t, "sha-bbb222", result.Tag, "Only sha- tags should be considered")
+	assert.Equal(t, "sha256:sha-bbb-digest", result.Digest)
+}
+
+// TestOCIWatcher_NoMatchingTagsReturnsNotChanged verifies behavior when
+// no tags match the filter.
+func TestOCIWatcher_NoMatchingTagsReturnsNotChanged(t *testing.T) {
+	const imageName = "myorg/myapp"
+	const oldDigest = "sha256:prev"
+
+	srv := fakeRegistry(t, imageName, []string{"v1.0.0", "v1.1.0"}, map[string]string{})
+	defer srv.Close()
+
+	registryRef := srv.URL + "/" + imageName
+	watcher := source.NewOCIWatcher(registryRef, "^sha-")
+	result, err := watcher.Watch(context.Background(), oldDigest)
+	require.NoError(t, err)
+
+	assert.False(t, result.Changed)
+	assert.Equal(t, oldDigest, result.Digest, "Digest must be previous when no tags match")
+}
+
+// TestOCIWatcher_InvalidTagFilterReturnsError verifies that an invalid regex is rejected.
+func TestOCIWatcher_InvalidTagFilterReturnsError(t *testing.T) {
+	const imageName = "myorg/myapp"
+
+	srv := fakeRegistry(t, imageName, []string{"v1.0"}, map[string]string{"v1.0": "sha256:abc"})
+	defer srv.Close()
+
+	registryRef := srv.URL + "/" + imageName
+	watcher := source.NewOCIWatcher(registryRef, "[invalid")
+	_, err := watcher.Watch(context.Background(), "")
+	assert.Error(t, err, "invalid regex must return error")
+}
+
+// TestOCIWatcher_EmptyRegistryReturnsError verifies validation.
+func TestOCIWatcher_EmptyRegistryReturnsError(t *testing.T) {
+	watcher := source.NewOCIWatcher("", "")
+	_, err := watcher.Watch(context.Background(), "")
+	assert.Error(t, err)
+}

--- a/pkg/source/watcher.go
+++ b/pkg/source/watcher.go
@@ -16,8 +16,8 @@
 // Package source provides interfaces and implementations for watching artifact sources.
 //
 // The Watcher interface is the pluggable integration point for artifact discovery.
-// Phase 1 ships stub implementations that return placeholder values; real OCI and
-// Git implementations will be added in subsequent phases.
+// OCIWatcher uses the OCI Distribution Specification API to list tags and read digests.
+// GitWatcher uses the Git Smart HTTP protocol to read branch HEAD SHAs without cloning.
 package source
 
 import "context"


### PR DESCRIPTION
[🔨 ENG]

## Summary

Implements the two Subscription source watchers that were stubs in the previous release. Closes #491 (OCI) and #493 (Git).

## OCI Watcher (#491)

**No external dependencies.** Uses the OCI Distribution Specification HTTP API directly:
1. `GET /v2/<name>/tags/list` — lists all tags
2. Filters by `tagFilter` regex
3. Sorts lexicographically (picks "newest" — works for sha-*, semver, timestamp tags)
4. `HEAD /v2/<name>/manifests/<tag>` — reads `Docker-Content-Digest` header
5. Returns `Changed=true` when digest ≠ `lastDigest`

**First-run semantics**: when `lastDigest=""` (Subscription just created), `Changed=false` to prevent spurious Bundle creation on every controller restart.

## Git Watcher (#493)

**No external dependencies or git binary.** Uses the Git Smart HTTP protocol:
- `GET <repoURL>/info/refs?service=git-upload-pack`
- Parses pkt-line encoded reference advertisement (two-section format)
- Falls back to plain text line parsing for older servers
- Returns latest commit SHA for the watched branch
- `PathGlob` is stored for future use when go-git migration (#495) enables commit path filtering

**First-run semantics**: same as OCI — `Changed=false` on first poll.

## Tests

13 new tests covering all behavior paths for both watchers using `httptest.Server` mocks — no network required, no external registry or git server.

| Category | Tests |
|---|---|
| Git | DetectsNewCommit, NoChangeWhenSHAUnchanged, FirstRunNotChanged, BranchNotFound, ServerError, EmptyRepoURL |
| OCI | DetectsNewTag, NoChangeWhenDigestUnchanged, FirstRunNotChanged, TagFilterApplied, NoMatchingTagsReturnsNotChanged, InvalidTagFilterReturnsError, EmptyRegistryReturnsError |

## Docs

Removed stub warnings from `docs/subscription.md` and `docs/concepts.md`.

## QA

- [x] No external dependencies added to go.mod
- [x] No exec.Command — pure stdlib
- [x] First-run semantics prevent spurious Bundle creation
- [x] All existing tests pass
- [x] 13 new tests, all green