### PR TITLE
docs: architecture review 2026-04-15 — fix false CEL claims, catalog new findings

### DIFF
--- a/.opencode/command/arch-audit.md
+++ b/.opencode/command/arch-audit.md
@@ -1,0 +1,18 @@
+---
+description: "Thorough architectural audit. Checks documentation claims against source, finds unused primitives in dependencies, identifies structural redundancy, and diagnoses missing reactivity wiring. Produces GitHub issues and a documentation fix PR. Does not make code changes."
+---
+
+```bash
+AGENTS_PATH=$(python3 -c "
+import re, os
+section = None
+for line in open('otherness-config.yaml'):
+    s = re.match(r'^(\w[\w_]*):', line)
+    if s: section = s.group(1)
+    if section == 'maqa':
+        m = re.match(r'^\s+agents_path:\s*[\"\'']?([^\"\'#\n]+)[\"\'']?', line)
+        if m: print(os.path.expanduser(m.group(1).strip())); break
+" 2>/dev/null || echo "$HOME/.otherness/agents")
+```
+
+Read and follow `$AGENTS_PATH/arch-audit.md`.

--- a/.opencode/command/otherness.arch-audit.md
+++ b/.opencode/command/otherness.arch-audit.md
@@ -15,4 +15,4 @@ for line in open('otherness-config.yaml'):
 " 2>/dev/null || echo "$HOME/.otherness/agents")
 ```
 
-Read and follow `$AGENTS_PATH/arch-audit.md`.
+Read and follow `$AGENTS_PATH/otherness.arch-audit.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,12 +257,21 @@ web/
 
 ## CEL Expressions — kro Library (READ BEFORE WRITING ANY CEL)
 
-kardinal uses `github.com/kubernetes-sigs/kro/pkg/cel/library` for all CEL evaluation.
-This gives PolicyGate expressions the **same extended function set** as kro's own
-`readyWhen`/`propagateWhen` expressions. Expressions written for kro graphs work
-identically in kardinal PolicyGates.
+kardinal uses `github.com/kubernetes-sigs/kro/pkg/cel/library` for CEL evaluation in
+the PolicyGate reconciler. The kro library functions are available in **two distinct
+contexts** that you must not confuse:
 
-**Available CEL functions (beyond standard CEL):**
+### Context 1: PolicyGate CEL (pkg/reconciler/policygate/cel_evaluator.go)
+
+The PolicyGate reconciler evaluates `spec.expression` using a CEL environment built
+in `newEvaluator()`. This environment includes the kro library extensions AND a set of
+**context map variables** injected at evaluation time.
+
+To add CEL evaluation in any new code: construct a `cel.NewEnv()` with explicit library
+imports following the pattern in `pkg/reconciler/policygate/cel_evaluator.go:newEvaluator()`.
+There is **no shared `pkg/cel/NewCELEnvironment()` function** — do not look for one.
+
+**kro library functions available in PolicyGate expressions:**
 
 ```
 # JSON
@@ -280,31 +289,57 @@ lists.removeAtIndex(list, index)       → list
 # Random (deterministic from seed — use for consistent soak calculations)
 random.seededInt(min, max, seed)       → int
 
-# Standard string extensions (via cel-go/ext)
+# Standard string extensions (standard cel-go/ext, NOT kro-specific)
 string.format(args)                    → string
 string.lowerAscii()                    → string
 ```
 
-**If any part of the system evaluates CEL expressions** (backend policy gate,
-CLI `policy simulate`, UI expression preview/validation) — it MUST use
-`pkg/cel/NewCELEnvironment()` which registers all kro libraries. Never construct
-a raw `cel.NewEnv()` without going through this package.
-
-**Example PolicyGate expressions using extended functions:**
+**PolicyGate context variables** (injected as map variables, NOT CEL functions):
 
 ```
-# Standard
-!schedule.isWeekend()
-bundle.metadata.annotations['team'] == 'platform'
+bundle.type, bundle.version, bundle.provenance.{author,commitSHA,ciRunURL}
+schedule.isWeekend    → bool   (true if Saturday or Sunday UTC)
+schedule.hour         → int    (current UTC hour, 0-23)
+schedule.dayOfWeek    → string (e.g. "Monday")
+environment.name      → string
+metrics.<name>.value  → string (from MetricCheck status)
+metrics.<name>.result → string ("Pass" or "Fail")
+upstream.<env>.soakMinutes → int64
+changewindow.<name>   → bool   (true when window is active/blocking)
+```
 
