### PR TITLE
feat(security): add syft SBOM generation to release workflow (#694)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,15 @@ jobs:
             org.opencontainers.image.version=${{ env.VERSION }}
             org.opencontainers.image.revision=${{ github.sha }}
 
+      # ── SBOM generation ──────────────────────────────────────────────────────
+      - name: Generate SBOM with syft (CycloneDX JSON)
+        uses: anchore/sbom-action@v0.17.2
+        with:
+          image: ghcr.io/pnz1990/kardinal-promoter/controller:${{ env.VERSION }}
+          format: cyclonedx-json
+          output-file: dist/kardinal-promoter-${{ env.VERSION }}-sbom.json
+          upload-artifact: false
+
       # ── Package and publish Helm chart ─────────────────────────────────────
       - name: Update chart version and krocodile tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,15 @@ jobs:
           image: ghcr.io/pnz1990/kardinal-promoter/controller:${{ env.VERSION }}
           format: cyclonedx-json
           output-file: dist/kardinal-promoter-${{ env.VERSION }}-sbom.json
-          upload-artifact: false
+          upload-artifact: true
+          artifact-name: sbom-${{ env.VERSION }}.json
+
+      - name: Upload SBOM to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ env.VERSION }}
+        run: |
+          gh release upload "${VERSION}"             "dist/kardinal-promoter-${VERSION}-sbom.json#SBOM (CycloneDX JSON)"             --clobber
 
       # ── Package and publish Helm chart ─────────────────────────────────────
       - name: Update chart version and krocodile tag


### PR DESCRIPTION
Generates a CycloneDX JSON SBOM for the controller container image using anchore/sbom-action. Output is saved to dist/ and included in the GitHub release. Part of epic #581.