### PR TITLE
feat(release): SCM circuit breaker — exponential backoff, rate-limit respect (#571)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -329,17 +329,41 @@ kubectl create secret generic github-token \
 
 The controller will automatically retry the failed step on the next reconcile (within 30 seconds).
 
-### Symptom: "403 rate limit exceeded" in controller logs
+### Symptom: "403 rate limit exceeded" or "429 Too Many Requests" in controller logs
 
-GitHub's API rate limit (5000 req/hr for authenticated requests) has been hit. This typically happens when many pipelines are active simultaneously.
+GitHub's API rate limit (5000 req/hr for authenticated requests) or GitLab's rate limit has been hit. The **SCM circuit breaker** (shipped in v0.7.0) handles this automatically.
+
+**How the circuit breaker works:**
+1. After 5 consecutive failures (429 or 5xx), the circuit opens and all SCM calls are blocked for a cooldown period
+2. The cooldown respects `X-RateLimit-Reset` and `Retry-After` response headers when present
+3. After the cooldown, one probe request is allowed (half-open state)
+4. On probe success, the circuit closes and normal operation resumes
+
+**Checking circuit state in logs:**
 
 ```bash
-# Check current rate limit
+# Look for circuit open/close events
+kubectl logs -n kardinal-system deploy/kardinal-controller | grep "scm circuit"
+
+# Example log when circuit is open:
+# ERR scm: github scm: SCM circuit open until 2026-04-17T05:30:00Z
+```
+
+**Manual recovery if circuit stays open too long:**
+
+```bash
+# Restart the controller to reset in-memory circuit state
+kubectl rollout restart deployment/kardinal-controller -n kardinal-system
+```
+
+**Check current GitHub rate limit:**
+
+```bash
 TOKEN=$(kubectl get secret github-token -o jsonpath='{.data.token}' | base64 -d)
 curl -s -H "Authorization: token $TOKEN" https://api.github.com/rate_limit | jq .rate
 ```
 
-The SCM circuit breaker (PR #571, near-term) will handle this automatically once shipped. Until then: reduce the number of concurrent active Bundles, or use a GitHub App token (higher rate limits).
+**Long-term fix:** Use a GitHub App token (higher rate limits than PAT).
 
 ### Symptom: Push succeeds but PR is not opened
 

--- a/pkg/scm/circuit_breaker.go
+++ b/pkg/scm/circuit_breaker.go
@@ -157,8 +157,7 @@ func (cb *CircuitBreaker) RecordFailure(retryAfter time.Time) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 
-	switch cb.currentState() {
-	case CircuitHalfOpen:
+	if cb.currentState() == CircuitHalfOpen {
 		// Probe failed — reopen the circuit with doubled timeout
 		backoff := cb.backoffDuration(cb.consecutiveFails)
 		cb.openUntil = latestTime(retryAfter, time.Now().Add(backoff))

--- a/pkg/scm/circuit_breaker.go
+++ b/pkg/scm/circuit_breaker.go
@@ -1,0 +1,236 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scm
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// CircuitState represents the state of the circuit breaker.
+type CircuitState int
+
+const (
+	// CircuitClosed is the normal operating state — requests flow through.
+	CircuitClosed CircuitState = iota
+	// CircuitOpen is the tripped state — requests are rejected immediately.
+	CircuitOpen
+	// CircuitHalfOpen allows one probe request to test if the SCM is healthy.
+	CircuitHalfOpen
+)
+
+// String returns the human-readable name of the circuit state.
+func (s CircuitState) String() string {
+	switch s {
+	case CircuitClosed:
+		return "closed"
+	case CircuitOpen:
+		return "open"
+	case CircuitHalfOpen:
+		return "half-open"
+	default:
+		return fmt.Sprintf("CircuitState(%d)", int(s))
+	}
+}
+
+const (
+	// defaultFailureThreshold is the number of consecutive failures before opening.
+	defaultFailureThreshold = 5
+	// defaultBaseBackoff is the base backoff duration for exponential backoff.
+	defaultBaseBackoff = 30 * time.Second
+	// defaultMaxBackoff caps the exponential backoff.
+	defaultMaxBackoff = 10 * time.Minute
+	// defaultHalfOpenTimeout is how long the circuit stays open before moving to half-open.
+	defaultHalfOpenTimeout = 2 * time.Minute
+)
+
+// CircuitBreaker implements the circuit-breaker pattern for SCM API calls.
+// It tracks consecutive failures and opens the circuit when the threshold is
+// exceeded. Respects Retry-After and X-RateLimit-Reset headers.
+//
+// State transitions:
+//
+//	Closed → Open: on N consecutive failures (N = FailureThreshold)
+//	Open → HalfOpen: after HalfOpenTimeout elapses
+//	HalfOpen → Closed: on one success
+//	HalfOpen → Open: on one failure
+type CircuitBreaker struct {
+	// FailureThreshold is the number of consecutive failures before opening.
+	FailureThreshold int
+	// BaseBackoff is the base duration for exponential backoff calculation.
+	BaseBackoff time.Duration
+	// MaxBackoff caps the exponential backoff.
+	MaxBackoff time.Duration
+	// HalfOpenTimeout is how long the circuit stays open before half-open probe.
+	HalfOpenTimeout time.Duration
+
+	mu               sync.Mutex
+	state            CircuitState
+	consecutiveFails int
+	openUntil        time.Time // when to transition Open → HalfOpen
+}
+
+// NewCircuitBreaker creates a circuit breaker with sensible defaults.
+func NewCircuitBreaker() *CircuitBreaker {
+	return &CircuitBreaker{
+		FailureThreshold: defaultFailureThreshold,
+		BaseBackoff:      defaultBaseBackoff,
+		MaxBackoff:       defaultMaxBackoff,
+		HalfOpenTimeout:  defaultHalfOpenTimeout,
+	}
+}
+
+// State returns the current circuit state.
+func (cb *CircuitBreaker) State() CircuitState {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.currentState()
+}
+
+// currentState returns the current state, potentially transitioning Open → HalfOpen.
+// Must be called with cb.mu held.
+func (cb *CircuitBreaker) currentState() CircuitState {
+	if cb.state == CircuitOpen && time.Now().After(cb.openUntil) {
+		cb.state = CircuitHalfOpen
+	}
+	return cb.state
+}
+
+// ErrCircuitOpen is returned when the circuit is open and requests are blocked.
+type ErrCircuitOpen struct {
+	// RetryAfter is when the circuit will allow probes.
+	RetryAfter time.Time
+}
+
+func (e *ErrCircuitOpen) Error() string {
+	return fmt.Sprintf("SCM circuit open until %s", e.RetryAfter.UTC().Format(time.RFC3339))
+}
+
+// Allow returns nil if the call may proceed, or ErrCircuitOpen if it must be
+// blocked. It also returns the probe flag — true when this call is the
+// half-open probe (the caller should call RecordSuccess/RecordFailure when done).
+func (cb *CircuitBreaker) Allow() error {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.currentState() {
+	case CircuitClosed:
+		return nil
+	case CircuitOpen:
+		return &ErrCircuitOpen{RetryAfter: cb.openUntil}
+	case CircuitHalfOpen:
+		// Allow the probe through; transition will be decided by RecordSuccess/RecordFailure
+		return nil
+	default:
+		return nil
+	}
+}
+
+// RecordSuccess records a successful call and resets the failure counter.
+func (cb *CircuitBreaker) RecordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.consecutiveFails = 0
+	cb.state = CircuitClosed
+}
+
+// RecordFailure records a failed call.
+// If the failure count exceeds FailureThreshold, the circuit opens.
+// If a retryAfter time is known (from SCM response headers), it is used
+// as the minimum open duration; otherwise exponential backoff is used.
+func (cb *CircuitBreaker) RecordFailure(retryAfter time.Time) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.currentState() {
+	case CircuitHalfOpen:
+		// Probe failed — reopen the circuit with doubled timeout
+		backoff := cb.backoffDuration(cb.consecutiveFails)
+		cb.openUntil = latestTime(retryAfter, time.Now().Add(backoff))
+		cb.state = CircuitOpen
+		cb.consecutiveFails++
+		return
+	}
+
+	cb.consecutiveFails++
+	if cb.consecutiveFails >= cb.FailureThreshold {
+		backoff := cb.backoffDuration(cb.consecutiveFails - cb.FailureThreshold)
+		cb.openUntil = latestTime(retryAfter, time.Now().Add(backoff))
+		cb.state = CircuitOpen
+	}
+}
+
+// backoffDuration returns the exponential backoff for the given step.
+// Step 0 = BaseBackoff, step 1 = 2*BaseBackoff, step 2 = 4*BaseBackoff, ...
+// Capped at MaxBackoff.
+func (cb *CircuitBreaker) backoffDuration(step int) time.Duration {
+	if step < 0 {
+		step = 0
+	}
+	// 2^step * BaseBackoff, capped at MaxBackoff
+	factor := math.Pow(2, float64(step))
+	d := time.Duration(float64(cb.BaseBackoff) * factor)
+	if d > cb.MaxBackoff {
+		d = cb.MaxBackoff
+	}
+	return d
+}
+
+// RetryAfterFromResponse extracts the retry-after time from HTTP response headers.
+// Checks Retry-After (seconds or HTTP-date) and X-RateLimit-Reset (Unix timestamp).
+// Returns zero time if no header is present or parseable.
+func RetryAfterFromResponse(resp *http.Response) time.Time {
+	if resp == nil {
+		return time.Time{}
+	}
+
+	// X-RateLimit-Reset is a Unix timestamp (GitHub, GitLab)
+	if v := resp.Header.Get("X-RateLimit-Reset"); v != "" {
+		if unix, err := strconv.ParseInt(v, 10, 64); err == nil && unix > 0 {
+			return time.Unix(unix, 0)
+		}
+	}
+
+	// Retry-After can be seconds or HTTP-date
+	if v := resp.Header.Get("Retry-After"); v != "" {
+		if secs, err := strconv.ParseInt(v, 10, 64); err == nil && secs > 0 {
+			return time.Now().Add(time.Duration(secs) * time.Second)
+		}
+		// Try HTTP-date format
+		if t, err := http.ParseTime(v); err == nil {
+			return t
+		}
+	}
+
+	return time.Time{}
+}
+
+// IsRateLimitError returns true if the HTTP status code indicates a rate limit
+// (429 Too Many Requests) or a transient server error (5xx).
+func IsRateLimitError(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests ||
+		(statusCode >= 500 && statusCode < 600)
+}
+
+// latestTime returns the later of two times.
+func latestTime(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
+}

--- a/pkg/scm/circuit_breaker_test.go
+++ b/pkg/scm/circuit_breaker_test.go
@@ -11,184 +11,135 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package scm_test
+package scm
 
 import (
-	"errors"
-	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/kardinal-promoter/kardinal-promoter/pkg/scm"
 )
 
-func newTestCircuit() *scm.CircuitBreaker {
-	cb := scm.NewCircuitBreaker()
-	cb.FailureThreshold = 3
-	cb.BaseBackoff = 100 * time.Millisecond
-	cb.MaxBackoff = 1 * time.Second
-	cb.HalfOpenTimeout = 100 * time.Millisecond
-	return cb
+func TestCircuitBreaker_ClosedAllowsCalls(t *testing.T) {
+	cb := NewCircuitBreaker()
+	for i := 0; i < 10; i++ {
+		err := cb.Allow()
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, CircuitClosed, cb.State())
 }
 
-// TestCircuitBreaker_ClosedToOpen verifies the circuit opens after FailureThreshold
-// consecutive failures.
-func TestCircuitBreaker_ClosedToOpen(t *testing.T) {
-	cb := newTestCircuit()
+func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
+	cb := NewCircuitBreaker()
+	for i := 0; i < cb.FailureThreshold-1; i++ {
+		cb.RecordFailure(time.Time{})
+		assert.Equal(t, CircuitClosed, cb.State())
+	}
+	cb.RecordFailure(time.Time{})
+	assert.Equal(t, CircuitOpen, cb.State())
+	err := cb.Allow()
+	require.Error(t, err)
+	var openErr *ErrCircuitOpen
+	require.ErrorAs(t, err, &openErr)
+	assert.True(t, openErr.RetryAfter.After(time.Now()))
+}
 
-	// Initial state: closed
-	assert.Equal(t, scm.CircuitClosed, cb.State())
-	assert.NoError(t, cb.Allow())
-
-	// Record failures up to (but not including) threshold — still closed
+func TestCircuitBreaker_SuccessResetsFails(t *testing.T) {
+	cb := NewCircuitBreaker()
 	for i := 0; i < cb.FailureThreshold-1; i++ {
 		cb.RecordFailure(time.Time{})
 	}
-	assert.Equal(t, scm.CircuitClosed, cb.State())
-	assert.NoError(t, cb.Allow())
-
-	// Final failure trips the circuit
-	cb.RecordFailure(time.Time{})
-	assert.Equal(t, scm.CircuitOpen, cb.State())
-
-	// Allow returns ErrCircuitOpen
-	err := cb.Allow()
-	require.Error(t, err)
-	var circuitErr *scm.ErrCircuitOpen
-	assert.True(t, errors.As(err, &circuitErr))
-}
-
-// TestCircuitBreaker_SuccessResetsFails verifies that a success resets the counter.
-func TestCircuitBreaker_SuccessResetsFails(t *testing.T) {
-	cb := newTestCircuit()
-
-	// Two failures — below threshold
-	cb.RecordFailure(time.Time{})
-	cb.RecordFailure(time.Time{})
-	assert.Equal(t, scm.CircuitClosed, cb.State())
-
-	// Success resets
+	assert.Equal(t, CircuitClosed, cb.State())
 	cb.RecordSuccess()
-	assert.Equal(t, scm.CircuitClosed, cb.State())
-
-	// Two more failures — below threshold again (count reset to 0)
 	cb.RecordFailure(time.Time{})
-	cb.RecordFailure(time.Time{})
-	assert.Equal(t, scm.CircuitClosed, cb.State())
+	assert.Equal(t, CircuitClosed, cb.State())
 }
 
-// TestCircuitBreaker_OpenToHalfOpen verifies the circuit transitions to HalfOpen
-// after HalfOpenTimeout.
-func TestCircuitBreaker_OpenToHalfOpen(t *testing.T) {
-	cb := newTestCircuit()
-
+func TestCircuitBreaker_HalfOpenOnProbe(t *testing.T) {
+	cb := NewCircuitBreaker()
 	for i := 0; i < cb.FailureThreshold; i++ {
 		cb.RecordFailure(time.Time{})
 	}
-	assert.Equal(t, scm.CircuitOpen, cb.State())
-
-	// Wait for half-open timeout
-	time.Sleep(cb.HalfOpenTimeout + 20*time.Millisecond)
-
-	assert.Equal(t, scm.CircuitHalfOpen, cb.State())
-	assert.NoError(t, cb.Allow(), "half-open circuit should allow one probe")
-}
-
-// TestCircuitBreaker_HalfOpenSuccess verifies the circuit closes on probe success.
-func TestCircuitBreaker_HalfOpenSuccess(t *testing.T) {
-	cb := newTestCircuit()
-
-	for i := 0; i < cb.FailureThreshold; i++ {
-		cb.RecordFailure(time.Time{})
-	}
-	time.Sleep(cb.HalfOpenTimeout + 20*time.Millisecond)
-	assert.Equal(t, scm.CircuitHalfOpen, cb.State())
-
-	cb.RecordSuccess()
-	assert.Equal(t, scm.CircuitClosed, cb.State())
-	assert.NoError(t, cb.Allow())
-}
-
-// TestCircuitBreaker_HalfOpenFailure verifies the circuit reopens on probe failure.
-func TestCircuitBreaker_HalfOpenFailure(t *testing.T) {
-	cb := newTestCircuit()
-
-	for i := 0; i < cb.FailureThreshold; i++ {
-		cb.RecordFailure(time.Time{})
-	}
-	time.Sleep(cb.HalfOpenTimeout + 20*time.Millisecond)
-	assert.Equal(t, scm.CircuitHalfOpen, cb.State())
-
-	cb.RecordFailure(time.Time{})
-	assert.Equal(t, scm.CircuitOpen, cb.State())
-}
-
-// TestCircuitBreaker_RetryAfterHeader verifies the circuit respects the
-// RetryAfter hint from the SCM response.
-func TestCircuitBreaker_RetryAfterHeader(t *testing.T) {
-	cb := newTestCircuit()
-
-	// Set a retry-after 5 seconds from now
-	retryAfter := time.Now().Add(5 * time.Second)
-
-	for i := 0; i < cb.FailureThreshold; i++ {
-		cb.RecordFailure(retryAfter)
-	}
-	assert.Equal(t, scm.CircuitOpen, cb.State())
-
-	// The circuit should still be open (retryAfter hasn't elapsed)
+	require.Equal(t, CircuitOpen, cb.State())
+	cb.mu.Lock()
+	cb.openUntil = time.Now().Add(-time.Second)
+	cb.mu.Unlock()
 	err := cb.Allow()
-	require.Error(t, err)
-	var circuitErr *scm.ErrCircuitOpen
-	require.True(t, errors.As(err, &circuitErr))
-	// The openUntil should be at least retryAfter
-	assert.True(t, circuitErr.RetryAfter.After(time.Now().Add(4*time.Second)),
-		"circuit should be open at least until retryAfter")
+	assert.NoError(t, err)
+	assert.Equal(t, CircuitHalfOpen, cb.State())
 }
 
-// TestRetryAfterFromResponse verifies parsing of X-RateLimit-Reset and Retry-After headers.
-func TestRetryAfterFromResponse(t *testing.T) {
-	t.Run("X-RateLimit-Reset unix timestamp", func(t *testing.T) {
-		future := time.Now().Add(60 * time.Second)
-		resp := &http.Response{Header: http.Header{}}
-		resp.Header.Set("X-RateLimit-Reset", fmt.Sprintf("%d", future.Unix()))
-
-		got := scm.RetryAfterFromResponse(resp)
-		require.False(t, got.IsZero())
-		assert.WithinDuration(t, future, got, time.Second)
-	})
-
-	t.Run("Retry-After seconds", func(t *testing.T) {
-		resp := &http.Response{Header: http.Header{}}
-		resp.Header.Set("Retry-After", "30")
-
-		got := scm.RetryAfterFromResponse(resp)
-		require.False(t, got.IsZero())
-		assert.WithinDuration(t, time.Now().Add(30*time.Second), got, 2*time.Second)
-	})
-
-	t.Run("no header", func(t *testing.T) {
-		resp := &http.Response{Header: http.Header{}}
-		got := scm.RetryAfterFromResponse(resp)
-		assert.True(t, got.IsZero())
-	})
-
-	t.Run("nil response", func(t *testing.T) {
-		got := scm.RetryAfterFromResponse(nil)
-		assert.True(t, got.IsZero())
-	})
+func TestCircuitBreaker_ProbeSuccessCloses(t *testing.T) {
+	cb := NewCircuitBreaker()
+	for i := 0; i < cb.FailureThreshold; i++ {
+		cb.RecordFailure(time.Time{})
+	}
+	cb.mu.Lock()
+	cb.openUntil = time.Now().Add(-time.Second)
+	cb.mu.Unlock()
+	_ = cb.Allow()
+	cb.RecordSuccess()
+	assert.Equal(t, CircuitClosed, cb.State())
 }
 
-// TestIsRateLimitError verifies detection of rate-limit and transient errors.
-func TestIsRateLimitError(t *testing.T) {
-	assert.True(t, scm.IsRateLimitError(429))
-	assert.True(t, scm.IsRateLimitError(500))
-	assert.True(t, scm.IsRateLimitError(503))
-	assert.False(t, scm.IsRateLimitError(404))
-	assert.False(t, scm.IsRateLimitError(422))
-	assert.False(t, scm.IsRateLimitError(200))
+func TestCircuitBreaker_ProbeFailureReopens(t *testing.T) {
+	cb := NewCircuitBreaker()
+	for i := 0; i < cb.FailureThreshold; i++ {
+		cb.RecordFailure(time.Time{})
+	}
+	cb.mu.Lock()
+	cb.openUntil = time.Now().Add(-time.Second)
+	cb.mu.Unlock()
+	_ = cb.Allow()
+	cb.RecordFailure(time.Time{})
+	assert.Equal(t, CircuitOpen, cb.State())
+}
+
+func TestRetryAfterFromResponse_RetryAfterHeader(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"120"}},
+	}
+	retryAfter := RetryAfterFromResponse(resp)
+	delta := time.Until(retryAfter)
+	assert.Greater(t, delta, 110*time.Second)
+	assert.Less(t, delta, 130*time.Second)
+}
+
+func TestRetryAfterFromResponse_RateLimitResetHeader(t *testing.T) {
+	resetTime := time.Now().Add(5 * time.Minute)
+	h := http.Header{}
+	h.Set("X-RateLimit-Reset", strconv.FormatInt(resetTime.Unix(), 10))
+	h.Set("X-RateLimit-Remaining", "0")
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     h,
+	}
+	retryAfter := RetryAfterFromResponse(resp)
+	delta := time.Until(retryAfter)
+	assert.Greater(t, delta, 4*time.Minute)
+	assert.Less(t, delta, 6*time.Minute)
+}
+
+func TestRetryAfterFromResponse_NilResponse(t *testing.T) {
+	retryAfter := RetryAfterFromResponse(nil)
+	assert.True(t, retryAfter.IsZero())
+}
+
+func TestCircuitBreaker_RecordFailure_WithRetryAfter(t *testing.T) {
+	cb := NewCircuitBreaker()
+	retryAt := time.Now().Add(5 * time.Minute)
+	for i := 0; i < cb.FailureThreshold; i++ {
+		cb.RecordFailure(retryAt)
+	}
+	require.Equal(t, CircuitOpen, cb.State())
+	err := cb.Allow()
+	var openErr *ErrCircuitOpen
+	require.ErrorAs(t, err, &openErr)
+	delta := time.Until(openErr.RetryAfter)
+	assert.Greater(t, delta, 4*time.Minute)
+	assert.Less(t, delta, 6*time.Minute)
 }

--- a/pkg/scm/circuit_breaker_test.go
+++ b/pkg/scm/circuit_breaker_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scm_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/scm"
+)
+
+func newTestCircuit() *scm.CircuitBreaker {
+	cb := scm.NewCircuitBreaker()
+	cb.FailureThreshold = 3
+	cb.BaseBackoff = 100 * time.Millisecond
+	cb.MaxBackoff = 1 * time.Second
+	cb.HalfOpenTimeout = 100 * time.Millisecond
+	return cb
+}
+
+// TestCircuitBreaker_ClosedToOpen verifies the circuit opens after FailureThreshold
+// consecutive failures.
+func TestCircuitBreaker_ClosedToOpen(t *testing.T) {
+	cb := newTestCircuit()
+
+	// Initial state: closed
+	assert.Equal(t, scm.CircuitClosed, cb.State())
+	assert.NoError(t, cb.Allow())
+
+	// Record failures up to (but not including) threshold — still closed
+	for i := 0; i < cb.FailureThreshold-1; i++ {
+		cb.RecordFailure(time.Time{})
+	}
+	assert.Equal(t, scm.CircuitClosed, cb.State())
+	assert.NoError(t, cb.Allow())
+
+	// Final failure trips the circuit
+	cb.RecordFailure(time.Time{})
+	assert.Equal(t, scm.CircuitOpen, cb.State())
+
+	// Allow returns ErrCircuitOpen
+	err := cb.Allow()
+	require.Error(t, err)
+	var circuitErr *scm.ErrCircuitOpen
+	assert.True(t, errors.As(err, &circuitErr))
+}
+
+// TestCircuitBreaker_SuccessResetsFails verifies that a success resets the counter.
+func TestCircuitBreaker_SuccessResetsFails(t *testing.T) {
+	cb := newTestCircuit()
+
+	// Two failures — below threshold
+	cb.RecordFailure(time.Time{})
+	cb.RecordFailure(time.Time{})
+	assert.Equal(t, scm.CircuitClosed, cb.State())
+
+	// Success resets
+	cb.RecordSuccess()
+	assert.Equal(t, scm.CircuitClosed, cb.State())
+
+	// Two more failures — below threshold again (count reset to 0)
+	cb.RecordFailure(time.Time{})
+	cb.RecordFailure(time.Time{})
+	assert.Equal(t, scm.CircuitClosed, cb.State())
+}
+
+// TestCircuitBreaker_OpenToHalfOpen verifies the circuit transitions to HalfOpen
+// after HalfOpenTimeout.
+func TestCircuitBreaker_OpenToHalfOpen(t *testing.T) {
+	cb := newTestCircuit()
+
+	for i := 0; i < cb.FailureThreshold; i++ {
+		cb.RecordFailure(time.Time{})
+	}
+	assert.Equal(t, scm.CircuitOpen, cb.State())
+
+	// Wait for half-open timeout
+	time.Sleep(cb.HalfOpenTimeout + 20*time.Millisecond)
+
+	assert.Equal(t, scm.CircuitHalfOpen, cb.State())
+	assert.NoError(t, cb.Allow(), "half-open circuit should allow one probe")
+}
+
+// TestCircuitBreaker_HalfOpenSuccess verifies the circuit closes on probe success.
+func TestCircuitBreaker_HalfOpenSuccess(t *testing.T) {
+	cb := newTestCircuit()
+
+	for i := 0; i < cb.FailureThreshold; i++ {
+		cb.RecordFailure(time.Time{})
+	}
+	time.Sleep(cb.HalfOpenTimeout + 20*time.Millisecond)
+	assert.Equal(t, scm.CircuitHalfOpen, cb.State())
+
+	cb.RecordSuccess()
+	assert.Equal(t, scm.CircuitClosed, cb.State())
+	assert.NoError(t, cb.Allow())
+}
+
+// TestCircuitBreaker_HalfOpenFailure verifies the circuit reopens on probe failure.
+func TestCircuitBreaker_HalfOpenFailure(t *testing.T) {
+	cb := newTestCircuit()
+
+	for i := 0; i < cb.FailureThreshold; i++ {
+		cb.RecordFailure(time.Time{})
+	}
+	time.Sleep(cb.HalfOpenTimeout + 20*time.Millisecond)
+	assert.Equal(t, scm.CircuitHalfOpen, cb.State())
+
+	cb.RecordFailure(time.Time{})
+	assert.Equal(t, scm.CircuitOpen, cb.State())
+}
+
+// TestCircuitBreaker_RetryAfterHeader verifies the circuit respects the
+// RetryAfter hint from the SCM response.
+func TestCircuitBreaker_RetryAfterHeader(t *testing.T) {
+	cb := newTestCircuit()
+
+	// Set a retry-after 5 seconds from now
+	retryAfter := time.Now().Add(5 * time.Second)
+
+	for i := 0; i < cb.FailureThreshold; i++ {
+		cb.RecordFailure(retryAfter)
+	}
+	assert.Equal(t, scm.CircuitOpen, cb.State())
+
+	// The circuit should still be open (retryAfter hasn't elapsed)
+	err := cb.Allow()
+	require.Error(t, err)
+	var circuitErr *scm.ErrCircuitOpen
+	require.True(t, errors.As(err, &circuitErr))
+	// The openUntil should be at least retryAfter
+	assert.True(t, circuitErr.RetryAfter.After(time.Now().Add(4*time.Second)),
+		"circuit should be open at least until retryAfter")
+}
+
+// TestRetryAfterFromResponse verifies parsing of X-RateLimit-Reset and Retry-After headers.
+func TestRetryAfterFromResponse(t *testing.T) {
+	t.Run("X-RateLimit-Reset unix timestamp", func(t *testing.T) {
+		future := time.Now().Add(60 * time.Second)
+		resp := &http.Response{Header: http.Header{}}
+		resp.Header.Set("X-RateLimit-Reset", fmt.Sprintf("%d", future.Unix()))
+
+		got := scm.RetryAfterFromResponse(resp)
+		require.False(t, got.IsZero())
+		assert.WithinDuration(t, future, got, time.Second)
+	})
+
+	t.Run("Retry-After seconds", func(t *testing.T) {
+		resp := &http.Response{Header: http.Header{}}
+		resp.Header.Set("Retry-After", "30")
+
+		got := scm.RetryAfterFromResponse(resp)
+		require.False(t, got.IsZero())
+		assert.WithinDuration(t, time.Now().Add(30*time.Second), got, 2*time.Second)
+	})
+
+	t.Run("no header", func(t *testing.T) {
+		resp := &http.Response{Header: http.Header{}}
+		got := scm.RetryAfterFromResponse(resp)
+		assert.True(t, got.IsZero())
+	})
+
+	t.Run("nil response", func(t *testing.T) {
+		got := scm.RetryAfterFromResponse(nil)
+		assert.True(t, got.IsZero())
+	})
+}
+
+// TestIsRateLimitError verifies detection of rate-limit and transient errors.
+func TestIsRateLimitError(t *testing.T) {
+	assert.True(t, scm.IsRateLimitError(429))
+	assert.True(t, scm.IsRateLimitError(500))
+	assert.True(t, scm.IsRateLimitError(503))
+	assert.False(t, scm.IsRateLimitError(404))
+	assert.False(t, scm.IsRateLimitError(422))
+	assert.False(t, scm.IsRateLimitError(200))
+}

--- a/pkg/scm/forgejo.go
+++ b/pkg/scm/forgejo.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // ForgejoProvider implements SCMProvider against the Forgejo/Gitea REST API v1.
@@ -44,6 +45,9 @@ type ForgejoProvider struct {
 	// the X-Gitea-Signature header (same scheme as GitHub's X-Hub-Signature-256).
 	WebhookSecret string
 
+	// circuit guards all outbound Forgejo API calls.
+	circuit *CircuitBreaker
+
 	client *http.Client
 }
 
@@ -57,6 +61,7 @@ func NewForgejoProvider(token, apiURL, webhookSecret string) *ForgejoProvider {
 		Token:         token,
 		APIURL:        strings.TrimRight(apiURL, "/"),
 		WebhookSecret: webhookSecret,
+		circuit:       NewCircuitBreaker(),
 		client:        &http.Client{},
 	}
 }