-# Using json functions
-json.unmarshal(bundle.spec.metadata).releaseType == 'hotfix'
+**IMPORTANT:** `schedule.*` variables are **PolicyGate reconciler context only**. They are
+NOT available in krocodile Graph `readyWhen`/`propagateWhen` expressions. Do NOT use
+`!schedule.isWeekend` in a Graph node template — it will fail krocodile CEL compilation.
+In a Graph node, use a ScheduleClock Watch node and reference `clock.status.tick` to
+trigger re-evaluation; schedule logic stays in the PolicyGate reconciler.
 
-# Using maps/lists
+See issue #616 for the planned path to making `schedule.*` available in Graph CEL.
+
+### Context 2: krocodile Graph CEL (readyWhen / propagateWhen / includeWhen)
+
+krocodile Graph expressions use the kro library functions via the Graph controller's
+built-in DefaultEnvironment. The same json/maps/lists/random functions are available.
+Context variables are the node IDs in scope (the Kubernetes objects each node manages).
+
+**Example PolicyGate expressions (PolicyGate reconciler context):**
+
+```
+# Time gate (schedule.* is PolicyGate-only)
+!schedule.isWeekend && schedule.hour >= 9 && schedule.hour < 17
+
+# Bundle metadata check
+bundle.provenance.author != "dependabot[bot]"
+
+# Upstream soak gate
+upstream.uat.soakMinutes >= 30
+
+# Metric gate
+metrics["error-rate"].result == "Pass"
+
+# Using json/maps functions
+json.unmarshal(bundle.provenance.commitSHA).releaseType == 'hotfix'
 maps.merge(environment.labels, bundle.labels)['env'] != 'prod'
-
-# Multi-condition with upstream soak
-!schedule.isWeekend() && upstream.uat.soakMinutes >= 30
 ```
 
 ## E2E Testing Infrastructure

--- a/docs/design/10-graph-first-architecture.md
+++ b/docs/design/10-graph-first-architecture.md
@@ -88,15 +88,20 @@ This is the correct pattern for:
 
 **Q3. Can this be expressed as a CEL extension on the Graph's CEL environment?**
 
-Custom CEL libraries (`schedule.isWeekend()`, `quantity.parse()`) can be registered
-on the Graph's CEL environment via `WithCustomDeclarations`. This is appropriate for
-**stateless, cheap, synchronous** computations (time functions, string utilities,
-Kubernetes quantity parsing).
+Custom CEL libraries can be registered on the Graph's CEL environment via
+`WithCustomDeclarations`. This is appropriate for **stateless, cheap, synchronous**
+computations (string utilities, Kubernetes quantity parsing).
+
+**Important caveat on `schedule.*`:** `schedule.isWeekend`, `schedule.hour`, and
+`schedule.dayOfWeek` are NOT currently registered as Graph CEL extensions. They are
+context map variables injected by the PolicyGate reconciler. They are not available
+in krocodile Graph `readyWhen`/`propagateWhen` expressions. See issue #616 for
+the path to making these available Graph-wide.
 
 This is **not** appropriate for:
 - HTTP calls (blocks reconcile loop)
 - External API queries (no retry, no backoff, no timeout injection)
-- Non-deterministic operations
+- Non-deterministic operations that need retry semantics
 
 **If none of Q1-Q3 apply: STOP. This requires human architectural input.**
 

--- a/docs/design/11-graph-purity-tech-debt.md
+++ b/docs/design/11-graph-purity-tech-debt.md
@@ -2,7 +2,28 @@
 
 > Status: Active — every logic leak is tracked here
 > Related: `docs/design/10-graph-first-architecture.md`
