### PR TITLE
feat(cli): kardinal get pipelines --watch — real-time promotion progress

### DIFF
--- a/cmd/kardinal/cmd/get_pipelines.go
+++ b/cmd/kardinal/cmd/get_pipelines.go
@@ -16,6 +16,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
+	"time"
 
 	"github.com/spf13/cobra"
 	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,29 +25,59 @@ import (
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 )
 
+// watchInterval is the polling interval for --watch mode.
+// 2 seconds matches the issue requirement and is fast enough to see step transitions.
+const getPipelinesWatchInterval = 2 * time.Second
+
 func newGetPipelinesCmd() *cobra.Command {
-	var allNamespaces bool
+	var (
+		allNamespaces bool
+		watchFlag     bool
+	)
 
 	cmd := &cobra.Command{
 		Use:     "pipelines [name]",
 		Aliases: []string{"pipeline"},
 		Short:   "List Pipelines",
-		Args:    cobra.MaximumNArgs(1),
+		Long: `List Pipelines and their per-environment promotion status.
+
+Use --watch / -w to stream live updates (polls every 2s, Ctrl-C to quit).`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGetPipelines(cmd, args, allNamespaces)
+			return runGetPipelines(cmd, args, allNamespaces, watchFlag)
 		},
 	}
 	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false,
 		"List pipelines across all namespaces (adds NAMESPACE column)")
+	cmd.Flags().BoolVarP(&watchFlag, "watch", "w", false,
+		"Stream live updates (polls every 2s, Ctrl-C to quit)")
 	return cmd
 }
 
