### PR TITLE
chore(graph): upgrade krocodile pin 948ad6c → 745998f (14 commits)

### DIFF
--- a/chart/kardinal-promoter/Chart.yaml
+++ b/chart/kardinal-promoter/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 annotations:
   # The krocodile commit bundled in this chart version.
   # Built and pushed to ghcr.io/pnz1990/kardinal-promoter/krocodile:<commit>
-  krocodile.commit: "948ad6c"
+  krocodile.commit: "745998f"

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -129,7 +129,7 @@ krocodile:
   # This is the commit the release pipeline built the image from.
   # Used as the default image tag when image.tag is not set.
   # Update via the krocodile upgrade protocol in AGENTS.md.
-  pinnedCommit: "948ad6c"
+  pinnedCommit: "745998f"
 
   # -- API group for Graph CRDs.
   apiGroup: "experimental.kro.run"

--- a/hack/install-krocodile.sh
+++ b/hack/install-krocodile.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 #                           key prefixes; adds IsDNS1123Label check in parseNodeList and
 #                           IsDNS1123Subdomain check in validateIdentityLabelKey)
 KROCODILE_REPO="https://github.com/ellistarn/kro.git"
-KROCODILE_COMMIT="${KROCODILE_COMMIT:-948ad6c}"
+KROCODILE_COMMIT="${KROCODILE_COMMIT:-745998f}"
 KROCODILE_IMAGE="krocodile-graph-controller:${KROCODILE_COMMIT}"
 KIND_CLUSTER="${KIND_CLUSTER:-kardinal-e2e}"
 

--- a/hack/install-krocodile.sh
+++ b/hack/install-krocodile.sh
@@ -16,9 +16,10 @@ set -euo pipefail
 # ── Pinned version ─────────────────────────────────────────────────────────────
 # Update this when intentionally upgrading krocodile.
 # Minimum required: 1b0ce353 (fixes double-dispatch race in DAG coordinator)
-# Last verified:    948ad6c (2026-04-14 — fix: validate node IDs produce valid DNS-1123 label
-#                           key prefixes; adds IsDNS1123Label check in parseNodeList and
-#                           IsDNS1123Subdomain check in validateIdentityLabelKey)
+# Last verified:    745998f (2026-04-15 — stdlib: Decorator as bootstrap primitive, Kind built on
+#                           Decorator; watch-kind → watchKind rename; forEach array format support;
+#                           DAG finalizer guard for non-resource nodes; Definition compile-time
+#                           type inference via SchemaResolver)
 KROCODILE_REPO="https://github.com/ellistarn/kro.git"
 KROCODILE_COMMIT="${KROCODILE_COMMIT:-745998f}"
 KROCODILE_IMAGE="krocodile-graph-controller:${KROCODILE_COMMIT}"


### PR DESCRIPTION
## Summary

Upgrade krocodile (kardinal's underlying DAG engine) from commit `948ad6c` to `745998f` (14 commits). Mandatory per AGENTS.md — ≥5 commits behind triggers upgrade.

## Files changed

- `hack/install-krocodile.sh`: KROCODILE_COMMIT `948ad6c` → `745998f`
- `chart/kardinal-promoter/values.yaml`: `krocodile.pinnedCommit` updated
- `chart/kardinal-promoter/Chart.yaml`: `krocodile.commit` annotation updated

## Compat analysis (source-verified)

| Change | Impact on kardinal |
|---|---|
| `watch-kind` → `watchKind` rename in Reference.String() | ✅ None — kardinal does not generate WatchKind nodes |
| `parseIdentityLabel` split into two functions | ✅ None — internal to krocodile's label parsing |
| forEach: accepts both array and map formats | ✅ None — kardinal uses flat-map format, still valid |
| DAG: finalizer guard for Definition/Watch/WatchKind targets | ✅ None — kardinal only finalizes Own nodes |
| New `Decorator` primitive | ✅ None — not applicable to kardinal's per-Bundle graph model |
| `Definition` node compile-time type inference | ✅ Free benefit from binary upgrade |
| `GraphReconciler` gains `SchemaResolver` optional field | ✅ None — additive, backward compat |

## Primitive rethink

**Decorator**: Creates a sub-Graph per watched K8s resource item. Kardinal creates per-Bundle Graphs via BundleReconciler. Not applicable — different pattern (per-lifecycle vs per-existing-resource augmentation). No simplification opportunity now.

**Definition compile-time inference**: Benefit is automatic from binary upgrade. No kardinal code changes needed.

**blocked-on-krocodile issues**: None open.

## Validation

- `go build ./...` ✅  
- `go vet ./...` ✅  
- `go test ./...` ✅ (all unit tests pass; TestInfrastructure skip expected without kind cluster)
- E2E CI will build and validate the new krocodile image on merge (release.yml triggers on release)