### PR TITLE
refactor(policygate): move upstreamEnvironment from spec to annotation (#618)

### DIFF
--- a/api/v1alpha1/policygate_types.go
+++ b/api/v1alpha1/policygate_types.go
@@ -35,12 +35,6 @@ type PolicyGateSpec struct {
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
-	// UpstreamEnvironment is set by the kro Graph controller via CEL expression
-	// substitution. It carries the resolved state of the upstream PromotionStep
-	// that must be Verified before this gate is evaluated.
-	// +optional
-	UpstreamEnvironment string `json:"upstreamEnvironment,omitempty"`
-
 	// When controls when this gate is evaluated in the promotion lifecycle (K-02).
 	// "pre-deploy" (default: post-deploy): evaluated before git operations start.
 	//   If not ready, the PromotionStep stays in Pending and no git-clone begins.

--- a/config/crd/bases/kardinal.io_policygates.yaml
+++ b/config/crd/bases/kardinal.io_policygates.yaml
@@ -170,12 +170,6 @@ spec:
                   SkipPermission controls whether bundles with intent.skipEnvironments can
                   bypass this gate. When false, skip requests are denied.
                 type: boolean
-              upstreamEnvironment:
-                description: |-
-                  UpstreamEnvironment is set by the kro Graph controller via CEL expression
-                  substitution. It carries the resolved state of the upstream PromotionStep
-                  that must be Verified before this gate is evaluated.
-                type: string
               when:
                 default: post-deploy
                 description: |-

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -587,17 +587,26 @@ func buildPolicyGateNode(
 			"kardinal.io/applies-to": appliesToLabel,
 		},
 	}
+	// Add upstream DAG edge annotation to maintain krocodile dependency ordering.
+	// krocodile's collectStrings() scans all string values in the template recursively,
+	// so placing the ${upstream.status.state} reference in an annotation still creates
+	// the DAG edge from the upstream PromotionStep to this PolicyGate node (#618).
+	// Using an annotation instead of spec.upstreamEnvironment avoids user confusion:
+	// users reading PolicyGate spec no longer see controller-internal wiring.
+	if len(upstreams) > 0 {
+		templateAnnotations := map[string]interface{}{
+			"kardinal.io/upstream-ref": fmt.Sprintf("${%s.status.state}", upstreams[0]),
+		}
+		templateMeta["annotations"] = templateAnnotations
+	}
 
 	templateSpec := map[string]interface{}{
 		"expression":      gate.Spec.Expression,
 		"message":         gate.Spec.Message,
 		"recheckInterval": gate.Spec.RecheckInterval,
 	}
-
-	// Add upstream reference to create dependency edge
-	if len(upstreams) > 0 {
-		templateSpec["upstreamEnvironment"] = fmt.Sprintf("${%s.status.state}", upstreams[0])
-	}
+	// Note: upstreamEnvironment removed from spec (#618).
+	// The upstream DAG edge is maintained via the metadata annotation below.
 
 	return GraphNode{
 		ID: nodeID,


### PR DESCRIPTION
## Summary

Removes `spec.upstreamEnvironment` from the PolicyGate CRD. This field confused users — it appeared to be gate configuration but was actually controller-internal DAG wiring.

## DAG edge preservation

The upstream DAG edge is moved to a metadata annotation: `kardinal.io/upstream-ref: ${upstream.status.state}`. krocodile's `collectStrings()` ([eval.go:584](https://github.com/ellistarn/kro/blob/krocodile/experimental/controller/eval.go#L584)) scans ALL string values in the template recursively, including `metadata.annotations`. The DAG dependency edge is preserved.

## No functional change

The PolicyGate reconciler never read `spec.upstreamEnvironment`. The change has zero impact on gate evaluation behavior. The Graph's `propagateWhen` on the upstream PromotionStep controls sequencing.

## Before/after

Before: `kubectl get policygate -o yaml` showed
```yaml
spec:
  expression: '!schedule.isWeekend'
  upstreamEnvironment: Verified  # confusing — what is this?
```

After:
```yaml
metadata:
  annotations:
    kardinal.io/upstream-ref: Verified  # internal wiring in annotation
spec:
  expression: '!schedule.isWeekend'
```

Closes #618