### PR TITLE
feat(controller): graceful shutdown — drain in-flight reconcile loops on SIGTERM

### DIFF
--- a/chart/kardinal-promoter/templates/deployment.yaml
+++ b/chart/kardinal-promoter/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       serviceAccountName: {{ include "kardinal-promoter.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 60 }}
       containers:
         - name: controller
           securityContext:

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -4,6 +4,11 @@
 # -- Number of controller replicas
 replicaCount: 1
 
+# -- Pod termination grace period in seconds.
+# Must be at least 2× the controller's GracefulShutdownTimeout (30s) to allow
+# in-flight reconcile loops to complete before SIGKILL. (#574)
+terminationGracePeriodSeconds: 60
+
 image:
   # -- Container image repository
   repository: ghcr.io/pnz1990/kardinal-promoter/controller

--- a/cmd/kardinal-controller/main.go
+++ b/cmd/kardinal-controller/main.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog"
 	corev1 "k8s.io/api/core/v1"
@@ -154,6 +155,10 @@ func main() {
 		HealthProbeBindAddress: healthProbeBindAddress,
 		LeaderElection:         leaderElect,
 		LeaderElectionID:       "kardinal-promoter-leader",
+		// GracefulShutdownTimeout allows in-flight reconcile loops to complete
+		// before the controller exits. Set to 30s — half the pod's
+		// terminationGracePeriodSeconds (60s) to leave room for cleanup. (#574)
+		GracefulShutdownTimeout: ptr(30 * time.Second),
 	})
 	if err != nil {
 		logger.Fatal().Err(err).Msg("unable to create manager")
@@ -430,3 +435,6 @@ func splitCSV(s string) []string {
 	}
 	return result
 }
+
+// ptr returns a pointer to v — used for optional ctrl.Options fields. (#574)
+func ptr[T any](v T) *T { return &v }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -131,6 +131,24 @@ helm upgrade kardinal-promoter oci://ghcr.io/pnz1990/charts/kardinal-promoter \
   --reuse-values
 ```
 
+## Graceful shutdown
+
+The controller handles `SIGTERM` gracefully: it stops accepting new reconcile requests
+and allows in-flight reconcile loops up to **30 seconds** to complete before exiting.
+This prevents mid-step interruptions during rolling updates or node evictions — for
+example, a git-push that was 5 seconds from finishing will complete rather than leaving
+the PromotionStep in an inconsistent state.
+
+The Helm chart sets `terminationGracePeriodSeconds: 60` (double the shutdown timeout)
+so Kubernetes sends `SIGKILL` only after the controller has had a full 30 seconds to drain.
+
+To adjust the timeout:
+
+```yaml
+# values.yaml
+terminationGracePeriodSeconds: 120  # increase if reconcile loops routinely take >30s
+```
+
 This upgrades both the kardinal-promoter controller and the bundled krocodile controller
 to the versions pinned in the new chart version.
 


### PR DESCRIPTION
## Summary

Wires up controller-runtime's built-in graceful shutdown support.

### Problem
When the controller pod is terminated, in-flight reconcile loops are interrupted mid-execution. This can leave PromotionSteps in inconsistent states (e.g., PR created but status not updated).

### Solution
Three minimal changes:

**`cmd/kardinal-controller/main.go`**
- Add `GracefulShutdownTimeout: 30s` to `ctrl.Options`
- On SIGTERM: controller-runtime stops accepting new reconcile requests and waits up to 30s for in-flight loops to complete
- Add generic `ptr[T any]` helper for optional option fields

**`chart/kardinal-promoter/templates/deployment.yaml`** + **`values.yaml`**
- Add `terminationGracePeriodSeconds: 60` (2× the shutdown timeout)
- Kubernetes sends SIGKILL only after the controller has had a full 30s to drain

**`docs/installation.md`**
- Add 'Graceful shutdown' section explaining the timeout, benefit, and how to tune it

### Acceptance
- [x] `ctrl.NewManager` called with `GracefulShutdownTimeout: 30*time.Second`
- [x] `values.yaml` has `terminationGracePeriodSeconds: 60`
- [x] `docs/installation.md` mentions graceful shutdown

Closes #574