### PR TITLE
feat(cli): improve error messages — actionable hints for common failures (#688)

### DIFF
--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,6 +88,27 @@ It communicates with the Kubernetes API server to read and write CRDs.`,
 }
 
 // buildClient constructs a controller-runtime client from the persistent flags.
+// enrichClientError adds actionable hints to common connection errors.
+// It helps users understand what went wrong without requiring deep Kubernetes knowledge.
+func enrichClientError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "no such file") || strings.Contains(msg, "kubeconfig"):
+		return fmt.Errorf("%w\n\nHint: no kubeconfig found — run 'kardinal doctor' to diagnose, or set --kubeconfig / KUBECONFIG", err)
+	case strings.Contains(msg, "context deadline exceeded") || strings.Contains(msg, "connection refused") || strings.Contains(msg, "i/o timeout"):
+		return fmt.Errorf("%w\n\nHint: cannot reach the cluster — check 'kubectl cluster-info' and run 'kardinal doctor'", err)
+	case strings.Contains(msg, "Forbidden") || strings.Contains(msg, "forbidden"):
+		return fmt.Errorf("%w\n\nHint: RBAC permission denied — check ServiceAccount permissions or run 'kardinal doctor'", err)
+	case strings.Contains(msg, "no kind is registered") || strings.Contains(msg, "no matches for kind"):
+		return fmt.Errorf("%w\n\nHint: kardinal CRDs not installed — run 'helm install kardinal ...' or 'make install'", err)
+	}
+	return err
+}
+
+
 func buildClient() (sigs_client.Client, string, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if globalKubeconfig != "" {
@@ -105,13 +127,13 @@ func buildClient() (sigs_client.Client, string, error) {
 		// Fall back to in-cluster config.
 		cfg, err = rest.InClusterConfig()
 		if err != nil {
-			return nil, "", fmt.Errorf("build kubeconfig: %w", err)
+			return nil, "", enrichClientError(fmt.Errorf("build kubeconfig: %w", err))
 		}
 	}
 
 	c, err := sigs_client.New(cfg, sigs_client.Options{Scheme: rootScheme})
 	if err != nil {
-		return nil, "", fmt.Errorf("create k8s client: %w", err)
+		return nil, "", enrichClientError(fmt.Errorf("create k8s client: %w", err))
 	}
 
 	// Resolve namespace.

--- a/cmd/kardinal/cmd/root_test.go
+++ b/cmd/kardinal/cmd/root_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnrichClientError verifies that enrichClientError adds actionable hints
+// to known connection failures without changing unknown errors.
+func TestEnrichClientError(t *testing.T) {
+	cases := []struct {
+		name          string
+		inputMsg      string
+		wantHint      string
+		wantUnchanged bool
+	}{
+		{
+			name:     "kubeconfig not found",
+			inputMsg: "build kubeconfig: no such file or directory",
+			wantHint: "kardinal doctor",
+		},
+		{
+			name:     "context deadline",
+			inputMsg: "context deadline exceeded while connecting",
+			wantHint: "kubectl cluster-info",
+		},
+		{
+			name:     "forbidden RBAC",
+			inputMsg: "Forbidden: access denied",
+			wantHint: "RBAC permission denied",
+		},
+		{
+			name:     "CRD not installed",
+			inputMsg: "no kind is registered for Pipeline",
+			wantHint: "CRDs not installed",
+		},
+		{
+			name:          "unknown error unchanged",
+			inputMsg:      "some unknown error",
+			wantUnchanged: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := fmt.Errorf("%s", tc.inputMsg) //nolint:err113
+			got := enrichClientError(input)
+			require.NotNil(t, got)
+			if tc.wantUnchanged {
+				assert.Equal(t, input.Error(), got.Error())
+			} else {
+				assert.Contains(t, got.Error(), tc.wantHint)
+				assert.Contains(t, got.Error(), tc.inputMsg, "original error must be preserved")
+			}
+		})
+	}
+}
+
+// TestEnrichClientError_Nil verifies that nil error is returned unchanged.
+func TestEnrichClientError_Nil(t *testing.T) {
+	assert.Nil(t, enrichClientError(nil))
+}


### PR DESCRIPTION
## Summary

Adds `enrichClientError()` to `buildClient()` which detects common Kubernetes connection failure patterns and appends actionable hints.

## Error patterns covered

| Pattern | Hint |
|---|---|
| kubeconfig not found | run `kardinal doctor` |
| context deadline / connection refused | check `kubectl cluster-info` |
| Forbidden / RBAC | check ServiceAccount permissions |
| CRD not installed | run `helm install` or `make install` |

Unknown errors are returned unchanged (no false positives).