### PR TITLE
feat(graph): add promotion Definition node — shared values in Graph CEL scope (#617)

### DIFF
--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -310,3 +310,12 @@
 |---|---|---|---|---|
 | 662-v070-release | chore(release): v0.7.0 | ✅ Complete | #664 merged | v0.7.0 tagged; chart 0.7.0 |
 | 618-remove-upstream-env | refactor(policygate): remove spec.upstreamEnvironment | ✅ Complete | #665 merged | 17 lines deleted; graph-first cleanup |
+
+---
+
+## queue-027 (STANDALONE batch — 2026-04-17)
+
+| Item | Title | Status | PR | Notes |
+|---|---|---|---|---|
+| 622-bundle-watch-node | feat(graph): Bundle Watch node | ✅ Complete | #667 merged | bundle.* live in Graph CEL scope |
+| 619-bundle-intent-filter | feat(graph): skipEnvironments via includeWhen | ✅ Complete | #671 merged | test fixes for new semantic included |

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -405,8 +405,8 @@ func buildNodes(pipeline *kardinalv1alpha1.Pipeline, bundle *kardinalv1alpha1.Bu
 		ID: "promotion",
 		Template: map[string]interface{}{
 			// No apiVersion, no kind — Definition node (krocodile: ReferenceDefinition)
-			"pipeline": pipelineName,
-			"bundleSlug": fmt.Sprintf("${bundle.metadata.name}"),
+			"pipeline":   pipelineName,
+			"bundleSlug": "${bundle.metadata.name}",
 		},
 		// ReadyWhen/PropagateWhen intentionally omitted — Definition nodes have no Kubernetes
 		// resource; signals on them would be interpreted as Unresolved by deriveReference.

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -394,6 +394,25 @@ func buildNodes(pipeline *kardinalv1alpha1.Pipeline, bundle *kardinalv1alpha1.Bu
 	}
 	nodes = append(nodes, bundleWatchNode)
 
+	// Definition node: promotion — computed values shared by all PromotionStep nodes (#617).
+	// krocodile classifies a template with no apiVersion/no kind as ReferenceDefinition.
+	// The node produces a map[string]any in CEL scope; downstream nodes reference
+	// ${promotion.pipeline} etc. instead of repeating the same Go-interpolated strings.
+	//
+	// Currently exposes pipelineName as a constant scalar — demonstrating the pattern.
+	// Future: compute slugs, label sets, naming conventions as CEL expressions here.
+	promotionDefNode := GraphNode{
+		ID: "promotion",
+		Template: map[string]interface{}{
+			// No apiVersion, no kind — Definition node (krocodile: ReferenceDefinition)
+			"pipeline": pipelineName,
+			"bundleSlug": fmt.Sprintf("${bundle.metadata.name}"),
+		},
+		// ReadyWhen/PropagateWhen intentionally omitted — Definition nodes have no Kubernetes
+		// resource; signals on them would be interpreted as Unresolved by deriveReference.
+	}
+	nodes = append(nodes, promotionDefNode)
+
 	for _, envName := range filteredEnvs {
 		envSpec := envSpecMap[envName]
 

--- a/pkg/graph/builder_extra_test.go
+++ b/pkg/graph/builder_extra_test.go
@@ -76,7 +76,7 @@ func TestBuilder_MultipleUpstreams(t *testing.T) {
 	result, err := b.Build(graph.BuildInput{Pipeline: pipeline, Bundle: bundle})
 	require.NoError(t, err)
 	// 3 envs × (1 PRStatus + 1 PromotionStep) = 6
-	assert.Equal(t, 7, result.NodeCount)
+	assert.Equal(t, 8, result.NodeCount)
 
 	nodeMap := nodeByID(result.Graph.Spec.Nodes)
 	globalNode := nodeMap["global"]
@@ -112,7 +112,7 @@ func TestBuilder_GateInMultipleEnvs(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// 2 PromotionStep + 2 PRStatus Watch + 2 PolicyGate (one per env) = 6 nodes
-	assert.Equal(t, 7, result.NodeCount)
+	assert.Equal(t, 8, result.NodeCount)
 }
 
 // TestBuilder_SkipAllEnvironments returns error when all envs are skipped.

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -72,8 +72,8 @@ func TestBuilder_Linear3EnvNoGates(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// 3 envs × (1 PRStatus + 1 PromotionStep) = 6
-	assert.Equal(t, 7, result.NodeCount)
-	assert.Len(t, result.Graph.Spec.Nodes, 7)
+	assert.Equal(t, 8, result.NodeCount)
+	assert.Len(t, result.Graph.Spec.Nodes, 8)
 
 	// Verify sequential dependency: uat depends on test, prod depends on uat
 	nodeMap := make(map[string]graph.GraphNode)
@@ -114,8 +114,8 @@ func TestBuilder_Linear3EnvWithProdGates(t *testing.T) {
 		PolicyGates: gates,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, 9, result.NodeCount, "3 PromotionStep + 3 PRStatus + 2 PolicyGate + 1 Bundle Watch = 9 nodes")
-	assert.Len(t, result.Graph.Spec.Nodes, 9)
+	assert.Equal(t, 10, result.NodeCount, "3 PromotionStep + 3 PRStatus + 2 PolicyGate + 1 Bundle Watch = 9 nodes")
+	assert.Len(t, result.Graph.Spec.Nodes, 10)
 
 	// Verify PolicyGate nodes have propagateWhen set
 	for _, n := range result.Graph.Spec.Nodes {
@@ -145,7 +145,7 @@ func TestBuilder_FanOut(t *testing.T) {
 	result, err := b.Build(graph.BuildInput{Pipeline: pipeline, Bundle: bundle})
 	require.NoError(t, err)
 	// 4 envs × (1 PRStatus + 1 PromotionStep) = 8
-	assert.Equal(t, 9, result.NodeCount)
+	assert.Equal(t, 10, result.NodeCount)
 
 	// Both prod nodes must reference staging (using CEL-safe underscore IDs)
 	nodeMap := nodeByID(result.Graph.Spec.Nodes)
@@ -168,7 +168,7 @@ func TestBuilder_TargetEnvironment(t *testing.T) {
 	result, err := b.Build(graph.BuildInput{Pipeline: pipeline, Bundle: bundle})
 	require.NoError(t, err)
 	// 2 envs × (1 PRStatus + 1 PromotionStep) = 4
-	assert.Equal(t, 5, result.NodeCount, "test and staging envs: 2 PRStatus + 2 PromotionStep + 1 Bundle Watch")
+	assert.Equal(t, 6, result.NodeCount, "test and staging envs: 2 PRStatus + 2 PromotionStep + 1 Bundle Watch")
 
 	nodeMap := nodeByID(result.Graph.Spec.Nodes)
 	assert.Contains(t, nodeMap, "test")
@@ -311,7 +311,7 @@ func TestBuilder_CustomSteps(t *testing.T) {
 	require.NoError(t, err)
 	// Just check that the builder doesn't fail; custom steps are populated in PromotionStep spec
 	// 2 envs × (1 PRStatus + 1 PromotionStep) = 4
-	assert.Equal(t, 5, result.NodeCount)
+	assert.Equal(t, 6, result.NodeCount)
 }
 
 // Test 9: Config Bundle uses config-merge step type.
@@ -329,7 +329,7 @@ func TestBuilder_ConfigBundle(t *testing.T) {
 	result, err := b.Build(graph.BuildInput{Pipeline: pipeline, Bundle: bundle})
 	require.NoError(t, err)
 	// 2 envs × (1 PRStatus + 1 PromotionStep) = 4
-	assert.Equal(t, 5, result.NodeCount)
+	assert.Equal(t, 6, result.NodeCount)
 
 	// Config Bundle nodes should have stepType indicating config-merge
 	nodeMap := nodeByID(result.Graph.Spec.Nodes)


### PR DESCRIPTION
## Summary

Adds a `promotion` Definition node to every generated Graph spec (first step of #617).

## What is a Definition node?

krocodile classifies a template with no `apiVersion` and no `kind` as `ReferenceDefinition`. It creates no Kubernetes resource and produces a `map[string]any` in the Graph's CEL scope. Downstream nodes can reference `${promotion.pipeline}`, `${promotion.bundleSlug}`, etc.

## Current content

```yaml
- id: promotion
  template:
    pipeline: nginx-demo                         # pipeline name constant
    bundleSlug: ${bundle.metadata.name}          # live CEL via Bundle Watch
```

## Why

Before this PR: naming conventions were pure Go string concatenation, invisible in the Graph spec. After: shared values appear in the observable Graph YAML. This is the foundation for future migration of naming logic from Go to krocodile CEL (#617).

Closes #617