### PR TITLE
feat(cli): shell completion for bash, zsh, fish, powershell

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -484,6 +484,28 @@ Controller: v0.1.0
 Graph:      v0.9.1 (kro)
 ```
 
+### kardinal completion
+
+Generate shell completion scripts for bash, zsh, fish, or PowerShell. (#579)
+
+```bash
+# Bash (Linux/macOS)
+kardinal completion bash > ~/.bash_completion.d/kardinal
+# or source directly:
+source <(kardinal completion bash)
+
+# Zsh
+kardinal completion zsh > "${fpath[1]}/_kardinal"
+# or source directly:
+source <(kardinal completion zsh)
+
+# Fish
+kardinal completion fish > ~/.config/fish/completions/kardinal.fish
+
+# PowerShell
+kardinal completion powershell | Out-String | Invoke-Expression
+```
+
 ## Global Flags
 
 | Flag | Description |


### PR DESCRIPTION
## Summary

Cobra v1.2+ auto-generates the `completion` subcommand — no Go code change required. This PR documents the feature.

### Problem
`kardinal` had no documented shell completion support, despite the binary already shipping it (Cobra auto-generates it).

### What's in this PR
- **`docs/cli-reference.md`**: Added `kardinal completion` section with installation instructions for bash, zsh, fish, and PowerShell.

### Verification
```bash
# Already works:
kardinal completion bash | head -5
# → # bash completion V2 for kardinal ...
kardinal completion zsh | head -5
# → #compdef kardinal
```

Closes #579