### PR TITLE
feat(release): PodDisruptionBudget + topology spread + fix PDCA helm release collision

### DIFF
--- a/.github/workflows/pdca.yml
+++ b/.github/workflows/pdca.yml
@@ -82,14 +82,14 @@ jobs:
           # Build and load the controller image into kind
           make docker-build IMG=ghcr.io/pnz1990/kardinal-promoter:dev
           kind load docker-image ghcr.io/pnz1990/kardinal-promoter:dev --name kardinal-e2e
-          # Apply CRDs (pre-generated above) and install via helm
-          # Override image.repository, image.tag, and image.pullPolicy to use the locally-built
-          # dev image loaded into kind. Without --set image.repository and --set image.tag, helm
-          # uses the default values.yaml (ghcr.io/*/controller:latest) which doesn't match the
-          # locally loaded image (ghcr.io/pnz1990/kardinal-promoter:dev).
-          # pullPolicy=Never ensures kind never tries to pull from ghcr.io for the dev tag.
+          # Apply CRDs (pre-generated above) and upgrade the existing Helm release.
+          # CRITICAL: use the same release name ("kardinal-promoter") as setup-e2e-env.sh
+          # to avoid "cannot import existing resource" errors. setup-e2e-env.sh creates
+          # the kro-system namespace owned by release "kardinal-promoter". If we install
+          # under a different release name ("kardinal"), Helm rejects the install because
+          # the existing namespace has ownership labels pointing to "kardinal-promoter".
           kubectl apply -f config/crd/bases/
-          helm upgrade --install kardinal chart/kardinal-promoter \
+          helm upgrade --install kardinal-promoter chart/kardinal-promoter \
             --namespace kardinal-system --create-namespace \
             --set image.repository=ghcr.io/pnz1990/kardinal-promoter \
             --set image.tag=dev \

--- a/chart/kardinal-promoter/templates/deployment.yaml
+++ b/chart/kardinal-promoter/templates/deployment.yaml
@@ -85,3 +85,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and .Values.topologySpread.enabled (gt (int .Values.replicaCount) 1) }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "kardinal-promoter.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/chart/kardinal-promoter/templates/pdb.yaml
+++ b/chart/kardinal-promoter/templates/pdb.yaml
@@ -1,0 +1,20 @@
+{{/*
+Copyright 2026 The kardinal-promoter Authors.
+Licensed under the Apache License, Version 2.0
+*/}}
+{{- if .Values.pdb.enabled }}
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kardinal-promoter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kardinal-promoter.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "kardinal-promoter.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -175,3 +175,17 @@ networkPolicy:
 scheduleClock:
   enabled: true
   interval: "1m"
+
+# -- PodDisruptionBudget for the controller.
+# Only created when replicaCount > 1 to ensure at least one replica is
+# available during node maintenance or rolling updates.
+pdb:
+  enabled: true
+  # -- Minimum number of pods that must be available during disruption.
+  minAvailable: 1
+
+# -- Topology spread constraints for multi-replica deployments.
+# When enabled and replicaCount > 1, spreads replicas across availability
+# zones to prevent both replicas from landing on the same node.
+topologySpread:
+  enabled: true

--- a/test/helm/chart_test.go
+++ b/test/helm/chart_test.go
@@ -198,3 +198,56 @@ func TestDockerfileContent(t *testing.T) {
 	assert.Contains(t, content, "kardinal-controller", "must build kardinal-controller binary")
 	assert.Contains(t, content, "ENTRYPOINT", "must set ENTRYPOINT")
 }
+
+func TestHelmTemplatePDBCreatedForMultiReplica(t *testing.T) {
+	helm := helmBin(t)
+	root := repoRoot(t)
+	chartDir := filepath.Join(root, "chart", "kardinal-promoter")
+
+	// With replicaCount=2, PDB must be created
+	cmd := exec.Command(helm, "template", "kardinal-promoter", chartDir,
+		"--set", "replicaCount=2",
+		"--set", "pdb.enabled=true")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "helm template with replicaCount=2 must succeed:\n%s", string(out))
+
+	rendered := string(out)
+	assert.Contains(t, rendered, "kind: PodDisruptionBudget",
+		"PDB must be rendered when replicaCount=2")
+	assert.Contains(t, rendered, "minAvailable: 1",
+		"PDB must set minAvailable: 1 by default")
+}
+
+func TestHelmTemplatePDBNotCreatedForSingleReplica(t *testing.T) {
+	helm := helmBin(t)
+	root := repoRoot(t)
+	chartDir := filepath.Join(root, "chart", "kardinal-promoter")
+
+	// With replicaCount=1 (default), PDB must NOT be created
+	cmd := exec.Command(helm, "template", "kardinal-promoter", chartDir)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "helm template must succeed:\n%s", string(out))
+
+	rendered := string(out)
+	assert.NotContains(t, rendered, "kind: PodDisruptionBudget",
+		"PDB must NOT be rendered when replicaCount=1 (single replica)")
+}
+
+func TestHelmTemplateTopologySpreadForMultiReplica(t *testing.T) {
+	helm := helmBin(t)
+	root := repoRoot(t)
+	chartDir := filepath.Join(root, "chart", "kardinal-promoter")
+
+	// With replicaCount=2, topology spread constraints must be added
+	cmd := exec.Command(helm, "template", "kardinal-promoter", chartDir,
+		"--set", "replicaCount=2",
+		"--set", "topologySpread.enabled=true")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "helm template with replicaCount=2 must succeed:\n%s", string(out))
+
+	rendered := string(out)
+	assert.Contains(t, rendered, "topologySpreadConstraints",
+		"topology spread constraints must be added when replicaCount=2")
+	assert.Contains(t, rendered, "topology.kubernetes.io/zone",
+		"topology spread must use zone topology key")
+}


### PR DESCRIPTION
## Summary

Closes #572.

### 1. PodDisruptionBudget (new feature)
- Adds `chart/kardinal-promoter/templates/pdb.yaml` — creates PDB with `minAvailable: 1` only when `replicaCount > 1`
- Controlled by `pdb.enabled: true` (default)
- Ensures at least one controller replica is available during node maintenance

### 2. Topology spread constraints (new feature)  
- Adds `topologySpreadConstraints` to the Deployment when `replicaCount > 1` and `topologySpread.enabled: true`
- Spreads replicas across `topology.kubernetes.io/zone` to prevent both replicas landing on the same node
- Uses `whenUnsatisfiable: ScheduleAnyway` (best-effort, not hard requirement)

### 3. Fix PDCA helm release name collision (critical bug fix)
Root cause of recent PDCA failures: the `setup-e2e-env.sh` step installs under release name `kardinal-promoter`, creating the `kro-system` namespace with Helm ownership labels. The 'Install kardinal-promoter controller' step then tried to install under a different release name (`kardinal`), which fails with:
```
Unable to continue with install: Namespace "kro-system" exists and cannot be imported into the current release
```
Fix: use `kardinal-promoter` as the release name in both steps (upgrade instead of install).

## Tests
- 3 new Helm chart tests for PDB/topology spread
- Helm lint: 0 errors

## Acceptance
```bash
grep -c 'kind: PodDisruptionBudget' chart/kardinal-promoter/templates/pdb.yaml
# Expected: 1

helm template kardinal-promoter chart/kardinal-promoter --set replicaCount=2 | grep -c 'PodDisruptionBudget'
# Expected: 1

helm template kardinal-promoter chart/kardinal-promoter | grep -c 'PodDisruptionBudget'
# Expected: 0 (single replica default)
```