### PR TITLE
fix(ci): PDCA helm install uses same release name as setup-e2e-env.sh

### DIFF
--- a/.github/workflows/pdca.yml
+++ b/.github/workflows/pdca.yml
@@ -89,7 +89,11 @@ jobs:
           # locally loaded image (ghcr.io/pnz1990/kardinal-promoter:dev).
           # pullPolicy=Never ensures kind never tries to pull from ghcr.io for the dev tag.
           kubectl apply -f config/crd/bases/
-          helm upgrade --install kardinal chart/kardinal-promoter \
+          # IMPORTANT: use "kardinal-promoter" as the release name to match setup-e2e-env.sh.
+          # setup-e2e-env.sh creates the ScheduleClock "kardinal-clock" with annotation
+          # meta.helm.sh/release-name=kardinal-promoter. Using a different release name
+          # ("kardinal") causes a Helm ownership conflict on the second upgrade.
+          helm upgrade --install kardinal-promoter chart/kardinal-promoter \
             --namespace kardinal-system --create-namespace \
             --set image.repository=ghcr.io/pnz1990/kardinal-promoter \
             --set image.tag=dev \


### PR DESCRIPTION
## Problem

PDCA Product Validation fails at 'Install kardinal-promoter controller' step with:
```
Error: Unable to continue with install: ScheduleClock "kardinal-clock" in namespace
"kardinal-system" exists and cannot be imported into the current release:
invalid ownership metadata; annotation validation error: key
"meta.helm.sh/release-name" must equal "kardinal": current value is "kardinal-promoter"
```

## Root cause

Two helm install steps use **different release names**:
1. `make setup-e2e-env` → `hack/setup-e2e-env.sh` → `helm upgrade --install kardinal-promoter` (creates ScheduleClock with annotation `release-name=kardinal-promoter`)
2. PDCA 'Install kardinal-promoter controller' → `helm upgrade --install kardinal` (tries to adopt it but expects `release-name=kardinal`)

## Fix

Change the PDCA install step to use `kardinal-promoter` as the release name,
matching what `setup-e2e-env.sh` uses.

Closes #601