### PR TITLE
chore(graph): upgrade krocodile pin 745998f → 81c5a03 with compat fixes (#646)

### DIFF
--- a/chart/kardinal-promoter/Chart.yaml
+++ b/chart/kardinal-promoter/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 annotations:
   # The krocodile commit bundled in this chart version.
   # Built and pushed to ghcr.io/pnz1990/kardinal-promoter/krocodile:<commit>
-  krocodile.commit: "745998f"
+  krocodile.commit: "81c5a03"

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -129,7 +129,7 @@ krocodile:
   # This is the commit the release pipeline built the image from.
   # Used as the default image tag when image.tag is not set.
   # Update via the krocodile upgrade protocol in AGENTS.md.
-  pinnedCommit: "745998f"
+  pinnedCommit: "81c5a03"
 
   # -- API group for Graph CRDs.
   apiGroup: "experimental.kro.run"

--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -284,3 +284,11 @@
 | 007 | Distributed Architecture | 📋 Planned | Design doc: docs/design/07-distributed-architecture.md |
 | 008 | Promotion Steps Engine | ✅ Complete | PR #57. SCMProvider, GitClient, Engine, 7 built-in steps, DefaultSequence. |
 | 009 | Config-Only Promotions | ✅ Complete | PR #75. Helm strategy, config-only Bundle type, kustomize-set-image step. |
+
+---
+
+## queue-023 (STANDALONE batch — 2026-04-17)
+
+| Item | Title | Status | PR | Notes |
+|---|---|---|---|---|
+| 901 | WatchKind health nodes for O(1) incremental cache | ✅ Complete | #652 merged | health.labelSelector → krocodile WatchKind; 6 new tests; docs MISS fixed |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,9 +31,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **WatchKind health nodes** — `health.labelSelector` on Pipeline environments switches from Watch (O(n) full list per event) to WatchKind (O(1) incremental cache). Requires krocodile `745998f`+ (#652)
+- **Kargo migration guide** — concept mapping, side-by-side Pipeline vs Kargo YAML, 7-step migration walkthrough in `docs/guides/` (#640)
+- **Operations runbook expanded** — PolicyGate debugging, SCM failure modes, RBAC issues, krocodile restarts, performance tuning added (#639)
+- **Bundle image diff in NodeDetail** — UI compares the current bundle's image against the previous bundle for that environment; closes a Kargo parity gap (#638)
 - **Per-step progress observability** — `PromotionStep.status.steps[]` exposes each step with individual state, start time, and duration (#630)
 - **`kardinal get pipelines --watch`** — real-time promotion progress with live table refresh (#629)
 - **PrometheusRule CRD** — 6 pre-built alerting rules in Helm chart: promotion stuck, high rollback rate, policy gate blocked, SCM errors (#621)
+- **UI: conditions summary and reason** — NodeDetail shows Kubernetes Conditions table with reason column; improved empty-state onboarding (#529, #530)
+- **UI: Kubernetes events stream** — timestamped event history per PromotionStep in NodeDetail (#560)
+- **UI: cross-environment error aggregation** — groups PromotionStep failures by type across environments; shows affected count (#564)
 - **krocodile upgraded to `745998f`** — Decorator bootstrap primitive, Definition compile-time type inference, forEach array format support, DAG finalizer guard for non-resource nodes (#614)
 
 ### Fixed

--- a/hack/install-krocodile.sh
+++ b/hack/install-krocodile.sh
@@ -16,12 +16,17 @@ set -euo pipefail
 # ── Pinned version ─────────────────────────────────────────────────────────────
 # Update this when intentionally upgrading krocodile.
 # Minimum required: 1b0ce353 (fixes double-dispatch race in DAG coordinator)
-# Last verified:    745998f (2026-04-15 — stdlib: Decorator as bootstrap primitive, Kind built on
-#                           Decorator; watch-kind → watchKind rename; forEach array format support;
-#                           DAG finalizer guard for non-resource nodes; Definition compile-time
-#                           type inference via SchemaResolver)
+# Last verified:    81c5a03 (2026-04-17 — 21 commits since 745998f; highlights:
+#                           - P0 correctness: WatchKind cache loss on GET error fixed (#136)
+#                           - P0 correctness: empty WatchKind no longer vacuous-true (#136)
+#                           - Stable topological sort via min-heap Kahn's (#127, #134)
+#                           - ResolvedReference type split (internal only — no kardinal impact)
+#                           - SSA field manager format: <name>.<namespace>.internal.kro.run (#139)
+#                           - Singleton node ID rename (internal — kardinal uses Watch/Own only)
+#                           - RGD compat test harness added (#130, #137, #146)
+#                           - ForEach parent scope publish order fix (#136))
 KROCODILE_REPO="https://github.com/ellistarn/kro.git"
-KROCODILE_COMMIT="${KROCODILE_COMMIT:-745998f}"
+KROCODILE_COMMIT="${KROCODILE_COMMIT:-81c5a03}"
 KROCODILE_IMAGE="krocodile-graph-controller:${KROCODILE_COMMIT}"
 KIND_CLUSTER="${KIND_CLUSTER:-kardinal-e2e}"
 

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -207,14 +207,18 @@ func injectHealthWatchNodes(
 			// We use the flat top-level form as it is simpler and matches the
 			// krocodile source exactly.
 			//
-			// The namespace is passed separately via graph.GetNamespace() in krocodile
-			// (the Graph object's namespace drives the list namespace). We do NOT
-			// include namespace in the template to avoid conflicting with krocodile's
-			// namespace handling.
+			// Namespace: krocodile ≥ 81c5a03 changed WatchKind namespace from
+			// graph.GetNamespace() to tmpl["metadata"]["namespace"] (absent = cluster-wide).
+			// We must include the namespace to scope the watch to the environment namespace.
+			// Note: metadata.name is intentionally omitted — krocodile uses its absence to
+			// classify this as ReferenceWatchKind rather than ReferenceWatch.
 			nodeTemplate = map[string]interface{}{
 				"apiVersion": spec.APIVersion,
 				"kind":       spec.Kind,
 				"selector":   spec.LabelSelector,
+				"metadata": map[string]interface{}{
+					"namespace": spec.Namespace,
+				},
 			}
 		} else {
 			// Watch: identity-only template (apiVersion + kind + metadata.name).

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -234,6 +234,7 @@ func injectHealthWatchNodes(
 			}
 		}
 
+		// Build the watch node.
 		watchNode := graph.GraphNode{
 			ID:        nodeID,
 			Template:  nodeTemplate,

--- a/pkg/translator/translator_health_test.go
+++ b/pkg/translator/translator_health_test.go
@@ -125,10 +125,11 @@ func TestInjectHealthWatchNodes_Resource(t *testing.T) {
 			"metadata must only have name/namespace for Watch-reference detection")
 	}
 
-	// krocodile >= 81c5a03: Watch nodes must NOT have ReadyWhen.
-	// deriveReference() upgrades Watch+ReadyWhen -> ReferenceUnresolved -> SSA on user workloads.
-	assert.Empty(t, watchNode.ReadyWhen, "Watch node must have no ReadyWhen (krocodile >= 81c5a03 compat)")
-	assert.Empty(t, watchNode.PropagateWhen, "Watch node must have no PropagateWhen")
+	// ReadyWhen must reference the actual node ID (not the placeholder "healthNode")
+	require.NotEmpty(t, watchNode.ReadyWhen)
+	assert.Contains(t, watchNode.ReadyWhen[0], "healthProd", "readyWhen must reference node ID")
+	assert.NotContains(t, watchNode.ReadyWhen[0], "healthNode", "placeholder must be substituted")
+	assert.Contains(t, watchNode.ReadyWhen[0], "Available", "readyWhen checks Available condition")
 }
 
 // TestInjectHealthWatchNodes_ArgoCD verifies health.type=argocd Watch node.
@@ -152,8 +153,9 @@ func TestInjectHealthWatchNodes_ArgoCD(t *testing.T) {
 	assert.Equal(t, "myapp-prod", md["name"], "application name = pipeline + env")
 	assert.Equal(t, "argocd", md["namespace"])
 
-	// krocodile >= 81c5a03: Watch nodes must NOT have ReadyWhen.
-	assert.Empty(t, watchNode.ReadyWhen, "Watch node must have no ReadyWhen (krocodile >= 81c5a03 compat)")
+	require.NotEmpty(t, watchNode.ReadyWhen)
+	assert.Contains(t, watchNode.ReadyWhen[0], "Healthy")
+	assert.Contains(t, watchNode.ReadyWhen[0], "Synced")
 }
 
 // TestInjectHealthWatchNodes_Flux verifies health.type=flux Watch node.
@@ -177,8 +179,8 @@ func TestInjectHealthWatchNodes_Flux(t *testing.T) {
 	assert.Equal(t, "myapp-staging", md["name"])
 	assert.Equal(t, "flux-system", md["namespace"])
 
-	// krocodile >= 81c5a03: Watch nodes must NOT have ReadyWhen.
-	assert.Empty(t, watchNode.ReadyWhen, "Watch node must have no ReadyWhen (krocodile >= 81c5a03 compat)")
+	require.NotEmpty(t, watchNode.ReadyWhen)
+	assert.Contains(t, watchNode.ReadyWhen[0], "Ready")
 }
 
 // TestInjectHealthWatchNodes_ArgoRollouts verifies health.type=argoRollouts Watch node.
@@ -221,8 +223,7 @@ func TestInjectHealthWatchNodes_Flagger(t *testing.T) {
 	tmpl := watchNode.Template
 	assert.Equal(t, "flagger.app/v1beta1", tmpl["apiVersion"])
 	assert.Equal(t, "Canary", tmpl["kind"])
-	// krocodile >= 81c5a03: Watch nodes must NOT have ReadyWhen.
-	assert.Empty(t, watchNode.ReadyWhen, "Watch node must have no ReadyWhen (krocodile >= 81c5a03 compat)")
+	assert.Contains(t, watchNode.ReadyWhen[0], "Succeeded")
 }
 
 // TestInjectHealthWatchNodes_MultipleEnvs verifies multiple environments each get
@@ -523,8 +524,7 @@ func TestInjectHealthWatchNodes_ResourceWatchKindVsWatch(t *testing.T) {
 	// Watch: must have metadata.name
 	md := tmplWatch["metadata"].(map[string]interface{})
 	assert.Equal(t, "myapp", md["name"])
-	// krocodile ≥ 81c5a03: Watch node must NOT have ReadyWhen.
-	assert.Empty(t, watchNode.ReadyWhen, "Watch node must have no ReadyWhen (krocodile ≥ 81c5a03 compat)")
+	assert.Contains(t, watchNode.ReadyWhen[0], "healthUat.status.conditions.exists(")
 
 	// WatchKind case: with LabelSelector
 	watchKindPipeline := makePipeline("myapp", []kardinalv1alpha1.EnvironmentSpec{
@@ -553,8 +553,6 @@ func TestInjectHealthWatchNodes_ResourceWatchKindVsWatch(t *testing.T) {
 	// WatchKind: must have top-level selector
 	_, hasSelector := tmplWatchKind["selector"]
 	assert.True(t, hasSelector, "WatchKind node must have top-level selector")
-	// WatchKind CAN have ReadyWhen (krocodile only upgrades ReferenceWatch, not WatchKind).
-	require.NotEmpty(t, watchKindNode.ReadyWhen, "WatchKind node must have ReadyWhen with .all() predicate")
 	assert.Contains(t, watchKindNode.ReadyWhen[0], ".all(",
-		"WatchKind readyWhen must use .all() list predicate")
+		"WatchKind readyWhen must use .all() predicate")
 }

--- a/pkg/translator/translator_health_test.go
+++ b/pkg/translator/translator_health_test.go
@@ -125,11 +125,10 @@ func TestInjectHealthWatchNodes_Resource(t *testing.T) {
 			"metadata must only have name/namespace for Watch-reference detection")
 	}
 
-	// ReadyWhen must reference the actual node ID (not the placeholder "healthNode")
-	require.NotEmpty(t, watchNode.ReadyWhen)
-	assert.Contains(t, watchNode.ReadyWhen[0], "healthProd", "readyWhen must reference node ID")
-	assert.NotContains(t, watchNode.ReadyWhen[0], "healthNode", "placeholder must be substituted")
-	assert.Contains(t, watchNode.ReadyWhen[0], "Available", "readyWhen checks Available condition")
+	// krocodile >= 81c5a03: Watch nodes must NOT have ReadyWhen.
+	// deriveReference() upgrades Watch+ReadyWhen -> ReferenceUnresolved -> SSA on user workloads.
+	assert.Empty(t, watchNode.ReadyWhen, "Watch node must have no ReadyWhen (krocodile >= 81c5a03 compat)")
+	assert.Empty(t, watchNode.PropagateWhen, "Watch node must have no PropagateWhen")
 }
 
 // TestInjectHealthWatchNodes_ArgoCD verifies health.type=argocd Watch node.
@@ -153,9 +152,8 @@ func TestInjectHealthWatchNodes_ArgoCD(t *testing.T) {
 	assert.Equal(t, "myapp-prod", md["name"], "application name = pipeline + env")
 	assert.Equal(t, "argocd", md["namespace"])
 
-	require.NotEmpty(t, watchNode.ReadyWhen)
-	assert.Contains(t, watchNode.ReadyWhen[0], "Healthy")
-	assert.Contains(t, watchNode.ReadyWhen[0], "Synced")
+	// krocodile >= 81c5a03: Watch nodes must NOT have ReadyWhen.
+	assert.Empty(t, watchNode.ReadyWhen, "Watch node must have no ReadyWhen (krocodile >= 81c5a03 compat)")
 }
 
 // TestInjectHealthWatchNodes_Flux verifies health.type=flux Watch node.
@@ -179,8 +177,8 @@ func TestInjectHealthWatchNodes_Flux(t *testing.T) {
 	assert.Equal(t, "myapp-staging", md["name"])
 	assert.Equal(t, "flux-system", md["namespace"])
 
-	require.NotEmpty(t, watchNode.ReadyWhen)
-	assert.Contains(t, watchNode.ReadyWhen[0], "Ready")
+	// krocodile >= 81c5a03: Watch nodes must NOT have ReadyWhen.
+	assert.Empty(t, watchNode.ReadyWhen, "Watch node must have no ReadyWhen (krocodile >= 81c5a03 compat)")
 }
 
 // TestInjectHealthWatchNodes_ArgoRollouts verifies health.type=argoRollouts Watch node.
@@ -223,7 +221,8 @@ func TestInjectHealthWatchNodes_Flagger(t *testing.T) {
 	tmpl := watchNode.Template
 	assert.Equal(t, "flagger.app/v1beta1", tmpl["apiVersion"])
 	assert.Equal(t, "Canary", tmpl["kind"])
-	assert.Contains(t, watchNode.ReadyWhen[0], "Succeeded")
+	// krocodile >= 81c5a03: Watch nodes must NOT have ReadyWhen.
+	assert.Empty(t, watchNode.ReadyWhen, "Watch node must have no ReadyWhen (krocodile >= 81c5a03 compat)")
 }
 
 // TestInjectHealthWatchNodes_MultipleEnvs verifies multiple environments each get
@@ -481,9 +480,16 @@ func TestInjectHealthWatchNodes_ResourceWatchKind(t *testing.T) {
 	assert.Equal(t, "apps/v1", tmpl["apiVersion"])
 	assert.Equal(t, "Deployment", tmpl["kind"])
 
-	// WatchKind: must NOT have metadata block (krocodile WatchKind detection requires no metadata.name).
-	_, hasMetadata := tmpl["metadata"]
-	assert.False(t, hasMetadata, "WatchKind node template must NOT have metadata block")
+	// WatchKind: metadata IS present (with namespace for scoping) but must NOT have metadata.name.
+	// krocodile ≥ 81c5a03 changed WatchKind namespace from graph.GetNamespace() to
+	// tmpl["metadata"]["namespace"] (absent = cluster-wide list). We include namespace to scope
+	// the watch to the environment namespace. The absence of metadata.name is what krocodile uses
+	// to classify as ReferenceWatchKind (types.go:DetectReference checks !hasName).
+	md, hasMd := tmpl["metadata"].(map[string]interface{})
+	require.True(t, hasMd, "WatchKind node template must have metadata block (for namespace scoping)")
+	_, hasName := md["name"]
+	assert.False(t, hasName, "WatchKind node template must NOT have metadata.name")
+	assert.Equal(t, "prod", md["namespace"], "WatchKind must have metadata.namespace = env name")
 
 	// WatchKind: must have top-level "selector" field (krocodile node.go:reconcileWatchKind
 	// extracts selector from tmpl["selector"] or tmpl["metadata"]["selector"]).
@@ -491,10 +497,6 @@ func TestInjectHealthWatchNodes_ResourceWatchKind(t *testing.T) {
 	require.True(t, ok, "WatchKind node template must have top-level 'selector' of type map[string]string")
 	assert.Equal(t, "nginx", labelSelector["app"])
 	assert.Equal(t, "nginx", labelSelector["kardinal.io/pipeline"])
-
-	// WatchKind: must NOT have metadata block (krocodile WatchKind detection requires no metadata.name).
-	_, hasMetadata = tmpl["metadata"]
-	assert.False(t, hasMetadata, "WatchKind node template must NOT have metadata block")
 
 	// ReadyWhen must use list.all() form.
 	require.NotEmpty(t, watchNode.ReadyWhen)
@@ -521,7 +523,8 @@ func TestInjectHealthWatchNodes_ResourceWatchKindVsWatch(t *testing.T) {
 	// Watch: must have metadata.name
 	md := tmplWatch["metadata"].(map[string]interface{})
 	assert.Equal(t, "myapp", md["name"])
-	assert.Contains(t, watchNode.ReadyWhen[0], "healthUat.status.conditions.exists(")
+	// krocodile ≥ 81c5a03: Watch node must NOT have ReadyWhen.
+	assert.Empty(t, watchNode.ReadyWhen, "Watch node must have no ReadyWhen (krocodile ≥ 81c5a03 compat)")
 
 	// WatchKind case: with LabelSelector
 	watchKindPipeline := makePipeline("myapp", []kardinalv1alpha1.EnvironmentSpec{
@@ -540,12 +543,18 @@ func TestInjectHealthWatchNodes_ResourceWatchKindVsWatch(t *testing.T) {
 	watchKindNode := findHealthNode(gWatchKind, "uat")
 	require.NotNil(t, watchKindNode)
 	tmplWatchKind := watchKindNode.Template
-	// WatchKind: must NOT have metadata block (krocodile WatchKind has no metadata.name)
-	_, hasMetadata := tmplWatchKind["metadata"]
-	assert.False(t, hasMetadata, "WatchKind node must not have a metadata block")
+	// WatchKind: metadata IS present (with namespace) but must NOT have metadata.name.
+	// krocodile ≥ 81c5a03: WatchKind namespace from tmpl["metadata"]["namespace"], not graph.GetNamespace().
+	wkMd, hasMd := tmplWatchKind["metadata"].(map[string]interface{})
+	require.True(t, hasMd, "WatchKind node must have metadata block for namespace scoping")
+	_, hasName := wkMd["name"]
+	assert.False(t, hasName, "WatchKind node must not have metadata.name")
+	assert.Equal(t, "uat", wkMd["namespace"], "WatchKind must scope to env namespace")
 	// WatchKind: must have top-level selector
 	_, hasSelector := tmplWatchKind["selector"]
 	assert.True(t, hasSelector, "WatchKind node must have top-level selector")
+	// WatchKind CAN have ReadyWhen (krocodile only upgrades ReferenceWatch, not WatchKind).
+	require.NotEmpty(t, watchKindNode.ReadyWhen, "WatchKind node must have ReadyWhen with .all() predicate")
 	assert.Contains(t, watchKindNode.ReadyWhen[0], ".all(",
-		"WatchKind readyWhen must use .all() predicate")
+		"WatchKind readyWhen must use .all() list predicate")
 }


### PR DESCRIPTION
## Summary

Upgrades krocodile from 745998f to 81c5a03 (21 commits). Includes compat fixes for a breaking behavioral change in this version.

## Breaking change in krocodile 81c5a03

**Symptom**: Health Watch nodes would cause krocodile to SSA-patch user Deployments.

**Root cause**: krocodile's `deriveReference()` now upgrades Watch+ReadyWhen → ReferenceUnresolved. On existing Deployments (no graph identity labels), this resolves to ReferenceContribute → SSA patch. Source: `experimental/controller/types.go:deriveReference`.

**Fix**: Removed `ReadyWhen` from health Watch nodes in `pkg/translator/translator.go`. The health condition is propagated to the companion PromotionStep node only (where it was already going). WatchKind nodes retain ReadyWhen (deriveReference only upgrades ReferenceWatch, not ReferenceWatchKind).

**Additional compat fix**: krocodile 81c5a03 changed WatchKind namespace scoping from `graph.GetNamespace()` to `tmpl["metadata"]["namespace"]`. Updated WatchKind template to include `metadata.namespace`.

## Non-breaking changes in 81c5a03

These required no kardinal changes:
- Reference → ResolvedReference type split (internal reconciler)
- `DetectReference` → `detectReference` (private — kardinal doesn't call it directly)
- `labelSafeGraphName` truncation for long graph names (additive)
- Declaration-order-stable topological sort via min-heap Kahn's
- SSA field manager format change (internal)
- Compat test suite additions

## Primitive rethink (5th upgrade check)

Checked blocked-on-krocodile issues:
- `gh issue list --repo pnz1990/kardinal-promoter --label blocked-on-krocodile --state open` → 0 issues

New capabilities in this batch (81c5a03):
- Singleton E2E via template expressions → Not applicable (kardinal doesn't use Singleton)
- Declaration-order-stable sort → Could simplify our Graph spec generation order checks if we were doing them — we're not.
- No kardinal simplifications identified from this upgrade batch.

## Acceptance

```bash
go test ./pkg/translator/... -race -count=1
# All TestInjectHealthWatchNodes_* pass
# Watch nodes have empty ReadyWhen
# WatchKind nodes retain ReadyWhen with .all() predicate
```

Closes #646