### PR TITLE
chore(graph): upgrade krocodile pin 81c5a03 → 05db829 — explicit-keyword schema

### DIFF
--- a/chart/kardinal-promoter/Chart.yaml
+++ b/chart/kardinal-promoter/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 annotations:
   # The krocodile commit bundled in this chart version.
   # Built and pushed to ghcr.io/pnz1990/kardinal-promoter/krocodile:<commit>
-  krocodile.commit: "81c5a03"
+  krocodile.commit: "05db829"

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -129,7 +129,7 @@ krocodile:
   # This is the commit the release pipeline built the image from.
   # Used as the default image tag when image.tag is not set.
   # Update via the krocodile upgrade protocol in AGENTS.md.
-  pinnedCommit: "81c5a03"
+  pinnedCommit: "05db829"
 
   # -- API group for Graph CRDs.
   apiGroup: "experimental.kro.run"

--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -319,3 +319,12 @@
 |---|---|---|---|---|
 | 622-bundle-watch-node | feat(graph): Bundle Watch node | ✅ Complete | #667 merged | bundle.* live in Graph CEL scope |
 | 619-bundle-intent-filter | feat(graph): skipEnvironments via includeWhen | ✅ Complete | #671 merged | test fixes for new semantic included |
+
+---
+
+## queue-028 (STANDALONE batch — 2026-04-17)
+
+| Item | Title | Status | PR | Notes |
+|---|---|---|---|---|
+| 573-admission-webhook | feat(api): Pipeline/Bundle VAP extension | ✅ Complete | #670 merged | 2 new VAP policies |
+| 617-definition-nodes | feat(graph): Definition nodes for naming | ⛔ NEEDS HUMAN | — | False premise: Go strings not in krocodile CEL scope |

--- a/docs/aide/progress.md
+++ b/docs/aide/progress.md
@@ -310,3 +310,12 @@
 |---|---|---|---|---|
 | 662-v070-release | chore(release): v0.7.0 | ✅ Complete | #664 merged | v0.7.0 tagged; chart 0.7.0 |
 | 618-remove-upstream-env | refactor(policygate): remove spec.upstreamEnvironment | ✅ Complete | #665 merged | 17 lines deleted; graph-first cleanup |
+
+---
+
+## queue-027 (STANDALONE batch — 2026-04-17)
+
+| Item | Title | Status | PR | Notes |
+|---|---|---|---|---|
+| 622-bundle-watch-node | feat(graph): Bundle Watch node | ✅ Complete | #667 merged | bundle.* live in Graph CEL scope |
+| 619-bundle-intent-filter | feat(graph): skipEnvironments via includeWhen | ✅ Complete | #671 merged | test fixes for new semantic included |

--- a/hack/install-krocodile.sh
+++ b/hack/install-krocodile.sh
@@ -16,17 +16,16 @@ set -euo pipefail
 # ── Pinned version ─────────────────────────────────────────────────────────────
 # Update this when intentionally upgrading krocodile.
 # Minimum required: 1b0ce353 (fixes double-dispatch race in DAG coordinator)
-# Last verified:    81c5a03 (2026-04-17 — 21 commits since 745998f; highlights:
-#                           - P0 correctness: WatchKind cache loss on GET error fixed (#136)
-#                           - P0 correctness: empty WatchKind no longer vacuous-true (#136)
-#                           - Stable topological sort via min-heap Kahn's (#127, #134)
-#                           - ResolvedReference type split (internal only — no kardinal impact)
-#                           - SSA field manager format: <name>.<namespace>.internal.kro.run (#139)
-#                           - Singleton node ID rename (internal — kardinal uses Watch/Own only)
-#                           - RGD compat test harness added (#130, #137, #146)
-#                           - ForEach parent scope publish order fix (#136))
+# Last verified:    05db829 (2026-04-17 — 5 commits since 81c5a03; highlights:
+#                           - BREAKING: explicit-keyword schema for Graph nodes (#150)
+#                             template: → Own, patch: → Contribute, ref: → Ref (single),
+#                             watch: → Watch (collection), def: → Definition
+#                             kardinal compat: Watch nodes → ref:, WatchKind → watch:
+#                           - stdlib: rename Kind items, Singleton holder (#155)
+#                           - stdlib: cluster-scoped Kind, printer columns (#152)
+#                           - RGD stdlib: instance GVK labels + force-apply (#149))
 KROCODILE_REPO="https://github.com/ellistarn/kro.git"
