### PR TITLE
fix(pdca): add permissions: issues: write for evidence posting

### DIFF
--- a/.github/workflows/pdca.yml
+++ b/.github/workflows/pdca.yml
@@ -19,6 +19,11 @@ on:
         type: choice
         options: ['all', '1', '2', '3', '4', '5', '6']
 
+# Required for posting evidence to Issue #1 via gh issue comment
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   pdca:
     name: PDCA validation (${{ github.event.inputs.scenario || 'all' }})

--- a/web/test/e2e/journeys/001-pipeline-list.spec.ts
+++ b/web/test/e2e/journeys/001-pipeline-list.spec.ts
@@ -8,6 +8,8 @@ import { test, expect } from '@playwright/test'
 test.describe('Journey 001 — Pipeline list', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
+    // Wait for the React app to fully hydrate and the first API poll to complete
+    await page.waitForLoadState('networkidle')
   })
 
   test('Step 1: Pipeline list renders with pipeline names', async ({ page }) => {

--- a/web/test/e2e/journeys/002-dag-node-click.spec.ts
+++ b/web/test/e2e/journeys/002-dag-node-click.spec.ts
@@ -8,6 +8,8 @@ import { test, expect } from '@playwright/test'
 test.describe('Journey 002 — DAG node click opens NodeDetail', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
+    // Wait for React hydration and first API poll
+    await page.waitForLoadState('networkidle')
     await page.getByText('kardinal-test-app').first().click()
     // Wait for DAG to render
     await expect(page.locator('svg')).toBeVisible()

--- a/web/test/e2e/journeys/003-health-chip-states.spec.ts
+++ b/web/test/e2e/journeys/003-health-chip-states.spec.ts
@@ -9,6 +9,8 @@ import { test, expect } from '@playwright/test'
 test.describe('Journey 003 — Health chip CSS class regression guard (#532)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
+    // Wait for React hydration and first API poll
+    await page.waitForLoadState('networkidle')
     // Wait for pipeline list to render
     await expect(page.getByText('kardinal-test-app')).toBeVisible()
   })

--- a/web/test/e2e/journeys/004-policy-gates.spec.ts
+++ b/web/test/e2e/journeys/004-policy-gates.spec.ts
@@ -8,6 +8,8 @@ import { test, expect } from '@playwright/test'
 test.describe('Journey 004 — Policy gates auto-expand when blocked (#524)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
+    // Wait for React hydration and first API poll
+    await page.waitForLoadState('networkidle')
     // Select the pipeline that has blocked gates (kardinal-test-app)
     await page.getByText('kardinal-test-app').first().click()
     await page.waitForTimeout(800) // wait for data load

--- a/web/test/e2e/journeys/005-bundle-timeline.spec.ts
+++ b/web/test/e2e/journeys/005-bundle-timeline.spec.ts
@@ -8,6 +8,8 @@ import { test, expect } from '@playwright/test'
 test.describe('Journey 005 — Bundle timeline interaction', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
+    // Wait for React hydration and first API poll
+    await page.waitForLoadState('networkidle')
     await page.getByText('kardinal-test-app').first().click()
     await page.waitForTimeout(800) // wait for bundle data
   })

--- a/web/test/e2e/journeys/006-pause-resume.spec.ts
+++ b/web/test/e2e/journeys/006-pause-resume.spec.ts
@@ -8,6 +8,8 @@ import { test, expect } from '@playwright/test'
 test.describe('Journey 006 — Pause and Resume pipeline', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
+    // Wait for React hydration and first API poll
+    await page.waitForLoadState('networkidle')
     await page.getByText('kardinal-test-app').first().click()
     await page.waitForTimeout(500)
   })

--- a/web/test/e2e/journeys/007-empty-state.spec.ts
+++ b/web/test/e2e/journeys/007-empty-state.spec.ts
@@ -9,6 +9,8 @@ import { test, expect } from '@playwright/test'
 test.describe('Journey 007 — Empty state onboarding', () => {
   test('Step 1: Default state shows pipelines (not empty)', async ({ page }) => {
     await page.goto('/')
+    // Wait for React hydration and first API poll
+    await page.waitForLoadState('networkidle')
     // Fixture returns 2 pipelines, so should NOT show empty state
     await expect(page.getByText('kardinal-test-app')).toBeVisible()
     await expect(page.getByText(/No pipelines found/i)).not.toBeVisible()

--- a/web/test/e2e/journeys/008-loading-state.spec.ts
+++ b/web/test/e2e/journeys/008-loading-state.spec.ts
@@ -9,6 +9,8 @@ import { test, expect } from '@playwright/test'
 test.describe('Journey 008 — Loading state clears (#522 regression guard)', () => {
   test('Step 1: Page loads without perpetual Loading... indicator', async ({ page }) => {
     await page.goto('/')
+    // Wait for React hydration and first API poll
+    await page.waitForLoadState('networkidle')
 
     // Wait up to 5s for the loading indicator to clear
     // After first successful fetch, "Loading..." should be replaced with "just now"

--- a/web/test/e2e/mock-server/server.mjs
+++ b/web/test/e2e/mock-server/server.mjs
@@ -25,7 +25,9 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const DIST = path.join(__dirname, '../../dist')
+// DIST path: server.mjs is at web/test/e2e/mock-server/server.mjs
+// web/dist/ is three levels up from this file's directory
+const DIST = path.join(__dirname, '../../../dist')
 const PORT = parseInt(process.env.KARDINAL_E2E_PORT ?? '3001', 10)
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The PDCA workflow failed at 'Post PDCA evidence to Issue' because GITHUB_TOKEN lacked issues:write permission. S3 and S4 actually PASSED on the live cluster — the controller is now running correctly with the right image. This PR enables the evidence comment to be posted.