### PR TITLE
docs: arch-audit 2026-04-16 — fix false claims in design docs and translator

### DIFF
--- a/docs/design/10-graph-first-architecture.md
+++ b/docs/design/10-graph-first-architecture.md
@@ -137,23 +137,27 @@ must be eliminated by migrating to one of the patterns above.
 
 ## Upstream Contribution Policy
 
-Two capabilities are currently missing from krocodile that would eliminate
-transitional workarounds:
+One capability is currently missing from krocodile that would eliminate an existing
+workaround. A second was resolved via the `ScheduleClock` pattern.
 
-### Contribution 1: `recheckAfter` (critical)
+### ~~Contribution 1: `recheckAfter`~~ — RESOLVED via ScheduleClock pattern (#641)
 
-**Problem:** Time-based and metric-based gates need periodic re-evaluation.
-Currently the PolicyGate reconciler implements this via `ctrl.Result{RequeueAfter: N}`
-which triggers a watch event that causes the Graph to re-evaluate. This is a
-workaround — it couples the re-evaluation cadence to the PolicyGate reconciler
-rather than expressing it as a Graph primitive.
+> **Status: Superseded.** The `ScheduleClock` CRD (PR #484) provides watch-driven
+> re-evaluation without a krocodile-native `recheckAfter` primitive. This contribution
+> is now **nice-to-have** for the broader krocodile ecosystem, not a kardinal prerequisite.
+> See `docs/design/11-graph-purity-tech-debt.md §ScheduleClock Implementation` and
+> §Pending Upstream Contributions for context.
 
-**Solution:** A native `recheckAfter` field on Graph nodes. When a node's
-`readyWhen` evaluates to false, the Graph controller automatically re-queues the
-node after the specified duration. No external controller needed for time-based gates.
+~~**Problem:** Time-based and metric-based gates need periodic re-evaluation.
+Currently the PolicyGate reconciler implements this via `ctrl.Result{RequeueAfter: N}`...~~
 
-**Upstream target:** `experimental/docs/design/` in krocodile branch.
-Track as: https://github.com/ellistarn/kro/issues (open a proposal)
+The kardinal solution: `ScheduleClock` is an Owned node reconciler that writes
+`status.tick` on a configurable interval, generating real Kubernetes watch events.
+PolicyGate nodes that need periodic re-evaluation Watch the `ScheduleClock` object —
+no `recheckAfter` primitive required.
+
+If contributing upstream to krocodile is desired, the target is
+`experimental/docs/design/` in the krocodile branch. It is not blocking any kardinal work.
 
 ### Contribution 2: `dependsOn` (explicit edges)
 

--- a/docs/design/11-graph-purity-tech-debt.md
+++ b/docs/design/11-graph-purity-tech-debt.md
@@ -144,7 +144,7 @@ See §Flat DAG Compilation — Why It Does Not Work below.
 The observable-progress gap this issue was trying to address is solved by #592:
 adding `status.steps[]` to PromotionStep (no architecture change needed).
 
-### #130 and #68 (eliminate pkg/cel): partially complete
+### #130 and #68 (eliminate pkg/cel): **partially complete — schedule.* library untracked**
 
 `pkg/cel/` no longer has an `environment.go` or a `NewCELEnvironment()` constructor — that
 was deleted in #701 and the CEL environment construction moved to
@@ -152,8 +152,12 @@ was deleted in #701 and the CEL environment construction moved to
 - `library/` — the kro library sub-package (ALLOWED — imported by cel_evaluator.go)
 - `conversion/` and `sentinels/` — utilities
 
-Full elimination of `pkg/cel/` (moving library imports directly into cel_evaluator.go)
-is blocked on `schedule.*` CEL library (#616) and is tracked there.
+The schedule.* CEL library extension (Part 2 of the ScheduleClock design) was tracked in
+issue #616, which is now **closed**. The `schedule.*` functions were NOT promoted to a CEL
+library during that work — they remain as plain map variables injected by the PolicyGate
+reconciler. The blocking condition has changed: this is now unblocked (no krocodile change
+required) but untriaged. If schedule.* as a proper Graph CEL library function is still desired,
+open a new issue — see #645 for context.
 
 ### #400 (Journey 2 multi-cluster): unblocked via Stage 14 implementation
 
@@ -327,28 +331,35 @@ status is a small delta that gives full observability without any structural cha
 
 ---
 
-## Aggregated API Adoption Plan (ellistarn/kro#80)
+## Aggregated API — Future Migration Path (ellistarn/kro#80 Closed Without Merging)
 
-> This section tracks the planned adoption of krocodile's aggregated API design for
-> external system integration. See: https://github.com/ellistarn/kro/pull/80
+> **Status: No upstream implementation.** `ellistarn/kro#80` was closed as a design
+> document without code changes on 2026-04-16 (state: closed, merged_at: null).
+> There is no aggregated API provider in krocodile. See #643 for the audit finding.
+>
+> The PRStatus CRD workaround (#133) was implemented as planned and is in production.
+> Do not block any SCM-related work on the aggregated API — it has no current timeline.
 
-### What it is
+This section describes the migration path **if and when** a krocodile aggregated API
+provider is contributed. It is a future design, not an imminent dependency.
+
+### What the aggregated API design described
 
 A design by the krocodile author for serving external system state as native Kubernetes
-resources via the Kubernetes API Aggregation Layer. The first provider is GitHub (`api.github.com`),
-exposing `GithubArtifact` and `GithubAuthentication` resources. Graphs consume these through
+resources via the Kubernetes API Aggregation Layer. The first provider was to be GitHub (`api.github.com`),
+exposing `GithubArtifact` and `GithubAuthentication` resources. Graphs would consume these through
 existing Watch semantics — no new krocodile primitives required.
 
-Key properties:
+Key properties described:
 - **No CRD sync drift** — state is served live via aggregated apiserver, not copied into CRDs
 - **Request deduplication** — N Graphs watching the same GitHub path produce one upstream API call
 - **ETag-based caching** — `If-None-Match` avoids counting polls against rate limits
 - **Content-hash resourceVersion** — watch events fire only when data actually changes
 - **OAuth device flow** — no PAT management; `kubectl get githubartifacts` shows the auth URL
 
-### What this eliminates in kardinal
+### What this would eliminate in kardinal
 
-When this lands in krocodile, kardinal should refactor the following **in a single PR**:
+If an aggregated API provider for GitHub were contributed to krocodile, kardinal could refactor:
 
 | Logic leak | Current (purity violation) | With aggregated API (pure) |
 |---|---|---|
@@ -362,9 +373,9 @@ When this lands in krocodile, kardinal should refactor the following **in a sing
 This single aggregated API adoption PR would close issues **#128, #133, #140, #143, #149**
 and unblock the Subscription CRD implementation as a clean Watch node.
 
-### Migration path
+### Future migration path
 
-When `ellistarn/kro#80` merges into krocodile mainline:
+If `ellistarn/kro#80` or equivalent is ever contributed to krocodile mainline:
 
 1. Deploy the `github-provider` aggregated API server alongside the kardinal controller
    (ship as an optional component in the kardinal Helm chart — off by default, enabled via
@@ -375,10 +386,7 @@ When `ellistarn/kro#80` merges into krocodile mainline:
 5. Update `kardinal init` to guide users through OAuth device flow instead of PAT creation
 6. Implement Subscription CRD as a Graph watching `GithubArtifact` for SHA changes
 
-**Do not implement the `PRStatus` CRD workaround (#133) if the aggregated API is imminent.**
-If `ellistarn/kro#80` is within 2–3 milestones of merging, skip the workaround and wait for
-the clean path. If it stalls, implement `PRStatus` CRD as a transitional measure and migrate
-when the aggregated API lands.
+**Do not defer any current SCM work on expectation of this landing — it has no timeline.**
 
 ### GitLab provider
 

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -193,8 +193,9 @@ func injectHealthWatchNodes(
 		readyWhen := strings.ReplaceAll(spec.ReadyWhen, "healthNode", nodeID)
 
 		// Build an identity-only template so krocodile detects it as a Watch reference.
-		// Watch reference detection (experimental/controller/types.go: DetectReference):
-		// template has apiVersion + kind + metadata.name; no spec or other fields.
+		// An identity-only template (apiVersion + kind + metadata.name/namespace, no spec
+		// or other fields) is classified ReferenceWatch by krocodile's node.Reference()
+		// method (experimental/controller/types.go:deriveReference — internal).
 		watchNode := graph.GraphNode{
 			ID: nodeID,
 			Template: map[string]interface{}{


### PR DESCRIPTION
## Summary

Architecture audit 2026-04-16. Three false documentation claims corrected. Four GitHub issues opened for code and documentation work not fixable in this session.

## Documentation fixes in this PR

- **`docs/design/10-graph-first-architecture.md`** — §Upstream Contribution Policy: retitled Contribution 1 (`recheckAfter`) as RESOLVED via ScheduleClock pattern. The section previously described recheckAfter as a current open gap while §Exception 1 in the same file said it was resolved. Contradiction eliminated. (#642)

- **`docs/design/11-graph-purity-tech-debt.md`** — §Aggregated API Adoption Plan: updated to reflect that `ellistarn/kro#80` was closed without merging. Removed the advisory "do not implement PRStatus CRD if kro#80 is imminent" (PRStatus is already implemented; the PR is closed). Reframed as a future migration path with no current timeline. (#643)

- **`docs/design/11-graph-purity-tech-debt.md`** — §Previously Blocked §#130 and #68: updated to reflect that issue #616 (the stated blocker) is closed, and that the schedule.* CEL library work is untriaged rather than blocked. (#645)

- **`pkg/translator/translator.go:196`** — stale comment referencing `DetectReference` (now `detectReference`, unexported since krocodile #141). Updated to reference `node.Reference()` public API. (#647)

## Issues opened (code changes — not in this PR)

| Issue | Priority | Finding |
|---|---|---|
| #641 | HIGH | AGENTS.md instructs use of `pkg/cel/NewCELEnvironment()` (deleted). AGENTS.md is protected; requires human to update. |
| #644 | MEDIUM | PromotionStep reconciler reads PRStatus and PolicyGate with no Watch on either — merges may be delayed up to `requeueWaitForMerge`. |
| #646 | HIGH | krocodile is 14 commits behind `745998f` — mandatory upgrade per AGENTS.md (≥5 commits). |

## Not fixed here

- AGENTS.md (`docs/agents/must-not-modify` list) — requires human update for #641.