### PR TITLE
fix(docs): correct false CEL claims — schedule.* is a map variable, not a library

### DIFF
--- a/cmd/kardinal/cmd/policy.go
+++ b/cmd/kardinal/cmd/policy.go
@@ -439,8 +439,9 @@ func trimSpace(s string) string {
 }
 
 // newSimulateCELEnvironment creates a CEL environment for policy simulation in the CLI.
-// It registers the same variables and library extensions as pkg/cel.NewCELEnvironment()
-// so that complex expressions using json.*, maps.*, lists.*, random.* work correctly.
+// It registers the same variables and library extensions as
+// pkg/reconciler/policygate/cel_evaluator.go:newEvaluator(), so that complex
+// expressions using json.*, maps.*, lists.*, random.* work correctly in simulate.
 //
 // The import of pkg/cel/library is allowed (see AGENTS.md — only pkg/cel itself is banned
 // outside pkg/reconciler/policygate). pkg/cel/library has no dependency on pkg/cel.
@@ -452,7 +453,7 @@ func newSimulateCELEnvironment() (*cel.Env, error) {
 		cel.Variable("metrics", cel.DynType),
 		cel.Variable("upstream", cel.DynType),
 		cel.Variable("previousBundle", cel.DynType),
-		// kro CEL library extensions — same set as pkg/cel.NewCELEnvironment().
+		// kro CEL library extensions — same set as pkg/reconciler/policygate/cel_evaluator.go.
 		// Ensures expressions like json.unmarshal(...), map1.merge(map2), etc. work in simulate.
 		library.JSON(),
 		library.Maps(),
@@ -467,7 +468,7 @@ func newSimulateCELEnvironment() (*cel.Env, error) {
 
 // simulateCELEvaluate compiles and evaluates a single CEL expression against the given context.
 // Returns (pass, reason, error). Errors are fail-closed (pass=false on error).
-// This is the CLI-local equivalent of pkg/cel.Evaluator.Evaluate() to avoid the banned import.
+// This mirrors pkg/reconciler/policygate/cel_evaluator.go:evaluate() in the CLI context.
 func simulateCELEvaluate(env *cel.Env, expr string, ctx map[string]interface{}) (bool, string, error) {
 	ast, issues := env.Compile(expr)
 	if issues != nil && issues.Err() != nil {

--- a/docs/design/10-graph-first-architecture.md
+++ b/docs/design/10-graph-first-architecture.md
@@ -88,10 +88,18 @@ This is the correct pattern for:
 
 **Q3. Can this be expressed as a CEL extension on the Graph's CEL environment?**
 
-Custom CEL libraries (`schedule.isWeekend()`, `quantity.parse()`) can be registered
-on the Graph's CEL environment via `WithCustomDeclarations`. This is appropriate for
-**stateless, cheap, synchronous** computations (time functions, string utilities,
-Kubernetes quantity parsing).
+Custom CEL libraries (`quantity.parse()`, string utilities) can be registered on the
+Graph's CEL environment via `WithCustomDeclarations`. This is appropriate for
+**stateless, cheap, synchronous** computations.
+
+> **Current status of `schedule.*`:** `schedule.isWeekend`, `schedule.hour`,
+> `schedule.dayOfWeek` are **NOT yet implemented as CEL library extensions**.
+> They are plain map variables injected into the PolicyGate CEL context by the
+> PolicyGate reconciler. They are available in PolicyGate expressions only — they
+> do NOT work in krocodile Graph `readyWhen`/`propagateWhen` expressions.
+> Registering them as a proper Q3 CEL library on the Graph DefaultEnvironment is
+> tracked in `docs/design/11-graph-purity-tech-debt.md` §ScheduleClock Implementation
+> (design goal, not yet shipped).
 
 This is **not** appropriate for:
 - HTTP calls (blocks reconcile loop)
@@ -111,6 +119,15 @@ evaluation in kardinal is either:
 1. A **reconciler that computes a result and writes it to a CRD status** (so Graph
    can read the result via readyWhen), or
 2. A **CEL library extension** registered on the Graph's environment.
+
+> **Note on `pkg/cel/`:** There is no `pkg/cel/NewCELEnvironment()` function.
+> The CEL environment for PolicyGate evaluation is constructed in
+> `pkg/reconciler/policygate/cel_evaluator.go:newEvaluator()` using `cel.NewEnv()`
+> directly, importing `github.com/kubernetes-sigs/kro/pkg/cel/library` extensions.
+> `pkg/cel/` contains only the library sub-package, conversion utilities, and
+> sentinels — it is not a facade with a constructor. Any new feature that needs CEL
+> evaluation must call `cel.NewEnv(...)` directly with explicit library imports, as
+> done in `cel_evaluator.go`. The `pkg/cel/` directory must not grow.
 
 There is no separate "kardinal CEL evaluator" at steady state. `pkg/cel` in its
 current form exists as a transitional artifact (see Known Exceptions below) and

--- a/docs/design/11-graph-purity-tech-debt.md
+++ b/docs/design/11-graph-purity-tech-debt.md
@@ -144,12 +144,16 @@ See §Flat DAG Compilation — Why It Does Not Work below.
 The observable-progress gap this issue was trying to address is solved by #592:
 adding `status.steps[]` to PromotionStep (no architecture change needed).
 
-### #130 and #68 (eliminate pkg/cel): fully unblocked
+### #130 and #68 (eliminate pkg/cel): partially complete
 
-With `ScheduleClock` + `schedule.*` CEL library (from #138 solution), `pkg/cel` can be deleted
-entirely:
-- Non-time-based expressions → Graph Watch nodes (no krocodile needed)
-- Time-based expressions (`schedule.*`) → CEL library on Graph DefaultEnvironment + ScheduleClock trigger
+`pkg/cel/` no longer has an `environment.go` or a `NewCELEnvironment()` constructor — that
+was deleted in #701 and the CEL environment construction moved to
+`pkg/reconciler/policygate/cel_evaluator.go`. What remains in `pkg/cel/` is:
+- `library/` — the kro library sub-package (ALLOWED — imported by cel_evaluator.go)
+- `conversion/` and `sentinels/` — utilities
+
+Full elimination of `pkg/cel/` (moving library imports directly into cel_evaluator.go)
+is blocked on `schedule.*` CEL library (#616) and is tracked there.
 
 ### #400 (Journey 2 multi-cluster): unblocked via Stage 14 implementation
 
@@ -158,17 +162,28 @@ a kardinal implementation task. Journey 2 test can be written once Stage 14 ship
 
 ---
 
-## ScheduleClock Implementation — #138 Unblocked
+## ScheduleClock Implementation — #138 Unblocked (Design Goal, Not Yet Shipped)
 
-> Closes: #138, #130, #68 (eliminates `pkg/cel` entirely)
+> **Status: Design approved. `ScheduleClock` CRD and reconciler are implemented.**
+> **`schedule.*` CEL library extension (Part 2 below) is NOT yet implemented.**
+> **Current state: `schedule.*` values are map variables in the PolicyGate reconciler,**
+> **not CEL library functions on the Graph DefaultEnvironment. See issue #616.**
+>
+> Closes: #138, #130, #68 (eliminates `pkg/cel` entirely) — pending Part 2
 > Suggested by: Ellis Tarn (krocodile author)
 > Architecture: ✅ Pure — Q2 (Owned node) + Q3 (CEL library extension)
 
 ### Problem
 
-Time-based PolicyGate expressions (`!schedule.isWeekend()`, `schedule.hour >= 9`) need
+Time-based PolicyGate expressions (`!schedule.isWeekend`, `schedule.hour >= 9`) need
 periodic re-evaluation. Nothing in the cluster changes when the clock advances — no watch
 event fires, so the Graph never re-evaluates these nodes.
+
+> **Current workaround (in production today):** The PolicyGate reconciler injects
+> `schedule.*` as a plain map variable into the CEL evaluation context. The
+> `ScheduleClock` reconciler re-enqueues all PolicyGates on each tick, triggering
+> re-evaluation. This works, but `schedule.*` is not available in Graph
+> `readyWhen`/`propagateWhen` expressions — only in the PolicyGate CEL context.
 
 ### Solution
 
@@ -213,10 +228,11 @@ status:
   tick: "2026-04-13T14:00:00Z"   # updated every interval
 ```
 
-**2. `schedule.*` CEL library on Graph DefaultEnvironment** — stateless functions:
+**2. `schedule.*` CEL library on Graph DefaultEnvironment** — stateless functions
+**(NOT YET IMPLEMENTED — design goal, tracked in issue #616):**
 
 ```go
-// pkg/cel/schedule/library.go
+// pkg/cel/schedule/library.go  ← does not exist yet
 // Registered on the Graph's DefaultEnvironment via WithCustomDeclarations.
 // schedule.isWeekend() — true if Saturday or Sunday UTC
 // schedule.hour()      — current UTC hour (0-23)
@@ -239,12 +255,11 @@ contains `schedule.` gets an automatic data-flow reference to the `ScheduleClock
     #  clock reference creates a data-flow edge — re-evaluated on every tick
 ```
 
-### What this eliminates
+### What this eliminates (when Part 2 ships)
 
-- `pkg/cel/environment.go` — deleted entirely (#130, #68)
-- `ctrl.Result{RequeueAfter: N}` timer loop in PolicyGate reconciler
-- `pkg/cel/` import in CLI (`cmd/kardinal/policy.go`) — CLI calls server API instead
-- All `time.Now()` / weekday/hour computation in `policygate/reconciler.go`
+- `ctrl.Result{RequeueAfter: N}` timer loop in PolicyGate reconciler (already eliminated — ScheduleClock handles this)
+- All inline `time.Now()` / weekday/hour map computation in `policygate/reconciler.go`
+- `schedule.*` scope limited to PolicyGate (once it's a Graph CEL library, it's available everywhere)
 
 ### One ScheduleClock per cluster is sufficient
 

--- a/pkg/reconciler/policygate/cel_evaluator.go
+++ b/pkg/reconciler/policygate/cel_evaluator.go
@@ -56,8 +56,9 @@ type evaluator struct {
 }
 
 // newEvaluator creates an Evaluator backed by a CEL environment that includes
-// all kro library extensions — the same function set as kro Graph readyWhen
-// expressions. This ensures PolicyGate expressions are compatible with Graph CEL.
+// all kro library extensions — the same extended function set as kro's Graph CEL.
+// (Note: kro Graph expressions and PolicyGate expressions share the same library
+// functions, but they run in separate environments and have different context variables.)
 //
 // Functions available in expressions:
 //   - Standard strings (cel-go/ext)
@@ -68,8 +69,13 @@ type evaluator struct {
 //   - changewindow.isAllowed(name) → bool  (true when the named window is NOT active/blocking)
 //   - changewindow.isBlocked(name) → bool  (true when the named window IS active/blocking)
 //
-// Context variables (populated by buildContext):
-//   - bundle, schedule, environment, metrics, upstream, previousBundle, changewindow
+// Context variables (populated by buildContext in reconciler.go):
+//   - bundle, environment, metrics, upstream, previousBundle, changewindow
+//   - schedule — a plain map variable {isWeekend:bool, hour:int, dayOfWeek:string}
+//     NOTE: schedule.* is a map injection, NOT a CEL library function.
+//     It is only available here (PolicyGate CEL context), not in krocodile
+//     Graph readyWhen/propagateWhen expressions. See issue #616 and
+//     docs/design/11-graph-purity-tech-debt.md §ScheduleClock Implementation.
 func newEvaluator() (*evaluator, error) {
 	env, err := goccel.NewEnv(
 		goccel.Variable("bundle", goccel.DynType),


### PR DESCRIPTION
## Summary

Closes #627. References #616.

Three design doc and one code comment correction. No behavioral changes — docs only.

## What was wrong

Prior agent sessions documented the **intended future state** as current reality:

1. `pkg/cel/NewCELEnvironment()` — claimed as the required constructor for CEL environments. Does not exist. The actual pattern is `cel.NewEnv(...)` with explicit library imports in `cel_evaluator.go`.

2. `schedule.*` as a Q3 CEL library — claimed as registered on the Graph's DefaultEnvironment. Not implemented. It is a plain map variable injected into the PolicyGate reconciler's CEL context (`reconciler.go:284`). It is **not** available in krocodile Graph `readyWhen`/`propagateWhen` expressions.

3. ScheduleClock Implementation section — described the full vision (Part 1: ScheduleClock CRD ✅ + Part 2: schedule.* CEL library ❌) as if both were complete.

## What this PR fixes

- `docs/design/10-graph-first-architecture.md`: Q3 section now has an explicit caveat about the current state of `schedule.*` and a note on the non-existent `NewCELEnvironment()`.
- `docs/design/11-graph-purity-tech-debt.md`: ScheduleClock Implementation header clearly labels Part 2 as a design goal, not shipped; adds a "current workaround" paragraph; corrects `#130/#68` status.
- `pkg/reconciler/policygate/cel_evaluator.go`: `newEvaluator()` comment now accurately documents `schedule.*` as a map variable, states its scope restriction, and links to the tracking issue.

## What this PR does NOT fix

**AGENTS.md §CEL Expressions — kro Library** contains the same false claims about `pkg/cel/NewCELEnvironment()` and uses `!schedule.isWeekend()` (function call syntax) in examples. AGENTS.md is in the agents-must-not-modify list. The specific lines requiring human correction are:

```
Line 290: '...it MUST use pkg/cel/NewCELEnvironment() which registers all kro libraries.'
          → AGENTS.md says to call a function that does not exist.
          Correct: 'construct a cel.NewEnv() with explicit library imports as in cel_evaluator.go'

Line 297: '!schedule.isWeekend()' (function call)
          → schedule.isWeekend is a bool map field, not a function.
          Correct: '!schedule.isWeekend' (no parentheses)

Line 307: '!schedule.isWeekend() && upstream.uat.soakMinutes >= 30'
          → Same: remove () from schedule.isWeekend
```

A human must edit AGENTS.md to fix these three lines.

## Verification

```bash
GOTOOLCHAIN=local go build ./... && go vet ./...
GOTOOLCHAIN=local go test ./pkg/reconciler/policygate/... -race
```
All pass.