### PR TITLE
fix(ci): disable krocodile in PDCA helm install — already installed by setup-e2e-env

### DIFF
--- a/.github/workflows/pdca.yml
+++ b/.github/workflows/pdca.yml
@@ -95,6 +95,7 @@ jobs:
             --set image.tag=dev \
             --set image.pullPolicy=Never \
             --set validatingAdmissionPolicy.enabled=false \
+            --set krocodile.enabled=false \
             --wait --timeout 300s
           kubectl get pods -n kardinal-system
 


### PR DESCRIPTION
## Problem
PDCA fails with:
```
Error: Namespace 'kro-system' cannot be imported into current release — invalid ownership metadata
```

`setup-e2e-env.sh` installs krocodile (which creates `kro-system` namespace) via `install-krocodile.sh`.
Then the 'Install kardinal controller' step also tries to install the full helm chart (which includes krocodile), conflicting with the pre-existing kro-system namespace.

## Fix
Add `--set krocodile.enabled=false` to the PDCA's helm install step.
Krocodile is already running from the setup step — installing it twice causes a namespace ownership conflict.

PDCA bug #10 in the infrastructure fix sequence.