### PR TITLE
fix(ci): enforce PR discipline, CI green gate, and live-cluster validation standard

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,12 @@ permissions:
   pages: write
   id-token: write
 
+# Serialise gh-pages deploys — never cancel an in-flight deploy (would corrupt
+# the gh-pages branch); queue the next one instead (cancel-in-progress: false).
+concurrency:
+  group: docs-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ── Step 1: Generate CLI reference from Cobra ──────────────────────────────
   generate-cli-docs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,14 @@ on:
         type: choice
         options: ['all', '1', '2', '3', '4', '5', '6', '7']
 
+# Cancel in-progress runs on new main pushes; keep scheduled/manual runs independent.
+concurrency:
+  group: e2e-${{ github.event_name == 'push' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 jobs:
+  # Cancel any in-progress e2e run when a new push to main supersedes it.
+  # Scheduled and manual runs get unique groups so they are never cancelled.
   e2e:
     name: e2e journey ${{ github.event.inputs.journey || 'all' }}
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,6 +464,66 @@ When the upstream change lands: upgrade our pin, remove the workaround, close th
 kardinal issue, update the history table in `docs/aide/vision.md §Upstream Issue
 and PR Protocol`.
 
+## Branch Policy — What May Go Directly to main
+
+Branch protection enforces `enforce_admins: true`. **No push bypasses the PR requirement,
+including the agent account.** The only exception is the state branch `_state`.
+
+| Allowed direct to `main` | Must go through PR |
+|---|---|
+| `state: …` commits to `_state` branch | All code changes |
+| — | All docs changes |
+| — | All workflow changes |
+| — | All coordinator queue/state updates |
+| — | Everything else |
+
+The agent process generates many housekeeping commits (queue generation, docs audits,
+state updates). These are not exempt. They must be squash-merged via PR like everything
+else. There is no "trivial docs fix" exception.
+
+**Consequence**: if you find yourself tempted to push directly to main, that is a sign
+the task is too small to warrant tracking and should be batched into the next PR that
+touches the same area.
+
+---
+
+## Journey Validation Standard
+
+**A journey is NOT done until there is live-cluster evidence.** Fake-client tests
+(`fake.NewClientBuilder()`) are unit tests, not E2E validation. They prove reconciler
+logic; they do not prove the full stack works on a real cluster with real images.
+
+### What counts as evidence
+
+A journey is marked ✅ in `docs/aide/definition-of-done.md` only when **one** of:
+
+1. The `PDCA Validation` GitHub Actions workflow posts `[PDCA AUTOMATED]` to Issue #1
+   with PASS for that scenario (uses a live kind cluster + real `kardinal-test-app` image).
+2. A human or agent posts `[LIVE CLUSTER VALIDATED]` to Issue #1 with:
+   - The exact commands run
+   - The exact terminal output
+   - The kind/EKS cluster version
+   - The `kardinal-test-app` image SHA used
+
+### What does NOT count as evidence
+
+- `TestJourneyN` passing in CI (fake client — proves logic, not cluster integration)
+- A comment like "all tests pass" without output
+- Marking the checkbox based on PR merge alone
+
+### Triggering live validation
+
+```bash
+# Trigger the PDCA workflow manually for a specific scenario
+gh workflow run pdca.yml --repo pnz1990/kardinal-promoter \
+  -f scenario=1   # or 2, 3, 4, 5, 6, or all
+
+# Check the result
+gh run list --repo pnz1990/kardinal-promoter --workflow=pdca.yml --limit 3
+```
+
+---
+
 ## Journey Self-Validation Commands (Engineer step 3)
 
 Engineer reads definition-of-done.md and runs the relevant journey steps:


### PR DESCRIPTION
## Problem

Three compounding issues identified in audit:

1. **Direct main pushes** — `enforce_admins: false` let the agent account bypass branch protection. ~56% of last 50 commits on main were pushed directly, including feature code, docs, coordinator queues, and krocodile upgrades.
2. **CI noise / Docs race** — Repeated rapid direct pushes to main cancelled in-flight CI runs. A concurrent docs deploy caused a `gh-pages` force-push conflict that failed the Docs workflow.
3. **False journey validation** — Journeys were being marked ✅ based on `TestJourneyN` passing with `fake.NewClientBuilder()`. These are unit tests. No journey has live-cluster evidence with real images.

## Changes

### GitHub branch protection (applied via API — immediate)
- `enforce_admins: true` — agent account can no longer push directly to main
- 8 required status checks: `build`, `integration tests`, `e2e stubs compile`, `golangci-lint`, `govulncheck`, `docs-lint`, `frontend build`, `helm lint`

### `.github/workflows/docs.yml`
- Added `concurrency: group: docs-deploy-${{ github.ref }}, cancel-in-progress: false`
- Serialises gh-pages deploys; the second run queues instead of both racing to force-push

### `.github/workflows/e2e.yml`
- Added `concurrency: group: e2e-${{ push ? ref : run_id }}, cancel-in-progress: ${{ push }}`
- Cancels superseded push-triggered runs; keeps scheduled (daily) and manual runs independent

### `AGENTS.md`
- Added **Branch Policy** section: explicit table of what may/may not go direct to main. Only `.otherness/state.json` writes to `_state` are exempt. All else — code, docs, workflows, coord queues — must go through a PR.
- Added **Journey Validation Standard** section: a journey is not ✅ until there is live-cluster evidence (`[PDCA AUTOMATED]` CI comment or `[LIVE CLUSTER VALIDATED]` comment with exact output). `TestJourneyN` passing is necessary, not sufficient.

## What is NOT changed here

The otherness agent files (`standalone.md`, `reconciling-implementations.md`) were also updated locally — those changes live in `~/.otherness/agents/` and should be pushed to the otherness fork separately.