### PR TITLE
feat(cli): improve error messages — actionable hints for common failures (#688)

### DIFF
--- a/cmd/kardinal/cmd/format.go
+++ b/cmd/kardinal/cmd/format.go
@@ -76,6 +76,13 @@ func FormatPipelineTable(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1a
 // showNamespace parameter. When showNamespace is true, a NAMESPACE column is prepended
 // to each row (used by --all-namespaces flag).
 func FormatPipelineTableWithOptions(w io.Writer, pipelines []v1alpha1.Pipeline, steps []v1alpha1.PromotionStep, showNamespace bool) error {
+	if len(pipelines) == 0 {
+		_, _ = fmt.Fprintln(w, "No pipelines found.")
+		_, _ = fmt.Fprintln(w, "  To get started, apply a Pipeline CRD:")
+		_, _ = fmt.Fprintln(w, "    kubectl apply -f examples/quickstart/pipeline.yaml")
+		_, _ = fmt.Fprintln(w, "  Or check CRD installation with: kardinal doctor")
+		return nil
+	}
 	// When multiple PromotionSteps exist for the same pipeline+env (from different
 	// bundles), prefer the one with the highest state priority, then most recently
 	// created.

--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -87,6 +87,7 @@ It communicates with the Kubernetes API server to read and write CRDs.`,
 }
 
 // buildClient constructs a controller-runtime client from the persistent flags.
+// Returns actionable error messages with hints for common failures (#688).
 func buildClient() (sigs_client.Client, string, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if globalKubeconfig != "" {
@@ -105,13 +106,16 @@ func buildClient() (sigs_client.Client, string, error) {
 		// Fall back to in-cluster config.
 		cfg, err = rest.InClusterConfig()
 		if err != nil {
-			return nil, "", fmt.Errorf("build kubeconfig: %w", err)
+			return nil, "", fmt.Errorf(
+				"cannot connect to cluster — run 'kardinal doctor' to diagnose\n"+
+					"  (underlying error: %w)", err)
 		}
 	}
 
 	c, err := sigs_client.New(cfg, sigs_client.Options{Scheme: rootScheme})
 	if err != nil {
-		return nil, "", fmt.Errorf("create k8s client: %w", err)
+		return nil, "", fmt.Errorf(
+			"failed to create Kubernetes client — check cluster connectivity: %w", err)
 	}
 
 	// Resolve namespace.


### PR DESCRIPTION
## Summary

Two DX improvements (#688):

1. `buildClient()` connection failures now show: _"cannot connect to cluster — run 'kardinal doctor' to diagnose"_
2. Empty pipeline list shows onboarding hints when no pipelines are found

Closes #688