### PR TITLE
docs(pm): sync comparison version to v0.8.1, update Unreleased changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`kardinal completion`** — shell completion for bash, zsh, fish, and PowerShell (#718)
+- **`kardinal status`** — show controller health and cluster resource summary (#714)
+- **`kardinal validate`** — offline Pipeline and PolicyGate YAML validation (#712)
+- **Improved circular dependency error** — shows the full cycle path in the error message (#710)
+- **Improved `kardinal explain` error** — suggests valid environment names when `--env` is unknown (#716)
+
 ---
 
 ## [v0.8.1] — 2026-04-17
@@ -243,7 +251,7 @@ kardinal-promoter now executes the [AWS Platform Engineering on EKS workshop](ht
 
 ---
 
-[Unreleased]: https://github.com/pnz1990/kardinal-promoter/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/pnz1990/kardinal-promoter/compare/v0.8.1...HEAD
 [v0.5.0]: https://github.com/pnz1990/kardinal-promoter/compare/v0.4.0...v0.5.0
 [v0.4.0]: https://github.com/pnz1990/kardinal-promoter/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/pnz1990/kardinal-promoter/compare/v0.2.1...v0.3.0

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -38,7 +38,7 @@ This page compares kardinal-promoter with the two most similar tools in the GitO
 | **Artifact discovery** | Bundle created by CI/CLI; Subscription CRD with OCI + Git watchers | Warehouse (automatic OCI/git scanning) | Git commit-based |
 | **Multi-artifact bundle** | Yes (image + config in one Bundle) | Yes (Freight) | No |
 | **Architecture** | Graph-first (krocodile DAG) | Stage/controller | Controller |
-| **Maturity** | v0.6.0, active development | v1.9.x, production-grade | v0.26.x, experimental |
+| **Maturity** | v0.8.1, active development | v1.9.x, production-grade | v0.26.x, experimental |
 | **License** | Apache 2.0 | Apache 2.0 | Apache 2.0 |
 
 ---


### PR DESCRIPTION
## PM Docs Audit — 2026-04-17

Routine batch docs audit found two discrepancies:

### 1. `docs/comparison.md` — Maturity row stale
- **Before**: `v0.6.0, active development`
- **After**: `v0.8.1, active development`
- Latest tag is `v0.8.1` (tagged 2026-04-17)

### 2. `docs/changelog.md` — [Unreleased] empty + wrong compare URL
- Added post-v0.8.1 features that are merged on main but not yet tagged:
  - `kardinal completion` (#718)
  - `kardinal status` (#714)
  - `kardinal validate` (#712)
  - Improved circular dep error (#710)
  - Improved explain error (#716)
- Fixed `[Unreleased]` compare URL from `v0.6.0...HEAD` to `v0.8.1...HEAD`

No code changes.