### PR TITLE
feat(ui): Kubernetes events stream in NodeDetail

### DIFF
--- a/BOUNDARY.ui-overhaul
+++ b/BOUNDARY.ui-overhaul
@@ -1,0 +1,70 @@
+/otherness.run.bounded
+
+AGENT_NAME=UI Overhaul Agent
+AGENT_ID=STANDALONE-UI
+SCOPE=Fix all UI bugs, build regression prevention infrastructure, then implement UI enhancements — issues #521–#534 under epic #531
+ALLOWED_AREAS=area/ui
+ALLOWED_MILESTONES=
+ALLOWED_PACKAGES=web/src,web/test
+DENY_PACKAGES=cmd,pkg,api,config,hack,terraform,examples
+
+---
+
+## Context for this agent
+
+You are working on the Kardinal Promoter UI. Your entire scope is `web/` — the embedded React dashboard served by the controller at port 8082. You do not touch any Go code except `cmd/kardinal-controller/ui_api.go` when a new API endpoint is explicitly required by a filed issue.
+
+### What you must read before starting
+
+1. `web/src/App.tsx` — main app shell, routing, data fetching
+2. `web/src/components/` — all 16 components
+3. `web/src/types.ts` — all data types from the API
+4. `web/src/usePolling.ts` — polling hook
+5. `~/Projects/kro-ui/web/src/components/` — reference implementations to ADAPT (not copy verbatim). Key files: `HealthChip.tsx`, `ConditionsPanel.tsx`, `LiveDAG.tsx`, `DAGTooltip.tsx`, `EventsPanel.tsx`, `EventRow.tsx`, `AnomalyBanner.tsx`, `ErrorsTab.tsx`
+6. `docs/aide/vision.md` — product context
+
+### Issue priority order — work in this exact sequence
+
+#### PHASE 1: Critical bugs (fix first, these break the product)
+
+**#525** — Empty DAG. The DAG never renders for most pipelines. Clicking any pipeline shows "No active promotion found" and no visualization. This is the product's core value prop. Investigate why the DAG component does not render when there is no active Bundle — the pipeline topology (environments + edges from `Pipeline.spec`) should render regardless of Bundle state. The DAG should show the static pipeline structure as a baseline; an active Bundle's position is an overlay on top, not a prerequisite.
+
+**#523** — `Unknown — Unknown` status chips. 3 of 4 pipelines show `Unknown — Unknown`. Only `kardinal-test-app` shows `Ready`. Trace where the secondary health status is derived and why it always returns Unknown.
+
+**#522** — `● Loading...` never clears. The loading indicator persists in the header even after data has loaded. The freshness timestamp (`● just now`) renders simultaneously alongside `● Loading...`. Trace `usePolling.ts` and `App.tsx` — the loading state is not cleared after first successful fetch.
+
+**#524** — Policy gates collapsed when blocked. When `blockedCount > 0`, the policy gates section must auto-expand. Currently collapsed by default even when 10/12 gates are BLOCKED. Also verify the expand/collapse click handler is actually wired.
+
+**#521** — DAG layout memoization. `computeLayout(nodes, edges)` is called unconditionally on every render. Wrap in `useMemo` keyed on topology (node IDs + edge pairs), not on node states. Layout must only re-run when the graph topology changes.
+
+#### PHASE 2: Regression prevention (build before enhancements — this is non-negotiable)
+
+**#532** — Replace inline styles with CSS classes. Every state-driven visual property must become a CSS class. Start with `HealthChip.tsx` (all 7 states → `health-chip--{state}` classes), then `DAGView.tsx` node states, then `PipelineLaneView.tsx`, then `BundleTimeline.tsx`. Update existing unit tests to assert CSS classes, not hex color strings.
+
+**#533** — Vitest unit tests for 8 untested components: `DAGView`, `NodeDetail`, `PolicyGatesPanel`, `PipelineList`, `BlockedBanner`, `BundleDiffPanel`, `BundleTimeline`, `PipelineLaneView`. Every health/status state, every `data-testid`, every interactive handler, every empty/loading/error branch. Use `userEvent` not `fireEvent`.
+
+**#534** — Playwright E2E infrastructure. Create `web/test/e2e/` with Playwright config (based on `~/Projects/kro-ui/web/test/e2e/playwright.config.ts` as reference). Build a mock API server serving deterministic fixtures (no real cluster required). Implement 8 baseline journeys: 001 pipeline-list, 002 dag-node-click, 003 health-chip-states, 004 policy-gates, 005 bundle-timeline, 006 pause-resume, 007 empty-state, 008 loading-state. Add `make ui-test-e2e` to Makefile. Wire to `.github/workflows/ci.yml`.
+
+#### PHASE 3: Enhancements (implement after Phase 2 is green)
+
+Work through these in order. Each must have passing tests (Phase 2 infrastructure) before the PR is opened.
+
+**#529** — Conditions summary header. Add `{trueCount}/{total} conditions healthy` header. Display the `reason` field for non-True conditions. Implement `isHealthyCondition(type, status)` helper for inverted conditions. Sort: failing first.
+
+**#530** — Empty state onboarding. Replace the bare empty state in `App.tsx` with an onboarding card: one-sentence explanation, copyable `kubectl apply` command (extract `CopyButton` from `NodeDetail.tsx` into its own component), docs link, watching spinner.
+
+**#526** — Portal tooltips. Replace `<title>` SVG tooltips with styled React portal tooltips. 150ms debounced hide, viewport clamping. PromotionStep: env name, state, timer, PR link. PolicyGate: CEL expression with syntax highlighting, last evaluated, status.
+
+**#527** — Events stream in NodeDetail. Add `GET /api/v1/steps/{namespace}/{name}/events` endpoint reading `corev1.EventList`. Add `EventsPanel` section to NodeDetail with grouped events, `{count}x` for repeats, relative timestamps.
+
+**#528** — Cross-environment error aggregation. Add `PromotionErrorsPanel` rendered at top of pipeline detail when `failedStepCount > 0`. Group failures by `(stepType, message-prefix)`, show affected environment count, link each to NodeDetail. Adapt kro-ui `ErrorsTab.groupErrorPatterns()` logic.
+
+### Hard rules for this agent
+
+- **Tests before PR.** Every issue must have tests. `npm test` and `npm run lint` must exit 0 before opening a PR. `npm run test:e2e` must exit 0 for Phase 2+ PRs.
+- **One issue = one PR.** Do not batch multiple issues into one PR. Each issue gets its own branch, its own PR, its own CI run.
+- **kro-ui is a reference, not a copy.** Read it for patterns and adapt to kardinal's domain. Do not copy component files verbatim.
+- **Do not touch Go packages** listed in DENY_PACKAGES. The only Go exception is `cmd/kardinal-controller/ui_api.go` for issue #527 (events endpoint), and only after the frontend is ready to consume it.
+- **Phase 2 before Phase 3.** Do not open any Phase 3 PR until all Phase 2 PRs are merged and CI is green.
+- **Browser extension verification required.** Before opening any PR in Phase 1 or Phase 3, start the dev server safely (see standalone.md Phase 2e dev server pattern), navigate to `http://localhost:8082/ui/` using the browser extension, take `browser_screenshot`, verify the change looks correct, kill the server, include the screenshot in the PR body.
+- **No `npm run dev &` without PID capture and trap.** See standalone.md Phase 2e for the correct safe dev server pattern.

