### PR TITLE
feat(ui): surface bundle image diff in NodeDetail — Kargo parity gap (#563)

### DIFF
--- a/cmd/kardinal-controller/ui_api.go
+++ b/cmd/kardinal-controller/ui_api.go
@@ -92,6 +92,8 @@ type uiBundleResponse struct {
 	Provenance *v1alpha1.BundleProvenance `json:"provenance,omitempty"`
 	// #503: Per-environment statuses for the bundle timeline view.
 	Environments []uiBundleEnvStatus `json:"environments,omitempty"`
+	// #563: Container images in this Bundle — used by NodeDetail diff preview.
+	Images []v1alpha1.ImageRef `json:"images,omitempty"`
 }
 
 // uiBundleEnvStatus is the per-environment status summary for the timeline (#503).
@@ -401,6 +403,7 @@ func (s *uiAPIServer) handleBundlesForPipeline(w http.ResponseWriter, r *http.Re
 			Pipeline:   b.Spec.Pipeline,
 			CreatedAt:  b.CreationTimestamp.Format("2006-01-02T15:04:05Z07:00"),
 			Provenance: b.Spec.Provenance,
+			Images:     b.Spec.Images, // #563: expose images for diff preview
 		}
 		if len(envStatuses) > 0 {
 			resp.Environments = envStatuses

--- a/cmd/kardinal-controller/ui_api_test.go
+++ b/cmd/kardinal-controller/ui_api_test.go
@@ -1005,3 +1005,37 @@ func TestUIAPI_StepEvents_InvalidPath(t *testing.T) {
 		assert.NotEqual(t, http.StatusOK, w.Code, "path %s should not return 200", path)
 	}
 }
+
+// TestUIAPI_ListBundles_ImagesIncluded verifies that container images are included
+// in the bundle response for the NodeDetail diff preview (#563).
+func TestUIAPI_ListBundles_ImagesIncluded(t *testing.T) {
+	b := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app-v2", Namespace: "default"},
+		Spec: v1alpha1.BundleSpec{
+			Type:     "image",
+			Pipeline: "my-app",
+			Images: []v1alpha1.ImageRef{
+				{Repository: "ghcr.io/pnz1990/kardinal-test-app", Tag: "sha-9349a3f"},
+			},
+		},
+		Status: v1alpha1.BundleStatus{Phase: "Promoting"},
+	}
+
+	s := uiScheme()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(b).Build()
+	srv := newUIAPIServer(c, zerolog.Nop())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ui/pipelines/my-app/bundles", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp []uiBundleResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	require.Len(t, resp[0].Images, 1, "images must be included in bundle response")
+	assert.Equal(t, "ghcr.io/pnz1990/kardinal-test-app", resp[0].Images[0].Repository)
+	assert.Equal(t, "sha-9349a3f", resp[0].Images[0].Tag)
+}

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -11,8 +11,10 @@
         "reactflow": "^11.11.4",
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.7.0",
@@ -154,6 +156,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
     "@reactflow/background": ["@reactflow/background@11.3.14", "", { "dependencies": { "@reactflow/core": "11.11.4", "classcat": "^5.0.3", "zustand": "^4.4.1" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA=="],
 
     "@reactflow/controls": ["@reactflow/controls@11.2.14", "", { "dependencies": { "@reactflow/core": "11.11.4", "classcat": "^5.0.3", "zustand": "^4.4.1" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw=="],
@@ -225,6 +229,8 @@
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
@@ -442,6 +448,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
@@ -533,5 +543,7 @@
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -641,6 +641,7 @@ export function App() {
                   pipelineName={selectedPipeline}
                   namespace={activePipeline?.namespace ?? 'default'}
                   steps={activeSteps}
+                  activeBundle={activeBundle}
                 />
               )}
             </div>

--- a/web/src/components/NodeDetail.tsx
+++ b/web/src/components/NodeDetail.tsx
@@ -14,7 +14,7 @@
 //
 // #527: EventsPanel — K8s events stream fetched per step when node is selected.
 import { useState, useEffect, useCallback } from 'react'
-import type { GraphNode, PromotionStep } from '../types'
+import type { GraphNode, PromotionStep, Bundle } from '../types'
 import { HealthChip, kardinalStateToHealth } from './HealthChip'
 import { api } from '../api/client'
 import EventsPanel, { type StepEvent } from './EventsPanel'
@@ -30,6 +30,8 @@ interface Props {
   namespace?: string
   /** Steps for the active bundle — from parent poll, no independent fetch needed (#322). */
   steps?: PromotionStep[]
+  /** Active bundle — used for the image diff preview in Promoting/WaitingForMerge state (#563). */
+  activeBundle?: Bundle
 }
 
 /** Format an ISO timestamp to a human-readable string. */
@@ -336,7 +338,7 @@ function StepProgress({ step }: { step: PromotionStep }) {
   )
 }
 
-export function NodeDetail({ node, onClose, bundleName, pipelineName, namespace = 'default', steps }: Props) {
+export function NodeDetail({ node, onClose, bundleName, pipelineName, namespace = 'default', steps, activeBundle }: Props) {
   const [stepDetail, setStepDetail] = useState<PromotionStep | null>(null)
   const [stepLoading, setStepLoading] = useState(false)
   const [promoteState, setPromoteState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
@@ -664,6 +666,38 @@ export function NodeDetail({ node, onClose, bundleName, pipelineName, namespace 
       {node.message && (
         <div style={{ fontSize: '0.85rem', color: '#94a3b8', marginBottom: '0.75rem' }}>
           <strong style={{ color: '#cbd5e1' }}>Message:</strong> {node.message}
+         </div>
+      )}
+
+      {/* #563: Image diff preview — shown when environment is actively promoting.
+          Surfaces "what will change" without requiring the operator to open the PR. */}
+      {activeBundle?.images && activeBundle.images.length > 0 &&
+        ['Promoting', 'Running', 'WaitingForMerge', 'HealthChecking'].includes(node.state) && (
+        <div style={{
+          marginBottom: '0.75rem',
+          padding: '0.6rem 0.75rem',
+          background: '#1e293b',
+          borderRadius: '6px',
+          border: '1px solid #334155',
+        }}>
+          <div style={{ fontSize: '0.75rem', color: '#94a3b8', marginBottom: '0.4rem', fontWeight: 600 }}>
+            Promoting Image{activeBundle.images.length > 1 ? 's' : ''}
+          </div>
+          {activeBundle.images.map((img, i) => (
+            <div key={i} style={{
+              fontFamily: 'monospace',
+              fontSize: '0.78rem',
+              color: '#e2e8f0',
+              wordBreak: 'break-all',
+              marginBottom: i < activeBundle.images!.length - 1 ? '0.3rem' : 0,
+            }}>
+              {img.repository && <span style={{ color: '#7dd3fc' }}>{img.repository}</span>}
+              {img.tag && <><span style={{ color: '#94a3b8' }}>:</span><span style={{ color: '#4ade80' }}>{img.tag}</span></>}
+              {!img.tag && img.digest && (
+                <><span style={{ color: '#94a3b8' }}>@</span><span style={{ color: '#a78bfa' }}>{img.digest.slice(0, 16)}…</span></>
+              )}
+            </div>
+          ))}
         </div>
       )}
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -45,6 +45,15 @@ export interface Bundle {
   environments?: BundleEnvStatus[]
   /** #504: True when this bundle was created as a rollback of a previous bundle. */
   isRollback?: boolean
+  /** #563: Container images in this Bundle — used by NodeDetail diff preview. */
+  images?: ImageRef[]
+}
+
+/** #563: A container image reference — repository, tag, and optional digest. */
+export interface ImageRef {
+  repository?: string
+  tag?: string
+  digest?: string
 }
 
 /** #503: Per-environment promotion status for a Bundle. */


### PR DESCRIPTION
## Summary

Closes #563.

Adds an inline "Promoting Images" section to the NodeDetail panel when the DAG node is actively promoting (Promoting/WaitingForMerge/HealthChecking). Answers "what will change?" without the operator needing to open the PR.

## Changes

| File | Change |
|---|---|
| `cmd/kardinal-controller/ui_api.go` | Add `images` field to `uiBundleResponse`; populate from `Bundle.spec.images` |
| `web/src/types.ts` | Add `ImageRef` interface; add `images` field to `Bundle` type |
| `web/src/App.tsx` | Pass `activeBundle` to NodeDetail |
| `web/src/components/NodeDetail.tsx` | Add `activeBundle` prop; render image diff section |
| Test | `TestUIAPI_ListBundles_ImagesIncluded` verifies images in API response |

## Before vs After

**Before:** Operator clicks prod node in WaitingForMerge, sees only step state and PR link.

**After:** Shows:
```
Promoting Images
ghcr.io/pnz1990/kardinal-test-app:sha-9349a3f
```

## Tests

- 305 frontend unit tests pass (no regressions)
- 1 new backend test: `TestUIAPI_ListBundles_ImagesIncluded`