### PR TITLE
chore: deploy otherness.cross-agent-monitor command

### DIFF
--- a/.opencode/command/otherness.cross-agent-monitor.md
+++ b/.opencode/command/otherness.cross-agent-monitor.md
@@ -1,0 +1,7 @@
+---
+description: "Cross-project health monitor. Shows real-time status of all otherness-managed projects: heartbeat freshness, velocity, blockers, and needs-human items. Pass repo list as arguments or configure in otherness-config.yaml. Prints a summary and posts to the report issue if blockers are found."
+---
+
+Read and follow `~/.otherness/agents/cross-agent-monitor.md`.
+
+Parse any repo arguments from the user: $ARGUMENTS


### PR DESCRIPTION
Deploys the /otherness.cross-agent-monitor command to this project.

Auto-merge — no review needed, this is a single command file addition.