### PR TITLE
chore(graph): upgrade krocodile pin to 745998f (2026-04-15)

### DIFF
--- a/chart/kardinal-promoter/Chart.yaml
+++ b/chart/kardinal-promoter/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 annotations:
   # The krocodile commit bundled in this chart version.
   # Built and pushed to ghcr.io/pnz1990/kardinal-promoter/krocodile:<commit>
-  krocodile.commit: "948ad6c"
+  krocodile.commit: "745998f"

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -129,7 +129,7 @@ krocodile:
   # This is the commit the release pipeline built the image from.
   # Used as the default image tag when image.tag is not set.
   # Update via the krocodile upgrade protocol in AGENTS.md.
-  pinnedCommit: "948ad6c"
+  pinnedCommit: "745998f"
 
   # -- API group for Graph CRDs.
   apiGroup: "experimental.kro.run"

--- a/hack/install-krocodile.sh
+++ b/hack/install-krocodile.sh
@@ -16,11 +16,20 @@ set -euo pipefail
 # ── Pinned version ─────────────────────────────────────────────────────────────
 # Update this when intentionally upgrading krocodile.
 # Minimum required: 1b0ce353 (fixes double-dispatch race in DAG coordinator)
-# Last verified:    948ad6c (2026-04-14 — fix: validate node IDs produce valid DNS-1123 label
-#                           key prefixes; adds IsDNS1123Label check in parseNodeList and
-#                           IsDNS1123Subdomain check in validateIdentityLabelKey)
+# Last verified:    745998f (2026-04-15 — stdlib: Decorator as bootstrap primitive,
+#                           Kind built on Decorator; also picks up:
+#                           - compilation failure fallback to previous revision (#125)
+#                           - forEach propagateWhen evaluated per-item (#125)
+#                           - WatchKind O(1) incremental cache (#118)
+#                           - SystemError exponential backoff (#118)
+#                           - readiness state included in propagation hash (#118)
+#                           - compile-time CEL type inference via SchemaResolver (#119)
+#                           - ErrEvaluation sentinel fixes misclassification (#111)
+#                           - graph_reconcile_duration_seconds + graph_node_eval_duration_seconds metrics (#111)
+#                           - finalizer validation: rejects finalizes on Watch/WatchKind/Definition (#111)
+#                           - forEach accepts both flat-map and upstream array format (#124))
 KROCODILE_REPO="https://github.com/ellistarn/kro.git"
-KROCODILE_COMMIT="${KROCODILE_COMMIT:-948ad6c}"
+KROCODILE_COMMIT="${KROCODILE_COMMIT:-745998f}"
 KROCODILE_IMAGE="krocodile-graph-controller:${KROCODILE_COMMIT}"
 KIND_CLUSTER="${KIND_CLUSTER:-kardinal-e2e}"
 


### PR DESCRIPTION
## Summary

Upgrades the krocodile pin from `948ad6c` (2026-04-14) to `745998f` (2026-04-15). 14 commits ahead. No kardinal code changes required — all improvements are in the krocodile controller binary.

## What's in this upgrade

| PR | Type | Impact |
|---|---|---|
| #125 | fix | Compilation failure no longer halts reconciliation; falls back to previous valid revision, healthy resources keep converging |
| #125 | fix | `forEach` `propagateWhen` now evaluated per-item with aggregate boolean (correctness fix) |
| #118 | fix | WatchKind incremental O(1) cache: GET only changed items per event; full List only on drift/first reconcile |
| #118 | fix | SystemError exponential backoff `[1s, resyncInterval]` replaces flat 5s retry |
| #118 | fix | Readiness state included in propagation hash; `.ready()` downstream triggers correctly on readiness change |
| #119 | feat | Compile-time CEL type inference via `SchemaResolver`; expression errors surface at compile time |
| #111 | fix | `ErrEvaluation` sentinel prevents CEL errors with network-like text from misclassifying as `SystemError` |
| #111 | feat | `graph_reconcile_duration_seconds` + `graph_node_eval_duration_seconds` Prometheus histograms |
| #111 | fix | Finalizer validation: rejects `finalizes` targeting Watch/WatchKind/Definition nodes at compile time |
| #124 | fix | `forEach` accepts both flat-map and upstream array formats, adds duplicate key detection |
| #123 | fix | `ReferenceWatchKind.String()` renamed `watch-kind` → `watchKind` |
| #126 | feat | Decorator/Kind/Singleton stdlib primitives (internal — no kardinal impact today) |

## Follow-up issues

- **#611**: Refactor health Watch nodes → WatchKind to benefit from the O(1) incremental cache (requires translator change, filed as medium priority)
- **#612**: Explore `forEach` for multi-region fan-out and PolicyGate fan-out (new feature territory, filed as low priority)

## Compat check

- No krocodile Graph CRD API changes
- No label key format changes  
- No `readyWhen`/`propagateWhen` semantic changes
- `forEach` flat-map format (what our translator would emit) still accepted
- `ReferenceWatchKind` string rename: kardinal doesn't compare this string directly
- Compilation fallback: transparent — we never relied on halt-on-error behavior