### PR TITLE
feat(cli): add shell completion command — kardinal completion bash/zsh/fish/powershell (#718)

### DIFF
--- a/cmd/kardinal/cmd/completion.go
+++ b/cmd/kardinal/cmd/completion.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts for kardinal.
+
+To load completions immediately in the current shell session:
+
+  # Bash
+  source <(kardinal completion bash)
+
+  # Zsh — must have compinit enabled
+  source <(kardinal completion zsh)
+
+  # Fish
+  kardinal completion fish | source
+
+  # PowerShell
+  kardinal completion powershell | Out-String | Invoke-Expression
+
+To install completions permanently:
+
+  # Bash (Linux)
+  kardinal completion bash > /etc/bash_completion.d/kardinal
+
+  # Bash (macOS with Homebrew bash-completion@2)
+  kardinal completion bash > $(brew --prefix)/etc/bash_completion.d/kardinal
+
+  # Zsh
+  kardinal completion zsh > "${fpath[1]}/_kardinal"
+
+  # Fish
+  kardinal completion fish > ~/.config/fish/completions/kardinal.fish
+
+  # PowerShell
+  kardinal completion powershell >> $PROFILE
+`,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root := cmd.Root()
+			out := cmd.OutOrStdout()
+			switch args[0] {
+			case "bash":
+				return root.GenBashCompletionV2(out, true)
+			case "zsh":
+				return root.GenZshCompletion(out)
+			case "fish":
+				return root.GenFishCompletion(out, true)
+			case "powershell":
+				return root.GenPowerShellCompletionWithDesc(out)
+			default:
+				return fmt.Errorf("unsupported shell %q — choose from: bash, zsh, fish, powershell", args[0])
+			}
+		},
+	}
+	return cmd
+}

--- a/cmd/kardinal/cmd/completion_test.go
+++ b/cmd/kardinal/cmd/completion_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletion_Bash(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "bash"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, len(out) > 0, "bash completion output must not be empty")
+	assert.Contains(t, out, "kardinal", "completion script must reference the binary name")
+}
+
+func TestCompletion_Zsh(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "zsh"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, len(out) > 0, "zsh completion output must not be empty")
+}
+
+func TestCompletion_Fish(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "fish"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, len(out) > 0, "fish completion output must not be empty")
+}
+
+func TestCompletion_PowerShell(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "powershell"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, len(out) > 0, "powershell completion output must not be empty")
+}
+
+func TestCompletion_UnknownShell(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "tcsh"})
+
+	err := root.Execute()
+	assert.Error(t, err, "unknown shell must return an error")
+}
+
+func TestCompletion_NoArg(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion"})
+
+	err := root.Execute()
+	assert.Error(t, err, "missing shell argument must return an error")
+}
+
+func TestCompletion_HelpIncludesInstallInstructions(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"completion", "--help"})
+
+	// --help exits with 0 via cobra
+	_ = root.Execute()
+
+	out := buf.String()
+	assert.True(t, strings.Contains(out, "bash") || strings.Contains(out, "source"),
+		"help text must mention bash or source")
+}

--- a/cmd/kardinal/cmd/root.go
+++ b/cmd/kardinal/cmd/root.go
@@ -84,6 +84,7 @@ It communicates with the Kubernetes API server to read and write CRDs.`,
 	root.AddCommand(newAuditCmd())
 	root.AddCommand(newValidateCmd())
 	root.AddCommand(newStatusCmd())
+	root.AddCommand(newCompletionCmd())
 
 	return root
 }

--- a/docs/reference/cli/kardinal-completion.md
+++ b/docs/reference/cli/kardinal-completion.md
@@ -1,0 +1,63 @@
+## kardinal completion
+
+Generate shell completion scripts
+
+### Synopsis
+
+Generate shell completion scripts for kardinal.
+
+To load completions immediately in the current shell session:
+
+  # Bash
+  source <(kardinal completion bash)
+
+  # Zsh — must have compinit enabled
+  source <(kardinal completion zsh)
+
+  # Fish
+  kardinal completion fish | source
+
+  # PowerShell
+  kardinal completion powershell | Out-String | Invoke-Expression
+
+To install completions permanently:
+
+  # Bash (Linux)
+  kardinal completion bash > /etc/bash_completion.d/kardinal
+
+  # Bash (macOS with Homebrew bash-completion@2)
+  kardinal completion bash > $(brew --prefix)/etc/bash_completion.d/kardinal
+
+  # Zsh
+  kardinal completion zsh > "${fpath[1]}/_kardinal"
+
+  # Fish
+  kardinal completion fish > ~/.config/fish/completions/kardinal.fish
+
+  # PowerShell
+  kardinal completion powershell >> $PROFILE
+
+
+```
+kardinal completion [bash|zsh|fish|powershell]
+```
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+      --context string      Kubeconfig context override
+      --kubeconfig string   Path to kubeconfig file (default "~/.kube/config")
+  -n, --namespace string    Kubernetes namespace (default: current context namespace)
+  -o, --output string       Output format: table (default), json, yaml
+```
+
+### SEE ALSO
+
+* [kardinal](kardinal.md)	 - kardinal manages promotion pipelines on Kubernetes
+

--- a/docs/reference/cli/kardinal.md
+++ b/docs/reference/cli/kardinal.md
@@ -21,6 +21,7 @@ It communicates with the Kubernetes API server to read and write CRDs.
 
 * [kardinal approve](kardinal_approve.md)	 - Approve a Bundle for promotion, bypassing upstream gate requirements
 * [kardinal audit](kardinal_audit.md)	 - Audit log commands — view and summarize promotion events
+* [kardinal completion](kardinal_completion.md)	 - Generate shell completion scripts
 * [kardinal create](kardinal_create.md)	 - Create kardinal resources
 * [kardinal dashboard](kardinal_dashboard.md)	 - Open the kardinal UI dashboard in a browser (Kargo parity)
 * [kardinal diff](kardinal_diff.md)	 - Show artifact differences between two Bundles


### PR DESCRIPTION
## Summary

Adds `kardinal completion` subcommand for bash, zsh, fish, and PowerShell (#718).

The command wraps Cobra's built-in completion generators. Output goes to `cmd.OutOrStdout()` for testability and pipe-friendliness.

## Files changed

- `cmd/kardinal/cmd/completion.go` — new command (82 lines)
- `cmd/kardinal/cmd/completion_test.go` — 7 tests
- `cmd/kardinal/cmd/root.go` — register command
- `docs/reference/cli/kardinal-completion.md` — generated reference doc
- `docs/reference/cli/kardinal.md` — add to SEE ALSO

## Usage

```bash
source <(kardinal completion bash)
source <(kardinal completion zsh)
kardinal completion fish | source
kardinal completion powershell | Out-String | Invoke-Expression
```

Closes #718