### PR TITLE
chore(release): v0.8.1 — security hardening patch

### DIFF
--- a/chart/kardinal-promoter/Chart.yaml
+++ b/chart/kardinal-promoter/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   A Kubernetes-native promotion controller with DAG pipelines and policy gates.
   Bundles the krocodile Graph controller — a single helm install installs everything.
 type: application
-version: 0.8.0
-appVersion: "v0.8.0"
+version: 0.8.1
+appVersion: "v0.8.1"
 keywords:
   - kubernetes
   - promotion

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [v0.8.1] — 2026-04-17
+
+**Security release: supply chain hardening — trivy, cosign, SBOM, SLSA, krocodile scan**
+
+---
+
 ## [v0.8.0] — 2026-04-17
 
 **Audit log, SCM circuit breaker, Bundle Watch node, Graph-first cleanup, DX improvements**


### PR DESCRIPTION
Tags v0.8.1 — patch release for security hardening series.

5 items: trivy scan, cosign signing, SBOM, SLSA provenance, krocodile image scan (#696, #700, #703, #707, #708)