### PR TITLE
feat(security): cosign keyless image signing in release workflow (#699)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,19 @@ jobs:
             org.opencontainers.image.version=${{ env.VERSION }}
             org.opencontainers.image.revision=${{ github.sha }}
 
+      # ── Cosign keyless image signing ──────────────────────────────────────────
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: v2.4.3
+
+      - name: Sign controller image with cosign (keyless — GitHub Actions OIDC)
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          cosign sign --yes \
+            ghcr.io/pnz1990/kardinal-promoter/controller:${{ env.VERSION }}
+
       # ── Vulnerability scanning ──────────────────────────────────────────────
       - name: Scan controller image for HIGH/CRITICAL CVEs (trivy)
         uses: aquasecurity/trivy-action@0.31.0


### PR DESCRIPTION
## Summary

Signs the controller image with cosign keyless signing after push.

Uses GitHub Actions OIDC — no private key management required. The signature and build provenance are recorded in the Sigstore transparency log.

## Verification

```bash
cosign verify ghcr.io/pnz1990/kardinal-promoter/controller:v0.9.0 \
  --certificate-identity-regexp='.*/pnz1990/kardinal-promoter/' \
  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
```

Closes #699, part of #581.