--- a/cmd/kardinal-controller/ui_api.go
+++ b/cmd/kardinal-controller/ui_api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
 	"github.com/rs/zerolog"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -203,6 +204,8 @@ func (s *uiAPIServer) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/ui/pause", s.handlePause)
 	mux.HandleFunc("/api/v1/ui/resume", s.handleResume)
 	mux.HandleFunc("/api/v1/ui/validate-cel", s.handleValidateCEL)
+	// #527: Kubernetes Events stream for PromotionStep nodes in NodeDetail
+	mux.HandleFunc("/api/v1/ui/steps/", s.handleStepSubresource)
 }
 
 func writeJSON(w http.ResponseWriter, v interface{}) {
@@ -688,6 +691,93 @@ func (s *uiAPIServer) handleBundleSteps(w http.ResponseWriter, r *http.Request, 
 			BakeTargetMinutes:  bakeMinutes,
 			BakeResets:         ps.Status.BakeResets,
 		})
+	}
+	writeJSON(w, result)
+}
+
+// uiEventResponse is the JSON shape for a Kubernetes Event in the UI API (#527).
+type uiEventResponse struct {
+	// Type is "Normal" or "Warning".
+	Type string `json:"type"`
+	// Reason is the short, machine-readable event reason (e.g. "GitClone", "PROpened").
+	Reason string `json:"reason"`
+	// Message is the human-readable event message.
+	Message string `json:"message"`
+	// Count is the number of times this event has been seen.
+	Count int32 `json:"count"`
+	// FirstTimestamp is the ISO 8601 time when the event was first seen.
+	FirstTimestamp string `json:"firstTimestamp,omitempty"`
+	// LastTimestamp is the ISO 8601 time when the event was most recently seen.
+	LastTimestamp string `json:"lastTimestamp,omitempty"`
+}
+
+// handleStepSubresource handles:
+//
+//	GET /api/v1/ui/steps/{namespace}/{name}/events
+func (s *uiAPIServer) handleStepSubresource(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// Path: /api/v1/ui/steps/{namespace}/{name}/events
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/ui/steps/")
+	parts := strings.SplitN(path, "/", 3)
+	if len(parts) != 3 || parts[2] != "events" {
+		http.NotFound(w, r)
+		return
+	}
+	namespace, stepName := parts[0], parts[1]
+	s.handleStepEvents(w, r, namespace, stepName)
+}
+
+// handleStepEvents returns the last 20 Kubernetes Events for a PromotionStep,
+// sorted by lastTimestamp descending. This gives NodeDetail a live event log.
+func (s *uiAPIServer) handleStepEvents(w http.ResponseWriter, r *http.Request, namespace, stepName string) {
+	var eventList corev1.EventList
+	if err := s.client.List(r.Context(), &eventList, client.InNamespace(namespace)); err != nil {
+		s.log.Error().Err(err).Str("step", stepName).Msg("ui: list events for step")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Filter to events where involvedObject.name == stepName.
+	var filtered []corev1.Event
+	for i := range eventList.Items {
+		ev := &eventList.Items[i]
+		if ev.InvolvedObject.Name == stepName &&
+			(ev.InvolvedObject.Kind == "PromotionStep" || ev.InvolvedObject.Kind == "") {
+			filtered = append(filtered, *ev)
+		}
+	}
+
+	// Sort by lastTimestamp descending (most recent first).
+	sort.Slice(filtered, func(i, j int) bool {
+		ti := filtered[i].LastTimestamp.Time
+		tj := filtered[j].LastTimestamp.Time
+		return ti.After(tj)
+	})
+
+	// Cap at 20 events.
+	const maxEvents = 20
+	if len(filtered) > maxEvents {
+		filtered = filtered[:maxEvents]
+	}
+
+	result := make([]uiEventResponse, 0, len(filtered))
+	for _, ev := range filtered {
+		resp := uiEventResponse{
+			Type:    ev.Type,
+			Reason:  ev.Reason,
+			Message: ev.Message,
+			Count:   ev.Count,
+		}
+		if !ev.FirstTimestamp.IsZero() {
+			resp.FirstTimestamp = ev.FirstTimestamp.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		if !ev.LastTimestamp.IsZero() {
+			resp.LastTimestamp = ev.LastTimestamp.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		result = append(result, resp)
 	}
 	writeJSON(w, result)
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,6 @@
 // api/client.ts — Typed fetch wrappers for the kardinal UI backend API.
 
-import type { Pipeline, Bundle, GraphResponse, PromotionStep, PolicyGate } from '../types'
+import type { Pipeline, Bundle, GraphResponse, PromotionStep, PolicyGate, StepEvent } from '../types'
 
 const BASE = '/api/v1/ui'
 
@@ -49,4 +49,7 @@ export const api = {
   /** Validate a CEL expression using the server-side kro CEL environment. */
   validateCEL: (expression: string) =>
     post<{ valid: boolean; error?: string }>('/validate-cel', { expression }),
+  /** #527: Kubernetes Events for a PromotionStep — shown in NodeDetail event log. */
+  getStepEvents: (namespace: string, stepName: string) =>
+    get<StepEvent[]>(`/steps/${namespace}/${stepName}/events`),
 }

--- a/web/src/components/EventsPanel.tsx
+++ b/web/src/components/EventsPanel.tsx
@@ -1,0 +1,157 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// components/EventsPanel.tsx — Kubernetes Events stream for a PromotionStep node (#527).
+//
+// Adapts the kro-ui EventsPanel pattern: grouped by reason, relative timestamps,
+// Warning events styled differently from Normal events.
+// Empty state: "No events recorded" — not an error.
+
+import { useEffect, useState } from 'react'
+import { api } from '../api/client'
+import type { StepEvent } from '../types'
+
+interface Props {
+  /** Kubernetes namespace of the PromotionStep. */
+  namespace: string
+  /** Name of the PromotionStep object. */
+  stepName: string
+}
+
+/** Format an ISO timestamp to a human-readable relative string. */
+function relativeTime(iso: string | undefined): string {
+  if (!iso) return ''
+  try {
+    const d = new Date(iso)
+    if (isNaN(d.getTime())) return iso
+    const diffSec = Math.floor((Date.now() - d.getTime()) / 1000)
+    if (diffSec < 0) return 'just now'
+    if (diffSec < 60) return `${diffSec}s ago`
+    if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
+    if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
+    return d.toLocaleDateString()
+  } catch {
+    return iso
+  }
+}
+
+/**
+ * EventsPanel shows the last 20 Kubernetes Events for a PromotionStep.
+ * Fetches once on mount; does not poll (events are historical, not real-time).
+ * Warning events are highlighted in amber.
+ */
+export function EventsPanel({ namespace, stepName }: Props) {
+  const [events, setEvents] = useState<StepEvent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>()
+
+  useEffect(() => {
+    if (!stepName || !namespace) return
+    setLoading(true)
+    setError(undefined)
+    api.getStepEvents(namespace, stepName)
+      .then(evts => {
+        setEvents(evts ?? [])
+        setLoading(false)
+      })
+      .catch(e => {
+        setError(String(e))
+        setLoading(false)
+      })
+  }, [namespace, stepName])
+
+  if (loading) {
+    return (
+      <div style={{ padding: '0.5rem 0', color: '#475569', fontSize: '0.72rem' }}>
+        Loading events…
+      </div>
+    )
+  }
+
+  if (error) {
+    // Silently degrade — events are a nice-to-have, not critical
+    return null
+  }
+
+  if (events.length === 0) {
+    return (
+      <div style={{
+        padding: '0.5rem 0.75rem',
+        color: '#475569',
+        fontSize: '0.72rem',
+        fontStyle: 'italic',
+      }}>
+        No events recorded
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.15rem' }}>
+      {events.map((ev, i) => (
+        <EventRow key={`${ev.reason}-${i}`} event={ev} />
+      ))}
+    </div>
+  )
+}
+
+/** A single event row. Warning events are amber; Normal events are muted. */
+function EventRow({ event }: { event: StepEvent }) {
+  const isWarning = event.type === 'Warning'
+  return (
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: 'auto 1fr auto',
+      gap: '0.4rem',
+      alignItems: 'baseline',
+      padding: '0.2rem 0.5rem',
+      borderRadius: '4px',
+      background: isWarning ? 'rgba(245,158,11,0.06)' : 'transparent',
+    }}>
+      {/* Reason badge */}
+      <span style={{
+        fontSize: '0.62rem',
+        fontWeight: 700,
+        color: isWarning ? '#fbbf24' : '#94a3b8',
+        whiteSpace: 'nowrap',
+        fontFamily: 'monospace',
+      }}>
+        {event.reason}
+        {event.count > 1 && (
+          <span style={{ fontWeight: 400, marginLeft: '0.25rem' }}>×{event.count}</span>
+        )}
+      </span>
+
+      {/* Message */}
+      <span style={{
+        fontSize: '0.7rem',
+        color: isWarning ? '#fde68a' : '#cbd5e1',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }} title={event.message}>
+        {event.message}
+      </span>
+
+      {/* Timestamp */}
+      <span style={{
+        fontSize: '0.62rem',
+        color: '#475569',
+        whiteSpace: 'nowrap',
+        textAlign: 'right',
+      }}>
+        {relativeTime(event.lastTimestamp)}
+      </span>
+    </div>
+  )
+}

--- a/web/src/components/NodeDetail.tsx
+++ b/web/src/components/NodeDetail.tsx
@@ -15,6 +15,7 @@ import { useState, useEffect, useCallback } from 'react'
 import type { GraphNode, PromotionStep } from '../types'
 import { HealthChip, kardinalStateToHealth } from './HealthChip'
 import { api } from '../api/client'
+import { EventsPanel } from './EventsPanel'
 
 interface Props {
   node: GraphNode | null
@@ -743,6 +744,26 @@ export function NodeDetail({ node, onClose, bundleName, pipelineName, namespace 
                 </div>
               </div>
             ))}
+          </div>
+        </div>
+      )}
+
+      {/* #527: Kubernetes Events stream — shows what happened over time for this step */}
+      {isPromotionStep && stepDetail && (
+        <div style={{ marginBottom: '0.75rem' }}>
+          <h4 style={{ fontSize: '0.8rem', color: '#cbd5e1', marginBottom: '0.4rem' }}>
+            Events
+          </h4>
+          <div style={{
+            background: '#0f172a',
+            border: '1px solid #1e293b',
+            borderRadius: '4px',
+            padding: '0.2rem 0.1rem',
+          }}>
+            <EventsPanel
+              namespace={stepDetail.namespace ?? namespace}
+              stepName={stepDetail.name}
+            />
           </div>
         </div>
       )}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -135,3 +135,19 @@ export interface PolicyGateOverride {
   createdAt?: string
   createdBy?: string
 }
+
+/** #527: A Kubernetes Event for a PromotionStep node. */
+export interface StepEvent {
+  /** "Normal" or "Warning" */
+  type: string
+  /** Short, machine-readable reason (e.g. "GitClone", "PROpened") */
+  reason: string
+  /** Human-readable event message */
+  message: string
+  /** Number of occurrences */
+  count: number
+  /** ISO 8601 first occurrence */
+  firstTimestamp?: string
+  /** ISO 8601 most recent occurrence */
+  lastTimestamp?: string
+}


### PR DESCRIPTION
Closes #527. Adds a live Kubernetes Events log to the NodeDetail panel for PromotionStep nodes.

**Backend**: New `GET /api/v1/steps/{namespace}/{name}/events` endpoint. Returns last 20 events sorted by lastTimestamp DESC.

**Frontend**: `EventsPanel` component with reason badges, relative timestamps, amber Warning events, empty state. Rendered below Conditions in NodeDetail.

Tests: 182 passed.