-> Last audited: 2026-04-14
+> Last audited: 2026-04-15
+
+---
+
+## New Findings — 2026-04-15 Architectural Review
+
+The following items were identified in a full architecture review against krocodile 745998f.
+All are tracked as GitHub issues.
+
+| ID | Issue | Description | Priority |
+|---|---|---|---|
+| SCHED-1 | #616 | `schedule.*` CEL variables are map injection in PolicyGate reconciler, NOT a kro library on Graph DefaultEnvironment — docs claim otherwise | HIGH |
+| GB-BUNDLE | #626 | Bundle reconciler does not watch Pipeline changes — Graph goes stale when Pipeline spec is edited | HIGH |
+| AGENTS-CEL | #627 | AGENTS.md claims `pkg/cel/NewCELEnvironment()` exists and `schedule.*` are Graph functions — both false | HIGH (FIXED) |
+| GB-INCLUDE | #619 | `filterByIntent` Go filtering should be Graph `includeWhen` expressions | MEDIUM |
+| PS-UP | #625 | `spec.upstreamVerifiedN` in PromotionStep is redundant — Graph `propagateWhen` already handles sequencing | MEDIUM |
+| PG-UP | #618 | `spec.upstreamEnvironment` in PolicyGate is Graph wiring, not gate logic — confuses users | MEDIUM |
+| GB-WATCH | #622 | Bundle is not a Watch node in the Graph — image/intent changes are invisible to the Graph | MEDIUM |
+| SUB-DUP | #620 | Subscription deduplication uses status field, not idempotent label selector | MEDIUM |
+| GB-DEF | #617 | Naming computation in Go (celSafeSlug, etc.) should move to Definition nodes | LOW |
+| DEC-RESEARCH | #623 | Research spike: can krocodile Decorator replace the Go translator entirely? | LOW |
+| PRST-DOC | #624 | PRStatus uses readyWhen not propagateWhen — design intent needs documentation | LOW |
 
 ---
 


### PR DESCRIPTION
## Summary

Full architecture review of kardinal against krocodile 745998f. Found false claims in AGENTS.md and design docs. Opened 11 GitHub issues (#616–#627). This PR fixes the three docs that had incorrect statements — everything else is tracked in the issues.

## Changes

### AGENTS.md — CEL section rewritten (#627)
- **Removed false claim**: `pkg/cel/NewCELEnvironment()` does not exist. Agents using this would get a compile error.
- **Removed false claim**: `schedule.isWeekend()` is not a Graph CEL function — it is a context map variable in the PolicyGate reconciler only
- **Added**: Two-context model documentation (PolicyGate reconciler vs krocodile Graph)
- **Added**: Canonical example reference to `cel_evaluator.go:newEvaluator()`
- **Added**: Explicit warning that `schedule.*` in a Graph node template will fail krocodile CEL compilation

### docs/design/10-graph-first-architecture.md — Q3 section fixed
- Removed `schedule.isWeekend()` example from "registered as Graph CEL extension" — it isn't
- Added caveat pointing to #616 for the path to Graph-wide schedule functions

### docs/design/11-graph-purity-tech-debt.md — new findings cataloged
11 new architectural findings with issue numbers, priorities, and descriptions.

## Issues opened

| # | Finding |
|---|---|
| #616 | `schedule.*` is map injection, docs claimed Graph CEL library |
| #617 | Naming computation should use Definition nodes |
| #618 | `spec.upstreamEnvironment` in PolicyGate is Graph wiring, not gate logic |
| #619 | `filterByIntent` should be Graph `includeWhen` expressions |
| #620 | Subscription deduplication uses fragile status field |
| #622 | Bundle has no Watch node — image/intent invisible to Graph |
| #623 | Research: can krocodile Decorator replace the Go translator? |
| #624 | PRStatus readyWhen vs propagateWhen design intent undocumented |
| #625 | `spec.upstreamVerifiedN` is redundant — Graph propagateWhen handles sequencing |
| #626 | Bundle reconciler doesn't watch Pipeline changes |
| #627 | AGENTS.md false CEL claims (fixed in this PR) |

Also previously opened as part of krocodile upgrade:
| #611 | Refactor health Watch nodes to WatchKind |
| #612 | forEach for multi-region fan-out |