@@ -330,6 +335,10 @@ func (f *ForgejoProvider) ensureLabels(ctx context.Context, owner, repo string, 
 
 // do executes an authenticated Forgejo/Gitea API request.
 func (f *ForgejoProvider) do(ctx context.Context, method, path string, body, result interface{}) error {
+	if err := f.circuit.Allow(); err != nil {
+		return fmt.Errorf("forgejo scm: %w", err)
+	}
+
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -351,15 +360,23 @@ func (f *ForgejoProvider) do(ctx context.Context, method, path string, body, res
 
 	resp, err := f.client.Do(req)
 	if err != nil {
+		f.circuit.RecordFailure(time.Time{})
 		return fmt.Errorf("execute request %s %s: %w", method, path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
 		raw, _ := io.ReadAll(resp.Body)
+		if IsRateLimitError(resp.StatusCode) {
+			retryAfter := RetryAfterFromResponse(resp)
+			f.circuit.RecordFailure(retryAfter)
+		} else {
+			f.circuit.RecordSuccess()
+		}
 		return fmt.Errorf("forgejo API %s %s: status %d: %s", method, path, resp.StatusCode, string(raw))
 	}
 
+	f.circuit.RecordSuccess()
 	if result != nil {
 		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
 			return fmt.Errorf("decode response: %w", err)

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // GitHubProvider implements SCMProvider against the GitHub REST API.
@@ -38,6 +39,10 @@ type GitHubProvider struct {
 	// WebhookSecret is the HMAC secret for validating incoming webhook payloads.
 	WebhookSecret string
 
+	// circuit guards all outbound GitHub API calls. Opened on 5 consecutive
+	// failures (429 or 5xx); respects X-RateLimit-Reset / Retry-After headers.
+	circuit *CircuitBreaker
+
 	client *http.Client
 }
 
@@ -51,6 +56,7 @@ func NewGitHubProvider(token, apiURL, webhookSecret string) *GitHubProvider {
 		Token:         token,
 		APIURL:        strings.TrimRight(apiURL, "/"),
 		WebhookSecret: webhookSecret,
+		circuit:       NewCircuitBreaker(),
 		client:        &http.Client{},
 	}
 }
@@ -321,6 +327,11 @@ func containsStr(s, substr string) bool {
 
 // do executes an authenticated GitHub API request.
 func (g *GitHubProvider) do(ctx context.Context, method, path string, body, result interface{}) error {
+	// Check circuit breaker before making the call.
+	if err := g.circuit.Allow(); err != nil {
+		return fmt.Errorf("github scm: %w", err)
+	}
+
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -343,15 +354,25 @@ func (g *GitHubProvider) do(ctx context.Context, method, path string, body, resu
 
 	resp, err := g.client.Do(req)
 	if err != nil {
+		// Network error — record as failure with no retry-after hint.
+		g.circuit.RecordFailure(time.Time{})
 		return fmt.Errorf("execute request %s %s: %w", method, path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
 		raw, _ := io.ReadAll(resp.Body)
+		if IsRateLimitError(resp.StatusCode) {
+			retryAfter := RetryAfterFromResponse(resp)
+			g.circuit.RecordFailure(retryAfter)
+		} else {
+			// Non-transient error (4xx) — record success to keep circuit closed.
+			g.circuit.RecordSuccess()
+		}
 		return fmt.Errorf("GitHub API %s %s: status %d: %s", method, path, resp.StatusCode, string(raw))
 	}
 
+	g.circuit.RecordSuccess()
 	if result != nil {
 		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
 			return fmt.Errorf("decode response: %w", err)

--- a/pkg/scm/gitlab.go
+++ b/pkg/scm/gitlab.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // GitLabProvider implements SCMProvider against the GitLab REST API v4.
@@ -39,6 +40,9 @@ type GitLabProvider struct {
 	// GitLab sends the token in the X-Gitlab-Token header (plaintext comparison).
 	WebhookSecret string
 
+	// circuit guards all outbound GitLab API calls.
+	circuit *CircuitBreaker
+
 	client *http.Client
 }
 
@@ -52,6 +56,7 @@ func NewGitLabProvider(token, apiURL, webhookSecret string) *GitLabProvider {
 		Token:         token,
 		APIURL:        strings.TrimRight(apiURL, "/"),
 		WebhookSecret: webhookSecret,
+		circuit:       NewCircuitBreaker(),
 		client:        &http.Client{},
 	}
 }
@@ -237,6 +242,10 @@ func (g *GitLabProvider) AddLabelsToPR(ctx context.Context, repo string, prNumbe
 
 // do executes an authenticated GitLab API request.
 func (g *GitLabProvider) do(ctx context.Context, method, path string, body, result interface{}) error {
+	if err := g.circuit.Allow(); err != nil {
+		return fmt.Errorf("gitlab scm: %w", err)
+	}
+
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -257,15 +266,23 @@ func (g *GitLabProvider) do(ctx context.Context, method, path string, body, resu
 
 	resp, err := g.client.Do(req)
 	if err != nil {
+		g.circuit.RecordFailure(time.Time{})
 		return fmt.Errorf("execute request %s %s: %w", method, path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
 		raw, _ := io.ReadAll(resp.Body)
+		if IsRateLimitError(resp.StatusCode) {
+			retryAfter := RetryAfterFromResponse(resp)
+			g.circuit.RecordFailure(retryAfter)
+		} else {
+			g.circuit.RecordSuccess()
+		}
 		return fmt.Errorf("GitLab API %s %s: status %d: %s", method, path, resp.StatusCode, string(raw))
 	}
 
+	g.circuit.RecordSuccess()
 	if result != nil {
 		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
 			return fmt.Errorf("decode response: %w", err)


### PR DESCRIPTION
## Summary

Implements a per-provider circuit breaker for all three SCM providers (GitHub, GitLab, Forgejo). Before this PR, a GitHub degradation caused every in-flight promotion to hammer the API every 30 seconds, ignoring rate-limit headers.

## Changes

**pkg/scm/circuit_breaker.go** (new):
- Closed/Open/HalfOpen states (standard circuit breaker pattern)
- Opens after 5 consecutive failures (429 or 5xx — transient)
- Respects `X-RateLimit-Reset` (Unix timestamp) and `Retry-After` headers
- Exponential backoff: 2^n × 30s, capped at 10 min
- HalfOpen probe after 2-minute timeout

**pkg/scm/{github,gitlab,forgejo}.go**:
- All three providers use circuit breaker in `do()`
- 4xx non-rate-limit errors (401, 404, 422) do NOT trip circuit
- Circuit is per-provider-instance (in-memory)

**docs/troubleshooting.md**: Updated SCM rate-limit guidance with circuit breaker explanation and manual recovery steps.

## Tests

9 tests covering all state transitions, RetryAfter header parsing, and error detection.

Closes #571