### PR TITLE
feat(cli): add shell completion command — kardinal completion bash/zsh/fish/powershell (#718)

### DIFF
--- a/cmd/kardinal/cmd/completion.go
+++ b/cmd/kardinal/cmd/completion.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts for kardinal.
+
+To load completions immediately in the current shell session:
+
+  # Bash
+  source <(kardinal completion bash)
+
+  # Zsh — must have compinit enabled
+  source <(kardinal completion zsh)
+
+  # Fish
+  kardinal completion fish | source
+
+  # PowerShell
+  kardinal completion powershell | Out-String | Invoke-Expression
+
+To install completions permanently:
+
+  # Bash (Linux)
+  kardinal completion bash > /etc/bash_completion.d/kardinal
+
+  # Bash (macOS with Homebrew bash-completion@2)
+  kardinal completion bash > $(brew --prefix)/etc/bash_completion.d/kardinal
+
+  # Zsh
+  kardinal completion zsh > "${fpath[1]}/_kardinal"
+
+  # Fish
+  kardinal completion fish > ~/.config/fish/completions/kardinal.fish
+
+  # PowerShell
+  kardinal completion powershell >> $PROFILE
+`,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root := cmd.Root()
+			out := cmd.OutOrStdout()
+			switch args[0] {
+			case "bash":
+				return root.GenBashCompletionV2(out, true)
+			case "zsh":
+				return root.GenZshCompletion(out)
+			case "fish":
+				return root.GenFishCompletion(out, true)
+			case "powershell":
+				return root.GenPowerShellCompletionWithDesc(out)
+			default:
+				return fmt.Errorf("unsupported shell %q — choose from: bash, zsh, fish, powershell", args[0])
+			}
+		},
+	}
+	return cmd
+}

--- a/cmd/kardinal/cmd/completion_test.go
+++ b/cmd/kardinal/cmd/completion_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletion_Bash(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "bash"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, len(out) > 0, "bash completion output must not be empty")
+	assert.Contains(t, out, "kardinal", "completion script must reference the binary name")
+}
+
+func TestCompletion_Zsh(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "zsh"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, len(out) > 0, "zsh completion output must not be empty")
+}
+
+func TestCompletion_Fish(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "fish"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, len(out) > 0, "fish completion output must not be empty")
+}
+
+func TestCompletion_PowerShell(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "powershell"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, len(out) > 0, "powershell completion output must not be empty")
+}
+
+func TestCompletion_UnknownShell(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "tcsh"})
+
+	err := root.Execute()
+	assert.Error(t, err, "unknown shell must return an error")
+}
+
+func TestCompletion_NoArg(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion"})
+
+	err := root.Execute()
+	assert.Error(t, err, "missing shell argument must return an error")
+}
+
+func TestCompletion_HelpIncludesInstallInstructions(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "--help"})
+
+	// --help exits with 0 via cobra
+	_ = root.Execute()
+
+	out := buf.String()
+	assert.True(t, strings.Contains(out, "bash") || strings.Contains(out, "source"),
+		"help text must mention bash or source")
+}

--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -84,6 +84,7 @@ It communicates with the Kubernetes API server to read and write CRDs.`,
 	root.AddCommand(newAuditCmd())
 	root.AddCommand(newValidateCmd())
 	root.AddCommand(newStatusCmd())
+	root.AddCommand(newCompletionCmd())
 
 	return root
 }


### PR DESCRIPTION
## Summary

Adds `kardinal completion` subcommand for bash, zsh, fish, and PowerShell.

The command wraps Cobra's built-in completion generators. Output is written to `cmd.OutOrStdout()` so it is testable and pipe-friendly.

## Files changed

- `cmd/kardinal/cmd/completion.go` — new command implementation
- `cmd/kardinal/cmd/completion_test.go` — 7 tests (bash, zsh, fish, powershell, unknown shell, missing arg, help)
- `cmd/kardinal/cmd/root.go` — register the command

## Usage

```bash
# Bash
source <(kardinal completion bash)

# Zsh
source <(kardinal completion zsh)

# Fish
kardinal completion fish | source

# PowerShell
kardinal completion powershell | Out-String | Invoke-Expression
```

`docs/cli-reference.md` already documents this command (added in #579).

Closes #718