### PR TITLE
feat(security): SLSA Level 2 provenance via GitHub attestation (#706)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@ on:
 permissions:
   contents: write
   packages: write
-  id-token: write   # required for OIDC-based cosign keyless signing (future)
+  id-token: write       # required for OIDC-based cosign keyless signing
+  attestations: write   # required for actions/attest-build-provenance (SLSA)
 
 jobs:
   release:
@@ -113,6 +114,7 @@ jobs:
 
       # ── Build kardinal-promoter controller image ───────────────────────────
       - name: Build and push kardinal-promoter controller image (multi-arch)
+        id: build-controller
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -125,6 +127,13 @@ jobs:
             org.opencontainers.image.title=kardinal-promoter-controller
             org.opencontainers.image.version=${{ env.VERSION }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+      # ── SLSA Level 2 provenance ──────────────────────────────────────────────
+      - name: Generate SLSA provenance attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/pnz1990/kardinal-promoter/controller
+          subject-digest: ${{ steps.build-controller.outputs.digest }}
 
       # ── Cosign keyless image signing ──────────────────────────────────────────
       - name: Install cosign


### PR DESCRIPTION
## Summary

Adds SLSA Level 2 build provenance attestation using GitHub's built-in attestation API.

The `actions/attest-build-provenance` action generates a non-forgeable SLSA provenance
record from the GitHub Actions OIDC token, stored in GitHub's attestation store.

## Verification

```bash
gh attestation verify oci://ghcr.io/pnz1990/kardinal-promoter/controller:v0.9.0 \
  --repo pnz1990/kardinal-promoter
```

This completes the full supply chain security stack for the release workflow:
- Trivy scan (#696)
- Cosign keyless signing (#700)
- SBOM generation + attestation (#703)
- SLSA Level 2 provenance (this PR)

Closes #706, part of #581.