### PR TITLE
fix(docs): update home page quick install — krocodile bundled since v0.6.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **krocodile bundled in Helm chart** — single `helm install` now installs both kardinal-promoter and the krocodile Graph controller; no separate `hack/install-krocodile.sh` step needed (#590)
 - **Library-based git operations** — replaced `exec.Command("git")` with `go-git` library (`#517`). Controller no longer requires a `git` binary. Improves portability (distroless images) and performance.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,22 +67,21 @@ See [detailed comparison →](comparison.md)
 
 ## Quick install
 
-```bash
-# 1. Install krocodile (Graph controller dependency)
-bash hack/install-krocodile.sh
+Since v0.6.0, kardinal-promoter bundles the krocodile Graph controller — a single Helm install is all you need.
 
-# 2. Create GitHub token secret
+```bash
+# 1. Create GitHub token secret
 kubectl create secret generic github-token \
   --namespace kardinal-system \
   --from-literal=token=$GITHUB_PAT
 
-# 3. Install kardinal-promoter
+# 2. Install kardinal-promoter (includes krocodile Graph controller)
 helm install kardinal-promoter oci://ghcr.io/pnz1990/charts/kardinal-promoter \
   --namespace kardinal-system \
   --create-namespace \
   --set github.secretRef.name=github-token
 
-# 4. Verify
+# 3. Verify
 kardinal version
 ```
 


### PR DESCRIPTION
## Problem

The home page (`docs/index.md`) quick install section still showed:
```bash
# 1. Install krocodile (Graph controller dependency)
bash hack/install-krocodile.sh
```

Since v0.6.0, krocodile is bundled in the Helm chart. A single `helm install` installs
everything. The `quickstart.md` doc was already updated but the home page was missed.

## Changes

1. `docs/index.md`: Remove the `hack/install-krocodile.sh` step from quick install
2. `docs/changelog.md`: Add krocodile bundling entry to Unreleased section

Closes #603