### PR TITLE
feat(security): scan krocodile image with trivy (parallel to controller, #698)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,15 +136,32 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: 1
           ignore-unfixed: true
-        # Upload SARIF even on failure so engineers can see the findings.
         continue-on-error: false
 
-      - name: Upload trivy SARIF report
+      - name: Scan krocodile image for HIGH/CRITICAL CVEs (trivy)
+        uses: aquasecurity/trivy-action@0.31.0
+        with:
+          image-ref: ghcr.io/pnz1990/kardinal-promoter/krocodile:${{ env.KROCODILE_COMMIT }}
+          format: sarif
+          output: trivy-krocodile-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: 1
+          ignore-unfixed: true
+        continue-on-error: false
+
+      - name: Upload trivy SARIF reports
         uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: trivy-controller-results.sarif
           category: trivy-controller
+
+      - name: Upload krocodile trivy SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-krocodile-results.sarif
+          category: trivy-krocodile
 
       # ── Package and publish Helm chart ─────────────────────────────────────
       - name: Update chart version and krocodile tag


### PR DESCRIPTION
Extends trivy scanning (added in PR #696) to also scan the bundled krocodile image. Both images now scanned in parallel with separate SARIF categories. Part of epic #581.