-KROCODILE_COMMIT="${KROCODILE_COMMIT:-81c5a03}"
+KROCODILE_COMMIT="${KROCODILE_COMMIT:-05db829}"
 KROCODILE_IMAGE="krocodile-graph-controller:${KROCODILE_COMMIT}"
 KIND_CLUSTER="${KIND_CLUSTER:-kardinal-e2e}"
 

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -377,12 +377,12 @@ func buildNodes(pipeline *kardinalv1alpha1.Pipeline, bundle *kardinalv1alpha1.Bu
 	// This is a single named Watch reference (not WatchKind) — the translator
 	// knows the exact Bundle name at graph generation time.
 	//
-	// krocodile >= 81c5a03: Watch node must NOT have ReadyWhen/PropagateWhen/IncludeWhen.
-	// deriveReference upgrades Watch+signals -> ReferenceUnresolved -> SSA on Bundle CRD.
-	// The Bundle Watch is read-only; all signals belong on PromotionStep nodes.
+	// krocodile ≥ 05db829 (explicit-keyword schema): identity-only Watch nodes
+	// must use the ref: keyword, not template:. template: always means Own.
+	// The Bundle Watch is read-only — use ref: to dereference it into scope.
 	bundleWatchNode := GraphNode{
 		ID: "bundle",
-		Template: map[string]interface{}{
+		Ref: map[string]interface{}{
 			"apiVersion": "kardinal.io/v1alpha1",
 			"kind":       "Bundle",
 			"metadata": map[string]interface{}{
@@ -390,7 +390,7 @@ func buildNodes(pipeline *kardinalv1alpha1.Pipeline, bundle *kardinalv1alpha1.Bu
 				"namespace": bundle.Namespace,
 			},
 		},
-		// ReadyWhen/PropagateWhen intentionally omitted — Watch node, not Owned node.
+		// ReadyWhen/PropagateWhen intentionally omitted — ref: is read-only.
 	}
 	nodes = append(nodes, bundleWatchNode)
 

--- a/pkg/graph/types.go
+++ b/pkg/graph/types.go
@@ -85,7 +85,21 @@ type GraphNode struct {
 
 	// Template is the raw resource template for this node.
 	// Stored as a map to allow arbitrary Kubernetes resource shapes.
+	// Template is the node body for an Own node (Graph creates the resource).
+	// Serialized as "template:" key — krocodile ≥ 05db829 (explicit-keyword schema).
+	// Previous name for this concept: "template" was also used for Watch/WatchKind,
+	// but those now use Ref/Watch fields.
 	Template map[string]interface{} `json:"template,omitempty"`
+
+	// Ref is the identity for a Ref node (dereference a single named object into scope).
+	// Serialized as "ref:" key — krocodile ≥ 05db829 (explicit-keyword schema).
+	// Replaces the old "template: {apiVersion, kind, metadata.name}" identity-only form.
+	Ref map[string]interface{} `json:"ref,omitempty"`
+
+	// Watch is the selector for a Watch node (observe a collection by selector).
+	// Serialized as "watch:" key — krocodile ≥ 05db829 (explicit-keyword schema).
+	// Replaces the old "template: {apiVersion, kind, selector}" WatchKind form.
+	Watch map[string]interface{} `json:"watch,omitempty"`
 
 	// ReadyWhen holds CEL expressions that are a health signal only.
 	// They feed the Graph's aggregated Ready condition and the UI.
@@ -114,6 +128,18 @@ func (in *GraphNode) DeepCopyInto(out *GraphNode) {
 		out.Template = make(map[string]interface{}, len(in.Template))
 		for k, v := range in.Template {
 			out.Template[k] = v
+		}
+	}
+	if in.Ref != nil {
+		out.Ref = make(map[string]interface{}, len(in.Ref))
+		for k, v := range in.Ref {
+			out.Ref[k] = v
+		}
+	}
+	if in.Watch != nil {
+		out.Watch = make(map[string]interface{}, len(in.Watch))
+		for k, v := range in.Watch {
+			out.Watch[k] = v
 		}
 	}
 	if in.ReadyWhen != nil {

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -192,53 +192,43 @@ func injectHealthWatchNodes(
 		// Substitute the "healthNode" placeholder in ReadyWhen with the actual node ID.
 		readyWhen := strings.ReplaceAll(spec.ReadyWhen, "healthNode", nodeID)
 
-		// Build the Graph node template.
-		// krocodile auto-detects the reference type from the template structure
-		// (experimental/controller/types.go: DetectReference):
-		//   - Watch:     apiVersion + kind + metadata.name  (single named resource)
-		//   - WatchKind: apiVersion + kind, no metadata.name (collection by selector)
-		var nodeTemplate map[string]interface{}
+		// Build the Graph node.
+		// krocodile ≥ 05db829 (explicit-keyword schema):
+		//   - ref:   → dereference a single named object (by-name, read-only)
+		//   - watch: → observe a collection by selector (read-only)
+		// The old "template:" key with identity-only body is no longer valid for
+		// read-only nodes — it means Own (Graph creates the resource) in the new schema.
+		var watchNode graph.GraphNode
 		if spec.UseWatchKind {
-			// WatchKind: no metadata.name — krocodile watches all resources matching
-			// the label selector.
-			//
-			// krocodile (node.go:reconcileWatchKind) extracts the selector from
-			// tmpl["selector"] (flat top-level key) or tmpl["metadata"]["selector"].
-			// We use the flat top-level form as it is simpler and matches the
-			// krocodile source exactly.
-			//
-			// Namespace: krocodile ≥ 81c5a03 changed WatchKind namespace from
-			// graph.GetNamespace() to tmpl["metadata"]["namespace"] (absent = cluster-wide).
-			// We must include the namespace to scope the watch to the environment namespace.
-			// Note: metadata.name is intentionally omitted — krocodile uses its absence to
-			// classify this as ReferenceWatchKind rather than ReferenceWatch.
-			nodeTemplate = map[string]interface{}{
-				"apiVersion": spec.APIVersion,
-				"kind":       spec.Kind,
-				"selector":   spec.LabelSelector,
-				"metadata": map[string]interface{}{
-					"namespace": spec.Namespace,
+			// WatchKind → watch: keyword. selector at top level, namespace in metadata.
+			// krocodile ≥ 81c5a03: namespace from watch["metadata"]["namespace"]
+			// (absent = cluster-wide). Include namespace for env scoping.
+			watchNode = graph.GraphNode{
+				ID: nodeID,
+				Watch: map[string]interface{}{
+					"apiVersion": spec.APIVersion,
+					"kind":       spec.Kind,
+					"selector":   spec.LabelSelector,
+					"metadata": map[string]interface{}{
+						"namespace": spec.Namespace,
+					},
 				},
+				ReadyWhen: []string{readyWhen},
 			}
 		} else {
-			// Watch: identity-only template (apiVersion + kind + metadata.name).
-			// An identity-only template is classified ReferenceWatch by krocodile's
-			// DetectReference (experimental/controller/types.go). Existing behavior — unchanged.
-			nodeTemplate = map[string]interface{}{
-				"apiVersion": spec.APIVersion,
-				"kind":       spec.Kind,
-				"metadata": map[string]interface{}{
-					"name":      spec.Name,
-					"namespace": spec.Namespace,
+			// Single-named Watch → ref: keyword (by-name dereference).
+			watchNode = graph.GraphNode{
+				ID: nodeID,
+				Ref: map[string]interface{}{
+					"apiVersion": spec.APIVersion,
+					"kind":       spec.Kind,
+					"metadata": map[string]interface{}{
+						"name":      spec.Name,
+						"namespace": spec.Namespace,
+					},
 				},
+				ReadyWhen: []string{readyWhen},
 			}
-		}
-
-		// Build the watch node.
-		watchNode := graph.GraphNode{
-			ID:        nodeID,
-			Template:  nodeTemplate,
-			ReadyWhen: []string{readyWhen},
 		}
 		g.Spec.Nodes = append(g.Spec.Nodes, watchNode)
 

--- a/pkg/translator/translator_health_test.go
+++ b/pkg/translator/translator_health_test.go
@@ -106,7 +106,7 @@ func TestInjectHealthWatchNodes_Resource(t *testing.T) {
 
 	// Template must be identity-only (Watch-reference auto-detection):
 	// Only apiVersion, kind, metadata.name/namespace
-	tmpl := watchNode.Template
+	tmpl := watchNode.Ref
 	assert.Equal(t, "apps/v1", tmpl["apiVersion"])
 	assert.Equal(t, "Deployment", tmpl["kind"])
 	md := tmpl["metadata"].(map[string]interface{})
@@ -146,7 +146,7 @@ func TestInjectHealthWatchNodes_ArgoCD(t *testing.T) {
 	watchNode := findHealthNode(g, "prod")
 	require.NotNil(t, watchNode)
 
-	tmpl := watchNode.Template
+	tmpl := watchNode.Ref
 	assert.Equal(t, "argoproj.io/v1alpha1", tmpl["apiVersion"])
 	assert.Equal(t, "Application", tmpl["kind"])
 	md := tmpl["metadata"].(map[string]interface{})
@@ -172,7 +172,7 @@ func TestInjectHealthWatchNodes_Flux(t *testing.T) {
 	watchNode := findHealthNode(g, "staging")
 	require.NotNil(t, watchNode)
 
-	tmpl := watchNode.Template
+	tmpl := watchNode.Ref
 	assert.Equal(t, "kustomize.toolkit.fluxcd.io/v1", tmpl["apiVersion"])
 	assert.Equal(t, "Kustomization", tmpl["kind"])
 	md := tmpl["metadata"].(map[string]interface{})
@@ -198,7 +198,7 @@ func TestInjectHealthWatchNodes_ArgoRollouts(t *testing.T) {
 	require.NotNil(t, watchNode)
 	assert.Equal(t, "healthProdEu", watchNode.ID, "hyphens in env name become camelCase word boundaries")
 
-	tmpl := watchNode.Template
+	tmpl := watchNode.Ref
 	assert.Equal(t, "argoproj.io/v1alpha1", tmpl["apiVersion"])
 	assert.Equal(t, "Rollout", tmpl["kind"])
 	md := tmpl["metadata"].(map[string]interface{})
@@ -220,7 +220,7 @@ func TestInjectHealthWatchNodes_Flagger(t *testing.T) {
 	watchNode := findHealthNode(g, "prod")
 	require.NotNil(t, watchNode)
 
-	tmpl := watchNode.Template
+	tmpl := watchNode.Ref
 	assert.Equal(t, "flagger.app/v1beta1", tmpl["apiVersion"])
 	assert.Equal(t, "Canary", tmpl["kind"])
 	assert.Contains(t, watchNode.ReadyWhen[0], "Succeeded")
@@ -384,7 +384,7 @@ func TestInjectHealthWatchNodes_WatchNodeIsIdentityOnly(t *testing.T) {
 			watchNode := findHealthNode(g, "prod")
 			require.NotNil(t, watchNode, "health Watch node must exist for type %s", tc.healthType)
 
-			tmpl := watchNode.Template
+			tmpl := watchNode.Ref
 
 			// Only allowed top-level keys: apiVersion, kind, metadata
 			for k := range tmpl {
@@ -477,7 +477,8 @@ func TestInjectHealthWatchNodes_ResourceWatchKind(t *testing.T) {
 	watchNode := findHealthNode(g, "prod")
 	require.NotNil(t, watchNode, "health node for prod must be present")
 
-	tmpl := watchNode.Template
+	// krocodile ≥ 05db829: WatchKind nodes use watch: keyword, not ref: or template:
+	tmpl := watchNode.Watch
 	assert.Equal(t, "apps/v1", tmpl["apiVersion"])
 	assert.Equal(t, "Deployment", tmpl["kind"])
 
@@ -520,7 +521,8 @@ func TestInjectHealthWatchNodes_ResourceWatchKindVsWatch(t *testing.T) {
 
 	watchNode := findHealthNode(gWatch, "uat")
 	require.NotNil(t, watchNode)
-	tmplWatch := watchNode.Template
+	// krocodile ≥ 05db829: single-named Watch nodes use ref: keyword
+	tmplWatch := watchNode.Ref
 	// Watch: must have metadata.name
 	md := tmplWatch["metadata"].(map[string]interface{})
 	assert.Equal(t, "myapp", md["name"])
@@ -542,9 +544,9 @@ func TestInjectHealthWatchNodes_ResourceWatchKindVsWatch(t *testing.T) {
 
 	watchKindNode := findHealthNode(gWatchKind, "uat")
 	require.NotNil(t, watchKindNode)
-	tmplWatchKind := watchKindNode.Template
+	// krocodile ≥ 05db829: WatchKind nodes use watch: keyword
+	tmplWatchKind := watchKindNode.Watch
 	// WatchKind: metadata IS present (with namespace) but must NOT have metadata.name.
-	// krocodile ≥ 81c5a03: WatchKind namespace from tmpl["metadata"]["namespace"], not graph.GetNamespace().
 	wkMd, hasMd := tmplWatchKind["metadata"].(map[string]interface{})
 	require.True(t, hasMd, "WatchKind node must have metadata block for namespace scoping")
 	_, hasName := wkMd["name"]


### PR DESCRIPTION
## Summary

Upgrades krocodile from `81c5a03` to `05db829` (5 commits). Contains a **breaking change** requiring kardinal compat fixes.

## Breaking change: explicit-keyword schema (#150)

krocodile 05db829 replaces shape-sniffing for node type with declared keywords:

| Keyword | NodeType | Behavior |
|---|---|---|
| `template:` | Own | Graph creates the resource |
| `patch:` | Contribute | Graph writes fields on existing resource |
| `ref:` | Ref | Read single named object into scope |
| `watch:` | Watch | Observe collection by selector |
| `def:` | Definition | Computed values in scope, no K8s resource |

Under the old schema, `template:` with identity-only body was a Watch. Under the new schema, `template:` ALWAYS means Own. Using `template:` for a Watch node would cause krocodile to try to create/patch Bundle CRDs, health adapter CRDs, etc.

## Compat fixes

- `pkg/graph/types.go`: add `Ref` and `Watch` fields to `GraphNode`
- `pkg/graph/builder.go`: Bundle Watch node uses `Ref` field (not `Template`)
- `pkg/translator/translator.go`: health Watch nodes use `Ref`; WatchKind nodes use `Watch`
- Tests: `watchNode.Ref` for single-named Watch, `watchNode.Watch` for WatchKind

## Other changes in 05db829

- stdlib: rename Kind items, Singleton holder (#155)
- stdlib: cluster-scoped Kind, printer columns, instance count (#152)
- RGD stdlib: instance GVK labels + force-apply (#149)

None of these require additional kardinal changes.

All tests pass. Closes #646.