### PR TITLE
fix(controller): add Watch on PRStatus and PolicyGate in PromotionStep reconciler (#644)

### DIFF
--- a/pkg/reconciler/promotionstep/internal_test.go
+++ b/pkg/reconciler/promotionstep/internal_test.go
@@ -14,6 +14,7 @@
 package promotionstep
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -21,7 +22,11 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // TestExtractRepo verifies that GitHub PR URLs are parsed into "owner/repo" format.
@@ -204,4 +209,106 @@ func TestUpdateStepStatuses_Idempotent(t *testing.T) {
 	updateStepStatuses(ps, seq, 1, false, "")
 	assert.Equal(t, v1alpha1.StepExecutionCompleted, ps.Status.Steps[0].State, "idempotent: step 0 stays Completed")
 	assert.Equal(t, firstCompletedAt, ps.Status.Steps[0].CompletedAt, "idempotent: completedAt unchanged")
+}
+
+// newTestScheme creates a runtime.Scheme with all required types registered.
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return scheme
+}
+
+// TestPRStatusMapper verifies that prStatusMapper re-enqueues the PromotionStep
+// that owns the changed PRStatus. This validates the Watch registration logic
+// added in #644 to eliminate polling in the WaitingForMerge state.
+func TestPRStatusMapper(t *testing.T) {
+	scheme := newTestScheme(t)
+	ctx := context.Background()
+
+	step := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-1", Namespace: "default"},
+		Spec:       v1alpha1.PromotionStepSpec{PRStatusRef: "prstatus-1"},
+	}
+	otherStep := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-2", Namespace: "default"},
+		Spec:       v1alpha1.PromotionStepSpec{PRStatusRef: "prstatus-other"},
+	}
+	prs := &v1alpha1.PRStatus{
+		ObjectMeta: metav1.ObjectMeta{Name: "prstatus-1", Namespace: "default"},
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).
+		WithObjects(step, otherStep, prs).
+		Build()
+
+	r := &Reconciler{Client: fakeClient}
+	reqs := r.prStatusMapper(ctx, prs)
+
+	require.Len(t, reqs, 1, "must enqueue exactly the owning PromotionStep")
+	assert.Equal(t, "step-1", reqs[0].Name)
+	assert.Equal(t, "default", reqs[0].Namespace)
+}
+
+// TestPRStatusMapper_UnmatchedPRStatus verifies that a PRStatus with no owning
+// PromotionStep produces no re-enqueue requests.
+func TestPRStatusMapper_UnmatchedPRStatus(t *testing.T) {
+	scheme := newTestScheme(t)
+	ctx := context.Background()
+
+	step := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-1", Namespace: "default"},
+		Spec:       v1alpha1.PromotionStepSpec{PRStatusRef: "prstatus-different"},
+	}
+	prs := &v1alpha1.PRStatus{
+		ObjectMeta: metav1.ObjectMeta{Name: "prstatus-1", Namespace: "default"},
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).
+		WithObjects(step, prs).
+		Build()
+
+	r := &Reconciler{Client: fakeClient}
+	reqs := r.prStatusMapper(ctx, prs)
+	assert.Empty(t, reqs, "no PromotionStep owns this PRStatus")
+}
+
+// TestPolicyGateMapper verifies that policyGateMapper re-enqueues all
+// PromotionSteps in the same namespace as the changed PolicyGate.
+func TestPolicyGateMapper(t *testing.T) {
+	scheme := newTestScheme(t)
+	ctx := context.Background()
+
+	step1 := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-1", Namespace: "default"},
+	}
+	step2 := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-2", Namespace: "default"},
+	}
+	otherNSStep := &v1alpha1.PromotionStep{
+		ObjectMeta: metav1.ObjectMeta{Name: "step-3", Namespace: "other-ns"},
+	}
+	gate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{Name: "gate-1", Namespace: "default"},
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).
+		WithObjects(step1, step2, otherNSStep, gate).
+		Build()
+
+	r := &Reconciler{Client: fakeClient}
+	reqs := r.policyGateMapper(ctx, gate)
+
+	// Must enqueue only steps in the same namespace
+	require.Len(t, reqs, 2, "must enqueue all PromotionSteps in the same namespace")
+	names := map[string]bool{}
+	for _, req := range reqs {
+		assert.Equal(t, "default", req.Namespace)
+		names[req.Name] = true
+	}
+	assert.True(t, names["step-1"])
+	assert.True(t, names["step-2"])
+	assert.False(t, names["step-3"], "steps in other namespaces must not be enqueued")
 }

--- a/pkg/reconciler/promotionstep/internal_test.go
+++ b/pkg/reconciler/promotionstep/internal_test.go
@@ -18,15 +18,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 )
 
 // TestExtractRepo verifies that GitHub PR URLs are parsed into "owner/repo" format.

--- a/pkg/reconciler/promotionstep/internal_test.go
+++ b/pkg/reconciler/promotionstep/internal_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 

