### PR TITLE
feat(cli): shell completion — kardinal completion bash/zsh/fish/powershell (#718)

### DIFF
--- a/cmd/kardinal/cmd/completion.go
+++ b/cmd/kardinal/cmd/completion.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion script",
+		Long: `Generate shell completion script for the specified shell.
+
+Installation:
+
+  Bash:
+    # Add to ~/.bashrc or ~/.bash_profile:
+    source <(kardinal completion bash)
+
+  Zsh:
+    # Add to ~/.zshrc (oh-my-zsh users should also add kardinal to the plugins list):
+    source <(kardinal completion zsh)
+    # Or install globally:
+    kardinal completion zsh > "${fpath[1]}/_kardinal"
+
+  Fish:
+    kardinal completion fish | source
+    # Or persist across sessions:
+    kardinal completion fish > ~/.config/fish/completions/kardinal.fish
+
+  PowerShell:
+    kardinal completion powershell | Out-String | Invoke-Expression
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root := cmd.Root()
+			switch args[0] {
+			case "bash":
+				return root.GenBashCompletion(cmd.OutOrStdout())
+			case "zsh":
+				return root.GenZshCompletion(cmd.OutOrStdout())
+			case "fish":
+				return root.GenFishCompletion(cmd.OutOrStdout(), true)
+			case "powershell":
+				return root.GenPowerShellCompletionWithDesc(cmd.OutOrStdout())
+			default:
+				return fmt.Errorf("unsupported shell: %q — supported: bash, zsh, fish, powershell", args[0])
+			}
+		},
+	}
+	return cmd
+}

--- a/cmd/kardinal/cmd/completion_test.go
+++ b/cmd/kardinal/cmd/completion_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletion_Bash(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+
+	root.SetArgs([]string{"completion", "bash"})
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "kardinal", "bash completion output must reference the command name")
+}
+
+func TestCompletion_Zsh(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+
+	root.SetArgs([]string{"completion", "zsh"})
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "kardinal", "zsh completion output must reference the command name")
+}
+
+func TestCompletion_Fish(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+
+	root.SetArgs([]string{"completion", "fish"})
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "kardinal", "fish completion output must reference the command name")
+}
+
+func TestCompletion_PowerShell(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+
+	root.SetArgs([]string{"completion", "powershell"})
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.NotEmpty(t, out, "powershell completion output must not be empty")
+}
+
+func TestCompletion_InvalidShell(t *testing.T) {
+	root := NewRootCmd()
+	root.SetArgs([]string{"completion", "nushell"})
+	err := root.Execute()
+	// cobra's OnlyValidArgs guard returns an error for unknown shells
+	assert.Error(t, err, "unknown shell must return an error")
+}
+
+func TestCompletion_NoArgs(t *testing.T) {
+	root := NewRootCmd()
+	root.SetArgs([]string{"completion"})
+	err := root.Execute()
+	assert.Error(t, err, "missing shell argument must return an error")
+}

--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -84,6 +84,7 @@ It communicates with the Kubernetes API server to read and write CRDs.`,
 	root.AddCommand(newAuditCmd())
 	root.AddCommand(newValidateCmd())
 	root.AddCommand(newStatusCmd())
+	root.AddCommand(newCompletionCmd())
 
 	return root
 }

