### PR TITLE
feat(api): admission validation for Pipeline and Bundle CRDs (#573)

### DIFF
--- a/chart/kardinal-promoter/templates/validating-admission-policy.yaml
+++ b/chart/kardinal-promoter/templates/validating-admission-policy.yaml
@@ -47,3 +47,108 @@ spec:
   policyName: kardinal-policygate-validation
   validationActions: [Deny]
 {{- end }}
+---
+{{/*
+ValidatingAdmissionPolicy for Pipeline validation.
+Validates:
+  1. spec.environments is non-empty
+  2. Each environment has a non-empty name and gitRepo
+  3. Each environment's updateStrategy is one of: kustomize, helm, custom
+  4. Each environment's approvalMode is one of: pr-review, auto
+*/}}
+{{- if .Values.validatingAdmissionPolicy.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kardinal-pipeline-validation
+  labels:
+    {{- include "kardinal-promoter.labels" . | nindent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["kardinal.io"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["pipelines"]
+  validations:
+  - expression: "has(object.spec.environments) && object.spec.environments.size() > 0"
+    message: "spec.environments must contain at least one environment"
+    reason: Invalid
+  - expression: >
+      object.spec.environments.all(e, has(e.name) && e.name != '')
+    message: "each environment must have a non-empty name"
+    reason: Invalid
+  - expression: >
+      object.spec.environments.all(e, has(e.gitRepo) && e.gitRepo != '')
+    message: "each environment must have a non-empty gitRepo"
+    reason: Invalid
+  - expression: >
+      object.spec.environments.all(e,
+        !has(e.updateStrategy) || e.updateStrategy == '' ||
+        e.updateStrategy in ['kustomize', 'helm', 'custom'])
+    message: "each environment's updateStrategy must be one of: kustomize, helm, custom"
+    reason: Invalid
+  - expression: >
+      object.spec.environments.all(e,
+        !has(e.approval) || e.approval == '' ||
+        e.approval in ['pr-review', 'auto'])
+    message: "each environment's approval must be one of: pr-review, auto"
+    reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: kardinal-pipeline-validation
+  labels:
+    {{- include "kardinal-promoter.labels" . | nindent 4 }}
+spec:
+  policyName: kardinal-pipeline-validation
+  validationActions: [Deny]
+---
+{{/*
+ValidatingAdmissionPolicy for Bundle validation.
+Validates:
+  1. spec.pipeline is non-empty
+  2. If spec.type is 'image', spec.images must contain at least one entry
+  3. spec.type, if set, must be one of: image, config, mixed
+*/}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kardinal-bundle-validation
+  labels:
+    {{- include "kardinal-promoter.labels" . | nindent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["kardinal.io"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["bundles"]
+  validations:
+  - expression: "has(object.spec.pipeline) && object.spec.pipeline != ''"
+    message: "spec.pipeline must not be empty — provide the Pipeline name to promote"
+    reason: Invalid
+  - expression: >
+      !has(object.spec.type) || object.spec.type == '' ||
+      object.spec.type in ['image', 'config', 'mixed']
+    message: "spec.type must be one of: image, config, mixed"
+    reason: Invalid
+  - expression: >
+      !has(object.spec.type) || object.spec.type != 'image' ||
+      (has(object.spec.images) && object.spec.images.size() > 0)
+    message: "spec.images must contain at least one image when spec.type is 'image'"
+    reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: kardinal-bundle-validation
+  labels:
+    {{- include "kardinal-promoter.labels" . | nindent 4 }}
+spec:
+  policyName: kardinal-bundle-validation
+  validationActions: [Deny]
+{{- end }}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,32 @@
 
 Common problems and how to diagnose them.
 
+## Admission validation errors
+
+kardinal-promoter ships with `ValidatingAdmissionPolicy` rules (Kubernetes 1.28+) that catch configuration errors at `kubectl apply` time. If you see an admission error, check the table below.
+
+| Error message | Fix |
+|---|---|
+| `spec.environments must contain at least one environment` | Add at least one environment to your Pipeline spec |
+| `each environment must have a non-empty gitRepo` | Add `gitRepo: https://github.com/org/repo` to each environment |
+| `each environment's updateStrategy must be one of: kustomize, helm, custom` | Fix the `updateStrategy` field — only `kustomize`, `helm`, `custom` are valid |
+| `spec.pipeline must not be empty` | Add `pipeline: <name>` to your Bundle spec |
+| `spec.images must contain at least one image when spec.type is 'image'` | Add at least one entry to `spec.images` |
+| `spec.expression must not be empty` | Add a CEL expression to your PolicyGate spec |
+| `spec.recheckInterval must be a valid Go duration` | Use Go format: `5m`, `30s`, `1h` (not `5 minutes`) |
+
+**Disabling admission validation:**
+
+Admission validation is enabled by default and requires Kubernetes 1.28+. To disable (e.g., for kind clusters with older Kubernetes, or when using `--validate=false`):
+
+```yaml
+# values.yaml
+validatingAdmissionPolicy:
+  enabled: false
+```
+
+---
+
 ## Start here: `kardinal doctor`
 
 Before diving into specific issues, run the pre-flight check to rule out common


### PR DESCRIPTION
## Summary

Extends the existing `ValidatingAdmissionPolicy` to cover Pipeline and Bundle CRDs. Invalid configurations now fail at `kubectl apply` time rather than surfacing as status conditions minutes later.

## New VAP rules

**Pipeline validation** (`kardinal-pipeline-validation`):
- Environments list non-empty
- Each environment has a name and gitRepo
- `updateStrategy` is one of: `kustomize`, `helm`, `custom`
- `approval` is one of: `pr-review`, `auto`

**Bundle validation** (`kardinal-bundle-validation`):
- `spec.pipeline` non-empty
- `spec.type` is one of: `image`, `config`, `mixed`
- `spec.images` non-empty when `spec.type == 'image'`

## What remains at reconcile time

Circular dependency detection and pipeline-exists validation require cross-object references — these cannot be expressed in VAP CEL and remain as reconcile-time status conditions.

## Testing

Helm lint: ✅. Helm chart tests: ✅.

Closes #573