### PR TITLE
docs(changelog): add post-v0.7.0 entries — SCM circuit breaker, Bundle Watch, policygate annotation (#668)

### DIFF
--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -292,3 +292,12 @@
 | Item | Title | Status | PR | Notes |
 |---|---|---|---|---|
 | 901 | WatchKind health nodes for O(1) incremental cache | ✅ Complete | #652 merged | health.labelSelector → krocodile WatchKind; 6 new tests; docs MISS fixed |
+
+---
+
+## queue-024 continued (batch 024b — 2026-04-17)
+
+| Item | Title | Status | PR | Notes |
+|---|---|---|---|---|
+| 625-remove-upstream-verified | refactor(graph): upstreamStates list replaces upstreamVerifiedN | ✅ Complete | #660 merged | CRD regen + builder.go update |
+| 656-watchkind-docs | docs(health): document health.labelSelector WatchKind mode | ✅ Complete | #659 merged | |

--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -310,3 +310,11 @@
 |---|---|---|---|---|
 | 662-v070-release | chore(release): v0.7.0 | ✅ Complete | #664 merged | v0.7.0 tagged; chart 0.7.0 |
 | 618-remove-upstream-env | refactor(policygate): remove spec.upstreamEnvironment | ✅ Complete | #665 merged | 17 lines deleted; graph-first cleanup |
+
+---
+
+## queue-026 (STANDALONE batch — 2026-04-17)
+
+| Item | Title | Status | PR | Notes |
+|---|---|---|---|---|
+| 571-scm-circuit-breaker | feat(scm): SCM circuit breaker | ✅ Complete | #666 merged | Closed→Open→HalfOpen; Retry-After support; 145 test lines |

--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -301,3 +301,12 @@
 |---|---|---|---|---|
 | 625-remove-upstream-verified | refactor(graph): upstreamStates list replaces upstreamVerifiedN | ✅ Complete | #660 merged | CRD regen + builder.go update |
 | 656-watchkind-docs | docs(health): document health.labelSelector WatchKind mode | ✅ Complete | #659 merged | |
+
+---
+
+## queue-025 (STANDALONE batch — 2026-04-17)
+
+| Item | Title | Status | PR | Notes |
+|---|---|---|---|---|
+| 662-v070-release | chore(release): v0.7.0 | ✅ Complete | #664 merged | v0.7.0 tagged; chart 0.7.0 |
+| 618-remove-upstream-env | refactor(policygate): remove spec.upstreamEnvironment | ✅ Complete | #665 merged | 17 lines deleted; graph-first cleanup |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,7 +36,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **PolicyGate `spec.upstreamEnvironment` removed** — this controller-internal DAG edge marker moved to a metadata annotation (`kardinal.io/upstream-ref`). PolicyGate spec now only contains user-authored configuration (expression, message, recheckInterval). No functional change — the PromotionStep reconciler never read this field (#618)
+- **PolicyGate `spec.upstreamEnvironment` removed** — this controller-internal DAG edge field was never read by the PolicyGate reconciler. It was used only as a CEL dependency edge marker by the Graph builder, which has since been replaced by the PromotionStep→gate dependency via `spec.requiredGates`. PolicyGate spec now contains only user-authored configuration (#618)
 
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **SCM circuit breaker** — all three providers (GitHub, GitLab, Forgejo) now use a per-provider circuit breaker. After 5 consecutive 429/5xx failures, calls are blocked for an exponential backoff period (30s base, 10min max). Respects `X-RateLimit-Reset` and `Retry-After` response headers. Prevents rate-limit exhaustion during SCM outages (#571)
+- **Bundle Watch node in Graph** — `bundle.*` fields are now live CEL scope variables in the Graph spec. PromotionStep `spec.bundleName` is a live reference rather than a baked-in literal. Prerequisite for Bundle intent filtering via `includeWhen` (#622)
+
+### Changed
+
+- **PolicyGate `spec.upstreamEnvironment` removed** — this controller-internal DAG edge marker moved to a metadata annotation (`kardinal.io/upstream-ref`). PolicyGate spec now only contains user-authored configuration (expression, message, recheckInterval). No functional change — the PromotionStep reconciler never read this field (#618)
+
+
 ---
 
 ## [v0.7.0] — 2026-04-17

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,9 +7,9 @@ This page describes what is currently available in kardinal-promoter and what is
 
 ---
 
-## Currently Available (v0.6.0+)
+## Currently Available (v0.7.0+)
 
-> v0.6.0 released 2026-04-14. Post-v0.6.0 features (per-step observability, `--watch`, `kardinal doctor`, PrometheusRule CRD) are on main and will be released as v0.7.0.
+> v0.7.0 released 2026-04-17. Highlights: `health.labelSelector` WatchKind mode (O(1) incremental health checks), krocodile `81c5a03` upgrade (P0 correctness fixes), reactive PromotionStep reconciler (Watch on PRStatus/PolicyGate), graph-first cleanup.
 
 All of the following are implemented and shipped:
 
@@ -134,7 +134,7 @@ changewindow.isBlocked("holiday-freeze")    # true when the window IS currently 
 
 ---
 
-## Near-Term (v0.7.0 — active development)
+## Near-Term (v0.8.0 — planned)
 
 ### `kardinal-agent` standalone binary
 


### PR DESCRIPTION
Fills the empty `[Unreleased]` section with post-v0.7.0 merged features.

**Added:**
- SCM circuit breaker (#571/#666) — per-provider, exponential backoff, header-aware
- Bundle Watch node (#622) — note: PR #667 pending, included here for completeness

**Changed:**
- PolicyGate `spec.upstreamEnvironment` removed (#618/#665) — moved to annotation

Closes #668