### PR TITLE
refactor(policygate): remove spec.upstreamEnvironment — Graph wiring not gate logic (#618)

### DIFF
--- a/api/v1alpha1/policygate_types.go
+++ b/api/v1alpha1/policygate_types.go
@@ -35,12 +35,6 @@ type PolicyGateSpec struct {
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
-	// UpstreamEnvironment is set by the kro Graph controller via CEL expression
-	// substitution. It carries the resolved state of the upstream PromotionStep
-	// that must be Verified before this gate is evaluated.
-	// +optional
-	UpstreamEnvironment string `json:"upstreamEnvironment,omitempty"`
-
 	// When controls when this gate is evaluated in the promotion lifecycle (K-02).
 	// "pre-deploy" (default: post-deploy): evaluated before git operations start.
 	//   If not ready, the PromotionStep stays in Pending and no git-clone begins.

--- a/config/crd/bases/kardinal.io_policygates.yaml
+++ b/config/crd/bases/kardinal.io_policygates.yaml
@@ -170,12 +170,6 @@ spec:
                   SkipPermission controls whether bundles with intent.skipEnvironments can
                   bypass this gate. When false, skip requests are denied.
                 type: boolean
-              upstreamEnvironment:
-                description: |-
-                  UpstreamEnvironment is set by the kro Graph controller via CEL expression
-                  substitution. It carries the resolved state of the upstream PromotionStep
-                  that must be Verified before this gate is evaluated.
-                type: string
               when:
                 default: post-deploy
                 description: |-

--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -292,3 +292,12 @@
 | Item | Title | Status | PR | Notes |
 |---|---|---|---|---|
 | 901 | WatchKind health nodes for O(1) incremental cache | ✅ Complete | #652 merged | health.labelSelector → krocodile WatchKind; 6 new tests; docs MISS fixed |
+
+---
+
+## queue-024 continued (batch 024b — 2026-04-17)
+
+| Item | Title | Status | PR | Notes |
+|---|---|---|---|---|
+| 625-remove-upstream-verified | refactor(graph): upstreamStates list replaces upstreamVerifiedN | ✅ Complete | #660 merged | CRD regen + builder.go update |
+| 656-watchkind-docs | docs(health): document health.labelSelector WatchKind mode | ✅ Complete | #659 merged | |

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -594,11 +594,6 @@ func buildPolicyGateNode(
 		"recheckInterval": gate.Spec.RecheckInterval,
 	}
 
-	// Add upstream reference to create dependency edge
-	if len(upstreams) > 0 {
-		templateSpec["upstreamEnvironment"] = fmt.Sprintf("${%s.status.state}", upstreams[0])
-	}
-
 	return GraphNode{
 		ID: nodeID,
 		Template: map[string]interface{}{


### PR DESCRIPTION
## Summary

Removes `PolicyGate.spec.upstreamEnvironment` — a field set by the Graph builder as Graph-internal wiring, not user-visible gate configuration.

## Why

The field was set to `${upstream.status.state}` by the Graph builder to create a CEL dependency edge from the PolicyGate node to the upstream PromotionStep. However:

1. **The reconciler never reads it** — `buildUpstreamContext()` reads Bundle status, not this field
2. **Sequencing is already correct** — the PromotionStep's `spec.requiredGates` carries CEL refs to gate node names, creating the correct dependency edges in krocodile (step depends on gates)
3. **Users are confused** — `kubectl get policygate` shows `upstreamEnvironment: "Verified"` which looks like user configuration but isn't

## What changes

| File | Change |
|---|---|
| `api/v1alpha1/policygate_types.go` | Remove `UpstreamEnvironment` field from `PolicyGateSpec` |
| `config/crd/bases/kardinal.io_policygates.yaml` | Regenerated (field removed, v0.17.3 annotation) |
| `pkg/graph/builder.go` | Remove `templateSpec["upstreamEnvironment"]` assignment |

## Correctness verification

The PromotionStep node's `readyWhen` checks `${step.status.state == "Verified"}`. The `propagateWhen` on the upstream PromotionStep blocks downstream nodes from receiving data until the step is Verified. The PolicyGate node's `readyWhen` and `propagateWhen` are `${gate.status.ready == true}`. The PromotionStep spec carries `requiredGates: [${gate.metadata.name}]` which creates the CEL dependency edge (step waits for gates) in krocodile.

Removing `upstreamEnvironment` from the PolicyGate removes a redundant one-way dependency (gate waiting for upstream step) that was never needed — the graph sequencing already handles this via PromotionStep's requiredGates.

All tests pass.

Closes #618