### PR TITLE
fix(e2e): disable krocodile in helm install — already installed by script

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,9 +83,14 @@ jobs:
           # VAP graduates to stable in k8s 1.30; re-enable when cluster is upgraded.
           make manifests
           kubectl apply -f config/crd/bases/
+          # krocodile is already installed by the prior step (hack/install-krocodile.sh).
+          # Disabling krocodile.enabled prevents Helm from trying to adopt the existing
+          # kro-system namespace (which lacks Helm management labels) and failing with
+          # "invalid ownership metadata".
           helm upgrade --install kardinal chart/kardinal-promoter \
             --namespace kardinal-system --create-namespace \
-            --set validatingAdmissionPolicy.enabled=false
+            --set validatingAdmissionPolicy.enabled=false \
+            --set krocodile.enabled=false
 
       - name: Verify both controllers are running
         run: |


### PR DESCRIPTION
## Problem

E2E tests failing at `Install kardinal-promoter` step with:
```
Error: Unable to continue with install: Namespace "kro-system" in namespace "" exists
and cannot be imported into the current release: invalid ownership metadata;
label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"
```

## Root cause

`hack/install-krocodile.sh` creates `kro-system` namespace via `kubectl create namespace`
(without Helm management labels). Then `helm upgrade --install kardinal` with
`krocodile.enabled=true` tries to adopt the existing namespace — but Helm requires its
management labels to be present, so it refuses.

## Fix

Add `--set krocodile.enabled=false` to the helm install command in e2e.yml — consistent
with how pdca.yml already handles this since PR #597.

## Test

CI E2E run will show green after this fix.

Closes #599