### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/chart/kardinal-promoter/Chart.yaml
+++ b/chart/kardinal-promoter/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   A Kubernetes-native promotion controller with DAG pipelines and policy gates.
   Bundles the krocodile Graph controller — a single helm install installs everything.
 type: application
-version: 0.6.0
-appVersion: "v0.6.0"
+version: 0.7.0
+appVersion: "v0.7.0"
 keywords:
   - kubernetes
   - promotion

--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -292,3 +292,12 @@
 | Item | Title | Status | PR | Notes |
 |---|---|---|---|---|
 | 901 | WatchKind health nodes for O(1) incremental cache | ✅ Complete | #652 merged | health.labelSelector → krocodile WatchKind; 6 new tests; docs MISS fixed |
+
+---
+
+## queue-024 continued (batch 024b — 2026-04-17)
+
+| Item | Title | Status | PR | Notes |
+|---|---|---|---|---|
+| 625-remove-upstream-verified | refactor(graph): upstreamStates list replaces upstreamVerifiedN | ✅ Complete | #660 merged | CRD regen + builder.go update |
+| 656-watchkind-docs | docs(health): document health.labelSelector WatchKind mode | ✅ Complete | #659 merged | |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [v0.7.0] — 2026-04-17
+
+**WatchKind O(1) health checks, krocodile 81c5a03 upgrade, reactive PromotionStep reconciler, graph-first cleanup**
+
 ### Added
 
 - **WatchKind health nodes** — `health.labelSelector` on Pipeline environments switches from Watch (O(n) full list per event) to WatchKind (O(1) incremental cache). Requires krocodile `745998f`+ (#652)


### PR DESCRIPTION
## Summary

Tags v0.7.0 — 57 commits since v0.6.0.

**Key items in this release:**
- `health.labelSelector` WatchKind mode — O(1) incremental health check (#652)
- krocodile upgraded to `81c5a03` — P0 correctness fixes (#654)
- PromotionStep Watch on PRStatus/PolicyGate — eliminates polling lag (#655)
- `upstreamStates` list replaces `upstreamVerifiedN` anti-pattern (#660)
- WatchKind mode documentation (#659)
- Kargo migration guide (#640)
- Operations runbook expanded (#639)
- Bundle image diff in NodeDetail (#638)
- Per-step observability (#630), `--watch` flag (#629), PrometheusRule CRD (#621)

**Changes in this PR:**
- `docs/changelog.md`: `[Unreleased]` renamed to `[v0.7.0] — 2026-04-17`; new empty `[Unreleased]` added
- `chart/kardinal-promoter/Chart.yaml`: version `0.6.0` → `0.7.0`, appVersion `"v0.6.0"` → `"v0.7.0"`

After this PR merges, create the git tag `v0.7.0` on the merge commit.

Closes #662