### PR TITLE
feat(security): Syft SBOM generation and cosign attestation (#702)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,24 @@ jobs:
           cosign sign --yes \
             ghcr.io/pnz1990/kardinal-promoter/controller:${{ env.VERSION }}
 
+      # ── SBOM generation ─────────────────────────────────────────────────────
+      - name: Generate SBOM with Syft
+        uses: anchore/sbom-action@v0.18.0
+        with:
+          image: ghcr.io/pnz1990/kardinal-promoter/controller:${{ env.VERSION }}
+          artifact-name: sbom-controller.spdx.json
+          output-file: ./sbom-controller.spdx.json
+          format: spdx-json
+
+      - name: Attach SBOM as cosign attestation
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          cosign attest --yes \
+            --predicate sbom-controller.spdx.json \
+            --type spdxjson \
+            ghcr.io/pnz1990/kardinal-promoter/controller:${{ env.VERSION }}
+
       # ── Vulnerability scanning ──────────────────────────────────────────────
       - name: Scan controller image for HIGH/CRITICAL CVEs (trivy)
         uses: aquasecurity/trivy-action@0.31.0


### PR DESCRIPTION
## Summary

Adds SBOM generation and attestation to the release workflow.

1. **Generate SBOM** — Syft generates an SPDX JSON SBOM from the published controller image
2. **Attest** — cosign attaches the SBOM as an OCI attestation (not just a release asset)

## Verification

```bash
cosign download attestation ghcr.io/pnz1990/kardinal-promoter/controller:v0.9.0 \
  | jq '.payload | @base64d | fromjson | .predicateType'
# Output: https://spdx.dev/Document
```

Part of #581. Closes #702.