--- a/pkg/reconciler/promotionstep/internal_test.go
+++ b/pkg/reconciler/promotionstep/internal_test.go
@@ -18,12 +18,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"

--- a/pkg/reconciler/promotionstep/reconciler.go
+++ b/pkg/reconciler/promotionstep/reconciler.go
@@ -34,6 +34,8 @@ import (
 	builderutil "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
 	"github.com/kardinal-promoter/kardinal-promoter/pkg/health"
@@ -1018,6 +1020,13 @@ func (r *Reconciler) patchState(ctx context.Context, ps *v1alpha1.PromotionStep,
 // PromotionSteps matching the agent's shard label are enqueued. This replaces the
 // silent Go-level skip (PS-3 in docs/design/11-graph-purity-tech-debt.md) with a
 // declarative controller-level filter that is observable via label selectors.
+//
+// Additionally registers Watches on PRStatus and PolicyGate CRDs:
+//   - PRStatus: re-enqueue the owning PromotionStep when status.merged changes.
+//     Without this Watch, a step in WaitingForMerge would only react after
+//     requeueWaitForMerge, defeating the purpose of the PRStatus CRD.
+//   - PolicyGate: re-enqueue PromotionSteps in the same namespace when any gate
+//     changes status.ready, reducing latency for pre-deploy gate advancement.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	b := ctrl.NewControllerManagedBy(mgr)
 	if r.Shard != "" {
@@ -1029,7 +1038,56 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	} else {
 		b = b.For(&v1alpha1.PromotionStep{})
 	}
+
+	b = b.Watches(&v1alpha1.PRStatus{}, handler.EnqueueRequestsFromMapFunc(r.prStatusMapper))
+	b = b.Watches(&v1alpha1.PolicyGate{}, handler.EnqueueRequestsFromMapFunc(r.policyGateMapper))
+
 	return b.Complete(r)
+}
+
+// prStatusMapper re-enqueues the PromotionStep that owns the changed PRStatus.
+// The owning step is identified via ps.Spec.PRStatusRef == changed PRStatus name.
+// This ensures the WaitingForMerge handler runs immediately when PRStatus.status.merged
+// flips to true, rather than waiting for requeueWaitForMerge. (#644)
+func (r *Reconciler) prStatusMapper(ctx context.Context, obj client.Object) []reconcile.Request {
+	prs := obj.(*v1alpha1.PRStatus)
+	var stepList v1alpha1.PromotionStepList
+	if err := r.List(ctx, &stepList, client.InNamespace(prs.GetNamespace())); err != nil {
+		return nil
+	}
+	var reqs []reconcile.Request
+	for _, step := range stepList.Items {
+		if step.Spec.PRStatusRef == prs.GetName() {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      step.Name,
+					Namespace: step.Namespace,
+				},
+			})
+		}
+	}
+	return reqs
+}
+
+// policyGateMapper re-enqueues all PromotionSteps in the namespace when a
+// PolicyGate changes status.ready. This reduces latency for pre-deploy gate
+// advancement. (#644)
+func (r *Reconciler) policyGateMapper(ctx context.Context, obj client.Object) []reconcile.Request {
+	gate := obj.(*v1alpha1.PolicyGate)
+	var stepList v1alpha1.PromotionStepList
+	if err := r.List(ctx, &stepList, client.InNamespace(gate.GetNamespace())); err != nil {
+		return nil
+	}
+	reqs := make([]reconcile.Request, 0, len(stepList.Items))
+	for _, step := range stepList.Items {
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      step.Name,
+				Namespace: step.Namespace,
+			},
+		})
+	}
+	return reqs
 }
 
 // shardMatchPredicate implements sigs.k8s.io/controller-runtime/pkg/predicate.Predicate


### PR DESCRIPTION
## Summary

Fixes the missing Watch registrations in the PromotionStep reconciler's `SetupWithManager`. Without these Watches, state transitions that depend on PRStatus and PolicyGate changes are delayed by the full requeue period.

## Root cause

`SetupWithManager` only had `.For(&v1alpha1.PromotionStep{})`. It didn't register Watches on:
1. **PRStatus** — read at line 483 to advance WaitingForMerge → HealthChecking
2. **PolicyGate** — read at line 889 in `checkPreDeployGates`

## Fix

Added two Watches:
- **prStatusMapper**: Re-enqueues the PromotionStep whose `spec.prStatusRef` matches the changed PRStatus name. When `PRStatus.status.merged` flips to `true`, the step is enqueued immediately (~1s latency) instead of after `requeueWaitForMerge` (30s default).
- **policyGateMapper**: Re-enqueues all PromotionSteps in the namespace when any PolicyGate's `status.ready` changes.

Both mappers extracted as named Reconciler methods for testability.

## Tests

```
TestPRStatusMapper — enqueues only the owning PromotionStep
TestPRStatusMapper_UnmatchedPRStatus — no enqueue when no step owns the PRStatus
TestPolicyGateMapper — enqueues all steps in same namespace
```

Closes #644