### PR TITLE
feat(graph): add Bundle Watch node — bundle.* live in Graph CEL scope (#622)

### DIFF
--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -301,3 +301,12 @@
 |---|---|---|---|---|
 | 625-remove-upstream-verified | refactor(graph): upstreamStates list replaces upstreamVerifiedN | ✅ Complete | #660 merged | CRD regen + builder.go update |
 | 656-watchkind-docs | docs(health): document health.labelSelector WatchKind mode | ✅ Complete | #659 merged | |
+
+---
+
+## queue-025 (STANDALONE batch — 2026-04-17)
+
+| Item | Title | Status | PR | Notes |
+|---|---|---|---|---|
+| 662-v070-release | chore(release): v0.7.0 | ✅ Complete | #664 merged | v0.7.0 tagged; chart 0.7.0 |
+| 618-remove-upstream-env | refactor(policygate): remove spec.upstreamEnvironment | ✅ Complete | #665 merged | 17 lines deleted; graph-first cleanup |

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -387,6 +387,27 @@ func buildNodes(pipeline *kardinalv1alpha1.Pipeline, bundle *kardinalv1alpha1.Bu
 
 	var nodes []GraphNode
 
+	// Bundle Watch node: brings bundle.spec.* into Graph CEL scope (#622).
+	// This is a single named Watch reference (not WatchKind) — the translator
+	// knows the exact Bundle name at graph generation time.
+	//
+	// krocodile >= 81c5a03: Watch node must NOT have ReadyWhen/PropagateWhen/IncludeWhen.
+	// deriveReference upgrades Watch+signals -> ReferenceUnresolved -> SSA on Bundle CRD.
+	// The Bundle Watch is read-only; all signals belong on PromotionStep nodes.
+	bundleWatchNode := GraphNode{
+		ID: "bundle",
+		Template: map[string]interface{}{
+			"apiVersion": "kardinal.io/v1alpha1",
+			"kind":       "Bundle",
+			"metadata": map[string]interface{}{
+				"name":      bundle.Name,
+				"namespace": bundle.Namespace,
+			},
+		},
+		// ReadyWhen/PropagateWhen intentionally omitted — Watch node, not Owned node.
+	}
+	nodes = append(nodes, bundleWatchNode)
+
 	for _, envName := range filteredEnvs {
 		envSpec := envSpecMap[envName]
 
@@ -489,9 +510,11 @@ func buildPromotionStepNode(
 
 	templateSpec := map[string]interface{}{
 		"pipelineName": pipelineName,
-		"bundleName":   bundle.Name,
-		"environment":  envName,
-		"stepType":     stepType,
+		// bundleName: live CEL reference to Bundle Watch node metadata.name (#622).
+		// Enables the Graph to react to Bundle changes without regenerating the spec.
+		"bundleName":  "${bundle.metadata.name}",
+		"environment": envName,
+		"stepType":    stepType,
 		// prStatusRef points to the companion PRStatus Watch node.
 		// The PromotionStep reconciler reads spec.prStatusRef.name to find the
 		// PRStatus CRD instead of polling GitHub directly (eliminates PS-4, SCM-2).

--- a/pkg/graph/builder_extra_test.go
+++ b/pkg/graph/builder_extra_test.go
@@ -76,7 +76,7 @@ func TestBuilder_MultipleUpstreams(t *testing.T) {
 	result, err := b.Build(graph.BuildInput{Pipeline: pipeline, Bundle: bundle})
 	require.NoError(t, err)
 	// 3 envs × (1 PRStatus + 1 PromotionStep) = 6
-	assert.Equal(t, 6, result.NodeCount)
+	assert.Equal(t, 7, result.NodeCount)
 
 	nodeMap := nodeByID(result.Graph.Spec.Nodes)
 	globalNode := nodeMap["global"]
@@ -112,7 +112,7 @@ func TestBuilder_GateInMultipleEnvs(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// 2 PromotionStep + 2 PRStatus Watch + 2 PolicyGate (one per env) = 6 nodes
-	assert.Equal(t, 6, result.NodeCount)
+	assert.Equal(t, 7, result.NodeCount)
 }
 
 // TestBuilder_SkipAllEnvironments returns error when all envs are skipped.

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -72,8 +72,8 @@ func TestBuilder_Linear3EnvNoGates(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// 3 envs × (1 PRStatus + 1 PromotionStep) = 6
-	assert.Equal(t, 6, result.NodeCount)
-	assert.Len(t, result.Graph.Spec.Nodes, 6)
+	assert.Equal(t, 7, result.NodeCount)
+	assert.Len(t, result.Graph.Spec.Nodes, 7)
 
 	// Verify sequential dependency: uat depends on test, prod depends on uat
 	nodeMap := make(map[string]graph.GraphNode)
@@ -114,8 +114,8 @@ func TestBuilder_Linear3EnvWithProdGates(t *testing.T) {
 		PolicyGates: gates,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, 8, result.NodeCount, "3 PromotionStep + 3 PRStatus + 2 PolicyGate = 8 nodes")
-	assert.Len(t, result.Graph.Spec.Nodes, 8)
+	assert.Equal(t, 9, result.NodeCount, "3 PromotionStep + 3 PRStatus + 2 PolicyGate + 1 Bundle Watch = 9 nodes")
+	assert.Len(t, result.Graph.Spec.Nodes, 9)
 
 	// Verify PolicyGate nodes have propagateWhen set
 	for _, n := range result.Graph.Spec.Nodes {
@@ -145,7 +145,7 @@ func TestBuilder_FanOut(t *testing.T) {
 	result, err := b.Build(graph.BuildInput{Pipeline: pipeline, Bundle: bundle})
 	require.NoError(t, err)
 	// 4 envs × (1 PRStatus + 1 PromotionStep) = 8
-	assert.Equal(t, 8, result.NodeCount)
+	assert.Equal(t, 9, result.NodeCount)
 
 	// Both prod nodes must reference staging (using CEL-safe underscore IDs)
 	nodeMap := nodeByID(result.Graph.Spec.Nodes)
@@ -168,7 +168,7 @@ func TestBuilder_TargetEnvironment(t *testing.T) {
 	result, err := b.Build(graph.BuildInput{Pipeline: pipeline, Bundle: bundle})
 	require.NoError(t, err)
 	// 2 envs × (1 PRStatus + 1 PromotionStep) = 4
-	assert.Equal(t, 4, result.NodeCount, "test and staging envs: 2 PRStatus + 2 PromotionStep")
+	assert.Equal(t, 5, result.NodeCount, "test and staging envs: 2 PRStatus + 2 PromotionStep + 1 Bundle Watch")
 
 	nodeMap := nodeByID(result.Graph.Spec.Nodes)
 	assert.Contains(t, nodeMap, "test")
@@ -303,7 +303,7 @@ func TestBuilder_CustomSteps(t *testing.T) {
 	require.NoError(t, err)
 	// Just check that the builder doesn't fail; custom steps are populated in PromotionStep spec
 	// 2 envs × (1 PRStatus + 1 PromotionStep) = 4
-	assert.Equal(t, 4, result.NodeCount)
+	assert.Equal(t, 5, result.NodeCount)
 }
 
 // Test 9: Config Bundle uses config-merge step type.
@@ -321,7 +321,7 @@ func TestBuilder_ConfigBundle(t *testing.T) {
 	result, err := b.Build(graph.BuildInput{Pipeline: pipeline, Bundle: bundle})
 	require.NoError(t, err)
 	// 2 envs × (1 PRStatus + 1 PromotionStep) = 4
-	assert.Equal(t, 4, result.NodeCount)
+	assert.Equal(t, 5, result.NodeCount)
 
 	// Config Bundle nodes should have stepType indicating config-merge
 	nodeMap := nodeByID(result.Graph.Spec.Nodes)


### PR DESCRIPTION
## Summary

Adds a Bundle Watch node as the first node in every generated Graph spec. This brings `bundle.spec.*` fields into krocodile's CEL scope as live references.

## Why

Previously, Bundle fields (name, images, intent) were baked-in as Go-interpolated string literals in PromotionStep templates. If the Bundle changed after Graph creation, the Graph would not react. With a Watch node:

1. `bundle.metadata.name`, `bundle.spec.*` are now live CEL references
2. If Bundle changes (e.g., operator patches intent), the Graph re-evaluates downstream nodes via watch events
3. This is a **prerequisite for #619** (Bundle intent filtering via `includeWhen`) — `bundle.spec.intent.*` can only be used in `includeWhen` expressions once the Bundle is in the Graph scope

## Changes

- `pkg/graph/builder.go`: `bundleWatchNode` (id: `bundle`) added as first node
- `spec.bundleName` changed from `bundle.Name` literal to `${bundle.metadata.name}` CEL ref
- Tests: node counts incremented by 1

## krocodile >= 81c5a03 compat

Bundle Watch node has no `ReadyWhen`/`PropagateWhen`/`IncludeWhen` — per the 81c5a03 rule: Watch+signals → ReferenceUnresolved → SSA on Bundle CRD.

Closes #622