### PR TITLE
feat(observability): PrometheusRule CRD in Helm chart — 6 pre-built alerting rules

### DIFF
--- a/chart/kardinal-promoter/templates/prometheusrule.yaml
+++ b/chart/kardinal-promoter/templates/prometheusrule.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "kardinal-promoter.fullname" . }}
+  namespace: {{ .Values.prometheusRule.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "kardinal-promoter.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: kardinal-promoter
+      rules:
+        # Controller availability
+        - alert: KardinalControllerDown
+          expr: up{job="{{ include "kardinal-promoter.fullname" . }}"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "kardinal-promoter controller is not scraping"
+            description: "The kardinal-promoter controller has been unreachable for more than 5 minutes. Promotions are stalled."
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#controller-not-running"
+
+        # Reconcile errors — any controller error rate above 0.1/s for 5m
+        - alert: KardinalHighReconcileErrors
+          expr: |
+            sum by (controller) (
+              rate(controller_runtime_reconcile_errors_total[5m])
+            ) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "kardinal {{ "{{" }} $labels.controller {{ "}}" }} reconciler error rate is elevated"
+            description: "The {{ "{{" }} $labels.controller {{ "}}" }} reconciler is failing at {{ "{{" }} $value | humanize {{ "}}" }} errors/s. Promotions may be stuck or failing silently."
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#reconcile-errors"
+
+        # PromotionStep stuck: BundleReconciler has not run for 10 minutes
+        - alert: KardinalBundleReconcilerStalled
+          expr: |
+            rate(controller_runtime_reconcile_total{controller="bundle"}[10m]) == 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "kardinal BundleReconciler has not run in 10 minutes"
+            description: "No Bundle reconcile events in the last 10 minutes. The controller may be stuck, leader election may be broken, or there may be no active Bundles."
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#bundle-reconciler-stalled"
+
+        # Work queue backlog — controller is falling behind
+        - alert: KardinalWorkQueueBacklog
+          expr: |
+            workqueue_depth{name=~"bundle|promotionstep|policygate"} > 100
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "kardinal {{ "{{" }} $labels.name {{ "}}" }} work queue depth > 100"
+            description: "The {{ "{{" }} $labels.name {{ "}}" }} work queue has {{ "{{" }} $value | humanize {{ "}}" }} items pending for more than 5 minutes. Controller may be overloaded."
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#work-queue-backlog"
+
+        # PolicyGate reconciler slow — gates may be blocking promotions with stale evaluations
+        - alert: KardinalPolicyGateReconcileSlow
+          expr: |
+            histogram_quantile(0.99,
+              rate(controller_runtime_reconcile_time_seconds_bucket{controller="policygate"}[5m])
+            ) > 10
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "kardinal PolicyGate reconcile P99 latency is above 10s"
+            description: "PolicyGate reconciles are taking more than 10s at P99. Gates may be stale and blocking or unblocking promotions late."
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#policygate-slow"
+
+        # Webhook error rate — Bundle creation API is failing
+        - alert: KardinalWebhookErrors
+          expr: |
+            rate(controller_runtime_webhook_requests_total{code=~"5.."}[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "kardinal Bundle creation webhook is returning 5xx errors"
+            description: "The /api/v1/bundles webhook is returning {{ "{{" }} $value | humanize {{ "}}" }} 5xx errors/s. CI pipelines calling the webhook will fail to create Bundles."
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#webhook-errors"
+{{- end }}

--- a/chart/kardinal-promoter/templates/prometheusrule.yaml
+++ b/chart/kardinal-promoter/templates/prometheusrule.yaml
@@ -22,7 +22,7 @@ spec:
           annotations:
             summary: "kardinal-promoter controller is not scraping"
             description: "The kardinal-promoter controller has been unreachable for more than 5 minutes. Promotions are stalled."
-            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#controller-not-running"
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#start-here-kardinal-doctor"
 
         # Reconcile errors — any controller error rate above 0.1/s for 5m
         - alert: KardinalHighReconcileErrors
@@ -36,7 +36,7 @@ spec:
           annotations:
             summary: "kardinal {{ "{{" }} $labels.controller {{ "}}" }} reconciler error rate is elevated"
             description: "The {{ "{{" }} $labels.controller {{ "}}" }} reconciler is failing at {{ "{{" }} $value | humanize {{ "}}" }} errors/s. Promotions may be stuck or failing silently."
-            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#reconcile-errors"
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#promotion-is-stuck"
 
         # PromotionStep stuck: BundleReconciler has not run for 10 minutes
         - alert: KardinalBundleReconcilerStalled
@@ -48,7 +48,7 @@ spec:
           annotations:
             summary: "kardinal BundleReconciler has not run in 10 minutes"
             description: "No Bundle reconcile events in the last 10 minutes. The controller may be stuck, leader election may be broken, or there may be no active Bundles."
-            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#bundle-reconciler-stalled"
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#bundle-not-promoting"
 
         # Work queue backlog — controller is falling behind
         - alert: KardinalWorkQueueBacklog
@@ -60,7 +60,7 @@ spec:
           annotations:
             summary: "kardinal {{ "{{" }} $labels.name {{ "}}" }} work queue depth > 100"
             description: "The {{ "{{" }} $labels.name {{ "}}" }} work queue has {{ "{{" }} $value | humanize {{ "}}" }} items pending for more than 5 minutes. Controller may be overloaded."
-            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#work-queue-backlog"
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#graph-controller-issues"
 
         # PolicyGate reconciler slow — gates may be blocking promotions with stale evaluations
         - alert: KardinalPolicyGateReconcileSlow
@@ -74,7 +74,7 @@ spec:
           annotations:
             summary: "kardinal PolicyGate reconcile P99 latency is above 10s"
             description: "PolicyGate reconciles are taking more than 10s at P99. Gates may be stale and blocking or unblocking promotions late."
-            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#policygate-slow"
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#promotion-is-stuck"
 
         # Webhook error rate — Bundle creation API is failing
         - alert: KardinalWebhookErrors
@@ -86,5 +86,5 @@ spec:
           annotations:
             summary: "kardinal Bundle creation webhook is returning 5xx errors"
             description: "The /api/v1/bundles webhook is returning {{ "{{" }} $value | humanize {{ "}}" }} 5xx errors/s. CI pipelines calling the webhook will fail to create Bundles."
-            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#webhook-errors"
+            runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#webhook-issues"
 {{- end }}

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -194,3 +194,16 @@ pdb:
 # zones to prevent both replicas from landing on the same node.
 topologySpread:
   enabled: true
+
+# -- PrometheusRule for Prometheus Operator.
+# Creates a PrometheusRule CR with pre-built alerting rules for kardinal-promoter.
+# Requires the Prometheus Operator CRD (monitoring.coreos.com/v1/PrometheusRule).
+# Disabled by default — enable when using kube-prometheus-stack or similar.
+prometheusRule:
+  # -- Create the PrometheusRule resource. Requires Prometheus Operator CRD.
+  enabled: false
+  # -- Additional labels to add to the PrometheusRule (for Prometheus selector matching).
+  # Example: { "release": "kube-prometheus-stack" }
+  additionalLabels: {}
+  # -- Namespace to deploy the PrometheusRule into. Defaults to Release.Namespace.
+  namespace: ""

--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -159,31 +159,70 @@ my-app     prod   30d      2.1/day       45m avg       3.2%        1
 
 ---
 
-## Alerting Examples
+## Alerting Rules — PrometheusRule (Helm)
 
-### Controller is not reconciling
+kardinal-promoter ships a `PrometheusRule` resource that works with the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) (kube-prometheus-stack, Victoria Metrics Operator, etc.).
+
+### Enable via Helm
+
+```yaml
+# values.yaml
+prometheusRule:
+  enabled: true
+  # Match your Prometheus Operator's selector labels:
+  additionalLabels:
+    release: kube-prometheus-stack
+```
+
+Install or upgrade:
+
+```bash
+helm upgrade --install kardinal-promoter oci://ghcr.io/pnz1990/kardinal-promoter/chart/kardinal-promoter \
+  --set prometheusRule.enabled=true \
+  --set 'prometheusRule.additionalLabels.release=kube-prometheus-stack'
+```
+
+### Included alerts
+
+| Alert | Expression | Severity | Description |
+|---|---|---|---|
+| `KardinalControllerDown` | `up{job="kardinal-promoter"} == 0` for 5m | critical | Controller unreachable; promotions stalled |
+| `KardinalHighReconcileErrors` | reconcile error rate > 0.1/s for 5m | warning | Reconciler failing; promotions may be stuck |
+| `KardinalBundleReconcilerStalled` | no bundle reconciles for 10m | warning | Controller idle; possible leader election issue |
+| `KardinalWorkQueueBacklog` | work queue depth > 100 for 5m | warning | Controller overloaded or starved of CPU |
+| `KardinalPolicyGateReconcileSlow` | PolicyGate P99 latency > 10s | warning | Gate evaluations stale; promotions blocked late |
+| `KardinalWebhookErrors` | webhook 5xx rate > 0 for 5m | warning | Bundle creation API failing; CI pipelines cannot promote |
+
+Every alert includes a `runbook_url` annotation pointing to the relevant section in [troubleshooting.md](../troubleshooting.md).
+
+### Manual alerting (without Prometheus Operator)
+
+If you don't use the Prometheus Operator, copy the rules into your `prometheus.yml`:
 
 ```yaml
 groups:
-  - name: kardinal
+  - name: kardinal-promoter
     rules:
-      - alert: KardinalControllerNotReconciling
-        expr: |
-          rate(controller_runtime_reconcile_total{controller="bundle"}[10m]) == 0
-        for: 10m
+      - alert: KardinalControllerDown
+        expr: up{job="kardinal-promoter"} == 0
+        for: 5m
         labels:
-          severity: warning
+          severity: critical
         annotations:
-          summary: "kardinal BundleReconciler has not run in 10 minutes"
+          summary: "kardinal-promoter controller is not scraping"
+          runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#controller-not-running"
 
       - alert: KardinalHighReconcileErrors
         expr: |
-          rate(controller_runtime_reconcile_errors_total[5m]) > 0.1
+          sum by (controller) (
+            rate(controller_runtime_reconcile_errors_total[5m])
+          ) > 0.1
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "kardinal reconcile error rate > 0.1/s for {{ $labels.controller }}"
+          summary: "kardinal {{ $labels.controller }} reconcile error rate elevated"
+          runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#reconcile-errors"
 
       - alert: KardinalWorkQueueBacklog
         expr: workqueue_depth{name=~"bundle|promotionstep|policygate"} > 100
@@ -192,6 +231,7 @@ groups:
           severity: warning
         annotations:
           summary: "kardinal work queue depth > 100 for {{ $labels.name }}"
+          runbook_url: "https://pnz1990.github.io/kardinal-promoter/troubleshooting/#work-queue-backlog"
 ```
 
 ---

--- a/test/helm/chart_test.go
+++ b/test/helm/chart_test.go
@@ -251,3 +251,68 @@ func TestHelmTemplateTopologySpreadForMultiReplica(t *testing.T) {
 	assert.Contains(t, rendered, "topology.kubernetes.io/zone",
 		"topology spread must use zone topology key")
 }
+
+func TestHelmTemplatePrometheusRuleDisabledByDefault(t *testing.T) {
+	helm := helmBin(t)
+	root := repoRoot(t)
+	chartDir := filepath.Join(root, "chart", "kardinal-promoter")
+
+	// PrometheusRule must NOT be created by default (requires Prometheus Operator)
+	cmd := exec.Command(helm, "template", "kardinal-promoter", chartDir)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "helm template must succeed:\n%s", string(out))
+
+	rendered := string(out)
+	assert.NotContains(t, rendered, "kind: PrometheusRule",
+		"PrometheusRule must NOT be rendered by default (disabled)")
+}
+
+func TestHelmTemplatePrometheusRuleEnabledWhenConfigured(t *testing.T) {
+	helm := helmBin(t)
+	root := repoRoot(t)
+	chartDir := filepath.Join(root, "chart", "kardinal-promoter")
+
+	// PrometheusRule must be created when enabled
+	cmd := exec.Command(helm, "template", "kardinal-promoter", chartDir,
+		"--set", "prometheusRule.enabled=true")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "helm template with prometheusRule.enabled=true must succeed:\n%s", string(out))
+
+	rendered := string(out)
+	assert.Contains(t, rendered, "kind: PrometheusRule",
+		"PrometheusRule must be rendered when prometheusRule.enabled=true")
+	assert.Contains(t, rendered, "monitoring.coreos.com/v1",
+		"PrometheusRule must use monitoring.coreos.com/v1 apiVersion")
+	assert.Contains(t, rendered, "KardinalControllerDown",
+		"PrometheusRule must include KardinalControllerDown alert")
+	assert.Contains(t, rendered, "KardinalHighReconcileErrors",
+		"PrometheusRule must include KardinalHighReconcileErrors alert")
+	assert.Contains(t, rendered, "KardinalBundleReconcilerStalled",
+		"PrometheusRule must include KardinalBundleReconcilerStalled alert")
+	assert.Contains(t, rendered, "KardinalWorkQueueBacklog",
+		"PrometheusRule must include KardinalWorkQueueBacklog alert")
+	assert.Contains(t, rendered, "KardinalPolicyGateReconcileSlow",
+		"PrometheusRule must include KardinalPolicyGateReconcileSlow alert")
+	assert.Contains(t, rendered, "KardinalWebhookErrors",
+		"PrometheusRule must include KardinalWebhookErrors alert")
+	// Every alert must have a runbook_url
+	assert.Contains(t, rendered, "runbook_url",
+		"All alerts must include runbook_url annotation")
+}
+
+func TestHelmTemplatePrometheusRuleAdditionalLabels(t *testing.T) {
+	helm := helmBin(t)
+	root := repoRoot(t)
+	chartDir := filepath.Join(root, "chart", "kardinal-promoter")
+
+	// Additional labels must be propagated to the PrometheusRule
+	cmd := exec.Command(helm, "template", "kardinal-promoter", chartDir,
+		"--set", "prometheusRule.enabled=true",
+		"--set", "prometheusRule.additionalLabels.release=kube-prometheus-stack")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "helm template with additionalLabels must succeed:\n%s", string(out))
+
+	rendered := string(out)
+	assert.Contains(t, rendered, "release: kube-prometheus-stack",
+		"additionalLabels must be propagated to the PrometheusRule metadata")
+}


### PR DESCRIPTION
## Summary

Adds `PrometheusRule` support to the kardinal-promoter Helm chart for [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) users.

## What's included

**New file**: `chart/kardinal-promoter/templates/prometheusrule.yaml`

6 pre-built alerting rules, all using controller-runtime standard metrics (no custom instrumentation required):

| Alert | Severity | Condition |
|---|---|---|
| `KardinalControllerDown` | critical | `up{job="kardinal-promoter"} == 0` for 5m |
| `KardinalHighReconcileErrors` | warning | reconcile error rate > 0.1/s for 5m |
| `KardinalBundleReconcilerStalled` | warning | no bundle reconciles for 10m |
| `KardinalWorkQueueBacklog` | warning | work queue depth > 100 for 5m |
| `KardinalPolicyGateReconcileSlow` | warning | PolicyGate P99 latency > 10s |
| `KardinalWebhookErrors` | warning | webhook 5xx rate > 0 for 5m |

Every alert has `runbook_url` pointing to the relevant troubleshooting doc section.

**Enable with**:
```yaml
prometheusRule:
  enabled: true
  additionalLabels:
    release: kube-prometheus-stack  # match your Prometheus Operator selector
```

Disabled by default (requires Prometheus Operator CRD).

## Testing

3 new Helm tests:
- `TestHelmTemplatePrometheusRuleDisabledByDefault` — verifies no PrometheusRule in default template
- `TestHelmTemplatePrometheusRuleEnabledWhenConfigured` — verifies all 6 alerts + runbook_url
- `TestHelmTemplatePrometheusRuleAdditionalLabels` — verifies label propagation

All 11 helm tests pass.