### PR TITLE
fix(controller): mount emptyDir at /tmp — git-clone fails with readOnlyRootFilesystem

### DIFF
--- a/chart/kardinal-promoter/templates/deployment.yaml
+++ b/chart/kardinal-promoter/templates/deployment.yaml
@@ -74,6 +74,12 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Problem

PDCA S1 (happy path promotion) fails with:
```
Message: step git-clone: git-clone: create clone dir: mkdir /tmp/kardinal: read-only file system
```

The Helm chart sets `securityContext.readOnlyRootFilesystem: true`, which makes the entire root filesystem including `/tmp` read-only. The PromotionStep reconciler uses `/tmp/kardinal/<pipeline>/<bundle>` as the git working directory.

## Fix

Mount an `emptyDir` volume at `/tmp`. This is the standard Kubernetes pattern for read-only root filesystem containers that still need scratch space.

The emptyDir is ephemeral (cleared on pod restart), which is correct: the step engine is idempotent and will re-clone if `/tmp` is cleared.

## Acceptance


Closes #608