-func runGetPipelines(cmd *cobra.Command, args []string, allNamespaces bool) error {
-	client, ns, err := buildClient()
+func runGetPipelines(cmd *cobra.Command, args []string, allNamespaces, watch bool) error {
+	c, ns, err := buildClient()
 	if err != nil {
 		return fmt.Errorf("get pipelines: %w", err)
 	}
 
+	if !watch {
+		return getPipelinesOnce(cmd.OutOrStdout(), c, ns, args, allNamespaces)
+	}
+
+	// Watch mode: poll every 2s and refresh the terminal output.
+	for {
+		// Clear screen using ANSI escape (same pattern as explain --watch).
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), "\033[H\033[2J")
+		if err := getPipelinesOnce(cmd.OutOrStdout(), c, ns, args, allNamespaces); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\n(watching — press Ctrl-C to quit)")
+		time.Sleep(getPipelinesWatchInterval)
+	}
+}
+
+// getPipelinesOnce fetches and renders a single snapshot of pipeline status.
+func getPipelinesOnce(w io.Writer, c sigs_client.Client, ns string, args []string, allNamespaces bool) error {
 	ctx := context.Background()
 	var opts []sigs_client.ListOption
 	if !allNamespaces {
@@ -53,13 +85,13 @@ func runGetPipelines(cmd *cobra.Command, args []string, allNamespaces bool) erro
 	}
 
 	var pipelines v1alpha1.PipelineList
-	if err := client.List(ctx, &pipelines, opts...); err != nil {
+	if err := c.List(ctx, &pipelines, opts...); err != nil {
 		return fmt.Errorf("list pipelines: %w", err)
 	}
 
 	// Fetch PromotionSteps in the same namespace(s) for per-environment status columns.
 	var promotionSteps v1alpha1.PromotionStepList
-	if err := client.List(ctx, &promotionSteps, opts...); err != nil {
+	if err := c.List(ctx, &promotionSteps, opts...); err != nil {
 		// Non-fatal: fall back to empty step list (env columns will show "-").
 		promotionSteps.Items = nil
 	}
@@ -77,13 +109,12 @@ func runGetPipelines(cmd *cobra.Command, args []string, allNamespaces bool) erro
 		items = filtered
 	}
 
-	out := cmd.OutOrStdout()
 	switch OutputFormat() {
 	case "json":
-		return WriteJSON(out, items)
+		return WriteJSON(w, items)
 	case "yaml":
-		return WriteYAML(out, items)
+		return WriteYAML(w, items)
 	default:
-		return FormatPipelineTableWithOptions(out, items, promotionSteps.Items, allNamespaces)
+		return FormatPipelineTableWithOptions(w, items, promotionSteps.Items, allNamespaces)
 	}
 }

--- a/cmd/kardinal/cmd/get_pipelines_test.go
+++ b/cmd/kardinal/cmd/get_pipelines_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+func buildGetPipelinesScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(s)
+	return s
+}
+
+// TestGetPipelines_WatchFlagRegistered verifies that the --watch / -w flags
+// are correctly registered on the `get pipelines` command.
+func TestGetPipelines_WatchFlagRegistered(t *testing.T) {
+	cmd := newGetPipelinesCmd()
+	f := cmd.Flags().Lookup("watch")
+	require.NotNil(t, f, "--watch flag must be registered on 'get pipelines'")
+	assert.Equal(t, "false", f.DefValue, "--watch must default to false")
+
+	// Shorthand
+	sf := cmd.Flags().ShorthandLookup("w")
+	require.NotNil(t, sf, "-w shorthand must be registered on 'get pipelines'")
+}
+
+// TestGetSteps_WatchFlagRegistered verifies that the --watch / -w flags
+// are correctly registered on the `get steps` command.
+func TestGetSteps_WatchFlagRegistered(t *testing.T) {
+	cmd := newGetStepsCmd()
+	f := cmd.Flags().Lookup("watch")
+	require.NotNil(t, f, "--watch flag must be registered on 'get steps'")
+	assert.Equal(t, "false", f.DefValue, "--watch must default to false")
+
+	sf := cmd.Flags().ShorthandLookup("w")
+	require.NotNil(t, sf, "-w shorthand must be registered on 'get steps'")
+}
+
+// TestGetPipelinesOnce_TableOutput verifies that getPipelinesOnce produces
+// the expected pipeline table output (same as the non-watch path).
+func TestGetPipelinesOnce_TableOutput(t *testing.T) {
+	s := buildGetPipelinesScheme(t)
+
+	pipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.PipelineSpec{
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test"},
+				{Name: "prod"},
+			},
+		},
+	}
+	step := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app-test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kardinal.io/pipeline":    "my-app",
+				"kardinal.io/environment": "test",
+				"kardinal.io/bundle":      "bundle-abc",
+			},
+		},
+		Spec: v1alpha1.PromotionStepSpec{
+			PipelineName: "my-app",
+			Environment:  "test",
+			BundleName:   "bundle-abc",
+		},
+		Status: v1alpha1.PromotionStepStatus{
+			State: "Verified",
+		},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(pipeline, step).Build()
+
+	var buf bytes.Buffer
+	err := getPipelinesOnce(&buf, fc, "default", nil, false)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "my-app", "pipeline name must appear in output")
+	// The table must have at least a header row
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	assert.Greater(t, len(lines), 1, "output must have at least a header and one data row")
+}
+
+// TestGetStepsOnce_TableOutput verifies that getStepsOnce produces
+// the expected steps table output (same as the non-watch path).
+func TestGetStepsOnce_TableOutput(t *testing.T) {
+	s := buildGetPipelinesScheme(t)
+
+	step := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app-test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kardinal.io/pipeline":    "my-app",
+				"kardinal.io/environment": "test",
+				"kardinal.io/bundle":      "bundle-abc",
+			},
+		},
+		Spec: v1alpha1.PromotionStepSpec{
+			PipelineName: "my-app",
+			Environment:  "test",
+			BundleName:   "bundle-abc",
+		},
+		Status: v1alpha1.PromotionStepStatus{
+			State: "Verified",
+		},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(step).Build()
+
+	var buf bytes.Buffer
+	err := getStepsOnce(&buf, fc, "default", "my-app")
+	require.NoError(t, err)
+
+	out := buf.String()
+	// Steps table must have at least headers
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	assert.Greater(t, len(lines), 0, "output must have at least one line")
+}