--- a/docs/reference/cli/kardinal-completion.md
+++ b/docs/reference/cli/kardinal-completion.md
@@ -1,0 +1,52 @@
+## kardinal completion
+
+Generate shell completion script
+
+### Synopsis
+
+Generate shell completion script for the specified shell.
+
+Installation:
+
+  Bash:
+    # Add to ~/.bashrc or ~/.bash_profile:
+    source <(kardinal completion bash)
+
+  Zsh:
+    # Add to ~/.zshrc (oh-my-zsh users should also add kardinal to the plugins list):
+    source <(kardinal completion zsh)
+    # Or install globally:
+    kardinal completion zsh > "${fpath[1]}/_kardinal"
+
+  Fish:
+    kardinal completion fish | source
+    # Or persist across sessions:
+    kardinal completion fish > ~/.config/fish/completions/kardinal.fish
+
+  PowerShell:
+    kardinal completion powershell | Out-String | Invoke-Expression
+
+
+```
+kardinal completion [bash|zsh|fish|powershell] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+      --context string      Kubeconfig context override
+      --kubeconfig string   Path to kubeconfig file (default "~/.kube/config")
+  -n, --namespace string    Kubernetes namespace (default: current context namespace)
+  -o, --output string       Output format: table (default), json, yaml
+```
+
+### SEE ALSO
+
+* [kardinal](kardinal.md)	 - kardinal manages promotion pipelines on Kubernetes
+

--- a/docs/reference/cli/kardinal-completion.md
+++ b/docs/reference/cli/kardinal-completion.md
@@ -28,7 +28,7 @@ Installation:
 
 
 ```
-kardinal completion [bash|zsh|fish|powershell] [flags]
+kardinal completion [bash|zsh|fish|powershell]
 ```
 
 ### Options

--- a/docs/reference/cli/kardinal.md
+++ b/docs/reference/cli/kardinal.md
@@ -21,7 +21,7 @@ It communicates with the Kubernetes API server to read and write CRDs.
 
 * [kardinal approve](kardinal_approve.md)	 - Approve a Bundle for promotion, bypassing upstream gate requirements
 * [kardinal audit](kardinal_audit.md)	 - Audit log commands — view and summarize promotion events
-* [kardinal completion](kardinal-completion.md)	 - Generate shell completion script
+* [kardinal completion](kardinal_completion.md)	 - Generate shell completion script
 * [kardinal create](kardinal_create.md)	 - Create kardinal resources
 * [kardinal dashboard](kardinal_dashboard.md)	 - Open the kardinal UI dashboard in a browser (Kargo parity)
 * [kardinal diff](kardinal_diff.md)	 - Show artifact differences between two Bundles

--- a/docs/reference/cli/kardinal.md
+++ b/docs/reference/cli/kardinal.md
@@ -21,6 +21,7 @@ It communicates with the Kubernetes API server to read and write CRDs.
 
 * [kardinal approve](kardinal_approve.md)	 - Approve a Bundle for promotion, bypassing upstream gate requirements
 * [kardinal audit](kardinal_audit.md)	 - Audit log commands — view and summarize promotion events
+* [kardinal completion](kardinal-completion.md)	 - Generate shell completion script
 * [kardinal create](kardinal_create.md)	 - Create kardinal resources
 * [kardinal dashboard](kardinal_dashboard.md)	 - Open the kardinal UI dashboard in a browser (Kargo parity)
 * [kardinal diff](kardinal_diff.md)	 - Show artifact differences between two Bundles


### PR DESCRIPTION
## Summary

Add `kardinal completion` subcommand using cobra's built-in shell completion generation. Closes epic DX sub-item (#718 / #577).

## Changes

- `cmd/kardinal/cmd/completion.go` — new `newCompletionCmd()` using cobra's `GenBashCompletion`, `GenZshCompletion`, `GenFishCompletion`, `GenPowerShellCompletionWithDesc`
- `cmd/kardinal/cmd/completion_test.go` — 6 tests covering bash/zsh/fish/powershell output and error cases
- `cmd/kardinal/cmd/root.go` — register `newCompletionCmd()`
- `docs/reference/cli/kardinal-completion.md` — generated reference page
- `docs/reference/cli/kardinal.md` — add completion to SEE ALSO list

## Usage

```bash
# Bash
source <(kardinal completion bash)

# Zsh  
kardinal completion zsh > "${fpath[1]}/_kardinal"

# Fish
kardinal completion fish > ~/.config/fish/completions/kardinal.fish

# PowerShell
kardinal completion powershell | Out-String | Invoke-Expression
```

## Testing

- All 6 completion tests pass locally
- Build and vet clean

Part of epic #577 (DX — CLI polish).