--- a/cmd/kardinal/cmd/get_steps.go
+++ b/cmd/kardinal/cmd/get_steps.go
@@ -16,6 +16,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
+	"time"
 
 	"github.com/spf13/cobra"
 	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,26 +26,54 @@ import (
 )
 
 func newGetStepsCmd() *cobra.Command {
-	return &cobra.Command{
+	var watchFlag bool
+
+	cmd := &cobra.Command{
 		Use:     "steps <pipeline>",
 		Aliases: []string{"step"},
 		Short:   "List PromotionSteps for a pipeline",
-		Args:    cobra.ExactArgs(1),
-		RunE:    runGetSteps,
+		Long: `List PromotionSteps for a pipeline.
+
+Use --watch / -w to stream live updates (polls every 2s, Ctrl-C to quit).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGetSteps(cmd, args, watchFlag)
+		},
 	}
+	cmd.Flags().BoolVarP(&watchFlag, "watch", "w", false,
+		"Stream live updates (polls every 2s, Ctrl-C to quit)")
+	return cmd
 }
 
-func runGetSteps(cmd *cobra.Command, args []string) error {
-	client, ns, err := buildClient()
+func runGetSteps(cmd *cobra.Command, args []string, watch bool) error {
+	c, ns, err := buildClient()
 	if err != nil {
 		return fmt.Errorf("get steps: %w", err)
 	}
 
 	pipeline := args[0]
+
+	if !watch {
+		return getStepsOnce(cmd.OutOrStdout(), c, ns, pipeline)
+	}
+
+	// Watch mode: poll every 2s and refresh the terminal output.
+	for {
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), "\033[H\033[2J")
+		if err := getStepsOnce(cmd.OutOrStdout(), c, ns, pipeline); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\n(watching — press Ctrl-C to quit)")
+		time.Sleep(getPipelinesWatchInterval) // reuse 2s constant from get_pipelines.go
+	}
+}
+
+// getStepsOnce fetches and renders a single snapshot of PromotionStep status.
+func getStepsOnce(w io.Writer, c sigs_client.Client, ns, pipeline string) error {
 	ctx := context.Background()
 
 	var steps v1alpha1.PromotionStepList
-	if err := client.List(ctx, &steps,
+	if err := c.List(ctx, &steps,
 		sigs_client.InNamespace(ns),
 		sigs_client.MatchingLabels{"kardinal.io/pipeline": pipeline},
 	); err != nil {
@@ -55,7 +85,7 @@ func runGetSteps(cmd *cobra.Command, args []string) error {
 	// non-Superseded bundle names, then filter steps accordingly.
 	activeBundles := make(map[string]bool)
 	var bundles v1alpha1.BundleList
-	if listErr := client.List(ctx, &bundles, sigs_client.InNamespace(ns)); listErr == nil {
+	if listErr := c.List(ctx, &bundles, sigs_client.InNamespace(ns)); listErr == nil {
 		for _, b := range bundles.Items {
 			if b.Spec.Pipeline == pipeline && b.Status.Phase != "Superseded" {
 				activeBundles[b.Name] = true
@@ -76,13 +106,12 @@ func runGetSteps(cmd *cobra.Command, args []string) error {
 		activeSteps = steps.Items
 	}
 
-	out := cmd.OutOrStdout()
 	switch OutputFormat() {
 	case "json":
-		return WriteJSON(out, activeSteps)
+		return WriteJSON(w, activeSteps)
 	case "yaml":
-		return WriteYAML(out, activeSteps)
+		return WriteYAML(w, activeSteps)
 	default:
-		return FormatStepsTable(out, activeSteps)
+		return FormatStepsTable(w, activeSteps)
 	}
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -54,6 +54,7 @@ List all Pipelines with the current Bundle and per-environment status.
 
 ```bash
 kardinal get pipelines
+kardinal get pipelines --watch  # live updates, Ctrl-C to quit
 ```
 
 Output:
@@ -67,6 +68,7 @@ frontend     v2.1.0    Verified   Verified   Verified       1d
 Flags:
 - `-n, --namespace <ns>`: filter by namespace (default: current context namespace)
 - `-A, --all-namespaces`: list across all namespaces
+- `-w, --watch`: stream live updates (polls every 2s, Ctrl-C to quit)
 - `-o, --output <format>`: output format (`table`, `json`, `yaml`)
 
 ### kardinal get steps
@@ -75,6 +77,7 @@ Show all PromotionSteps and PolicyGates for a Pipeline's current promotion.
 
 ```bash
 kardinal get steps <pipeline>
+kardinal get steps <pipeline> --watch  # live updates, Ctrl-C to quit
 ```
 
 Output:
@@ -87,6 +90,7 @@ prod          kustomize-set-image   WaitingForMerge   PR #144 open
 
 Flags:
 - `--bundle <version>`: show steps for a specific Bundle (default: latest active)
+- `-w, --watch`: stream live updates (polls every 2s, Ctrl-C to quit)
 
 ### kardinal get bundles
 

--- a/docs/reference/cli/kardinal-get-pipelines.md
+++ b/docs/reference/cli/kardinal-get-pipelines.md
@@ -2,6 +2,12 @@
 
 List Pipelines
 
+### Synopsis
+
+List Pipelines and their per-environment promotion status.
+
+Use --watch / -w to stream live updates (polls every 2s, Ctrl-C to quit).
+
 ```
 kardinal get pipelines [name] [flags]
 ```
@@ -11,6 +17,7 @@ kardinal get pipelines [name] [flags]
 ```
   -A, --all-namespaces   List pipelines across all namespaces (adds NAMESPACE column)
   -h, --help             help for pipelines
+  -w, --watch            Stream live updates (polls every 2s, Ctrl-C to quit)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/kardinal-get-steps.md
+++ b/docs/reference/cli/kardinal-get-steps.md
@@ -2,6 +2,12 @@
 
 List PromotionSteps for a pipeline
 
+### Synopsis
+
+List PromotionSteps for a pipeline.
+
+Use --watch / -w to stream live updates (polls every 2s, Ctrl-C to quit).
+
 ```
 kardinal get steps <pipeline> [flags]
 ```
@@ -9,7 +15,8 @@ kardinal get steps <pipeline> [flags]
 ### Options
 
 ```
-  -h, --help   help for steps
+  -h, --help    help for steps
+  -w, --watch   Stream live updates (polls every 2s, Ctrl-C to quit)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Summary

Adds `--watch` / `-w` flag to `kardinal get pipelines` and `kardinal get steps`.

```bash
# Watch promotion progress in real-time (polls every 2s, Ctrl-C to quit)
kardinal get pipelines --watch
kardinal get steps my-app --watch
```

Terminal clears and re-renders on each poll (ANSI escape, same pattern as `kardinal explain --watch`).

## Implementation

- **get_pipelines.go**: `--watch`/`-w` flag + `getPipelinesOnce()` helper
- **get_steps.go**: `--watch`/`-w` flag + `getStepsOnce()` helper
- **get_pipelines_test.go** (new): 4 tests (flag registration × 2, table output × 2)
- **cli-reference.md**: Documents `--watch` flag on both commands

## Non-watch path

Identical to before — no regression risk. The refactor extracts `getPipelinesOnce` as a helper function used by both paths.

## Tests

- `TestGetPipelines_WatchFlagRegistered` ✅
- `TestGetSteps_WatchFlagRegistered` ✅
- `TestGetPipelinesOnce_TableOutput` ✅
- `TestGetStepsOnce_TableOutput` ✅