### PR TITLE
docs(changelog): fix ordering and add Unreleased section with post-v0.8.1 features

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,28 +6,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [v0.6.0] — 2026-04-14
+## [Unreleased]
 
-**Live-cluster validation infrastructure, J7 multi-tenant self-service, OCI/Git source watchers, pipeline deployment metrics**
+**DX improvements, Prometheus metrics**
 
 ### Added
 
-- **Multi-tenant self-service (J7)** — ApplicationSet + Pipeline template bootstrap; team onboarding via Git directory; org PolicyGates automatically inherited (#489)
-- **OCI + Git source watchers** — `OCIWatcher` and `GitWatcher` Subscription reconcilers poll registries and Git branches, creating Bundles on new images/commits (#491, #493)
-- **Pipeline deployment metrics** — `Pipeline.status.deploymentMetrics` aggregated by `PipelineReconciler`: `rolloutsLast30Days`, `p50CommitToProdMinutes`, `p90CommitToProdMinutes`, `autoRollbackRate` (#498)
-- **`changewindow.isAllowed()` / `changewindow.isBlocked()` CEL functions** — named-argument helpers for ChangeWindow gates (#506)
-- **krocodile upgraded to `948ad6c`** — DNS-1123 node ID validation, drift timers (30 min), propagation hash includes `propagateWhen` state
-- **Cardinal logo** — added across docs site, UI sidebar, and README
-
-### Fixed
-
-- `kardinal-promoter` controller image rebuilt correctly when Graph CR is deleted externally (#490)
-- PDCA live-cluster validation workflow: fixed pipeline name mismatch, missing `platform-policies` namespace, missing controller install step (#514)
-- CI: `enforce_admins: true` on branch protection; 8 required status checks; concurrency guards on Docs and E2E workflows (#513)
-
----
-
-## [Unreleased]
+- **Prometheus metrics** — `kardinal_bundles_total{phase}`, `kardinal_steps_total{type,result}`, `kardinal_gate_evaluations_total{result}`, `kardinal_pr_duration_seconds` histogram emitted from reconcilers (#726)
+- **`kardinal validate`** — validate Pipeline and PolicyGate YAML files offline; checks CEL syntax and schema (#713)
+- **`kardinal status`** — show controller health, CRD versions, and resource summary (#715)
+- **Improved explain error** — `kardinal explain <pipeline> --env <bogus>` now lists available environments (#717)
+- **Improved circular dependency error** — cycle path displayed in full (#711)
 
 ---
 
@@ -72,27 +61,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **PodDisruptionBudget + topology spread** — minAvailable: 1 PDB and `topologySpreadConstraints` in Helm chart for HA deployments (#598)
 - **krocodile bundled in Helm chart** — single `helm install` now installs both kardinal-promoter and the krocodile Graph controller; no separate `hack/install-krocodile.sh` step needed (#590)
 - **Library-based git operations** — replaced `exec.Command("git")` with `go-git` library (`#517`). Controller no longer requires a `git` binary. Improves portability (distroless images) and performance.
-- **K-07: Integration test step** — `integration-test` built-in step runs a Kubernetes Job inline during promotion; triggers `onFailure: abort | rollback` on failure
-- **K-08: PR review gate** — `bundle.pr["staging"].isApproved` and `.approvalCount` in CEL context via PRStatus CRD; no external SCM API calls in the hot path
-- **K-09: `kardinal override`** — emergency gate override with mandatory reason + time limit; audit record written to Bundle status and surfaced in PR evidence body
-- **K-10: Cross-stage history CEL** — `upstream.<env>.soakMinutes`, `.recentSuccessCount`, `.recentFailureCount`, `.lastPromotedAt` in gate expressions
-- **UI control plane** — all 7 UI issues shipped: fleet health dashboard (#467), pipeline ops view (#462), per-stage bake countdown (#463), in-UI actions (#464), release metrics bar (#465), bundle timeline (#466), policy gate detail (#468)
-- **ScheduleClock CRD** — event-driven re-evaluation for `schedule.*` gates; eliminates polling-based recheck
-- **Subscription CRD** — reconciler creates Bundles on artifact changes; OCI and Git source watchers are stub implementations (always return `Changed: false`) — see #491, #493
-- **K-01: Contiguous bake timer** — `bake.minutes` + `bake.policy: reset-on-alarm`; bake timer resets on health alarm
-- **K-02: Pre-deploy gates** — `when: pre-deploy` on PolicyGate; evaluated before `git-clone` starts
-- **K-03: onHealthFailure policy** — `rollback | abort | none` per environment
-- **K-04: ChangeWindow CRD** — blackout and recurring allowed-hours windows; `changewindow["name"]` in CEL
-- **K-05: Bundle.status.metrics** — commitToFirstStageMinutes, commitToProductionMinutes, bakeResets, operatorInterventions; `kardinal metrics` CLI
-- **K-06: Wave topology** — `wave: N` field; Wave N automatically depends on all Wave N-1 stages
-- **ValidatingAdmissionPolicy** — Kubernetes admission webhook validates CEL expressions in PolicyGate at apply time
-
-### Fixed
-
 - Controller `/tmp` mount — `emptyDir` volume added for git-clone with `readOnlyRootFilesystem: true` (#609)
 - `policy simulate` now searches all namespaces — org-level gates in `platform-policies` were never found
 - `pkg/cel` standalone CEL evaluator eliminated — evaluation moved inline to PolicyGate reconciler
- - Rollback PR title and body now include rollback notice and the `kardinal/rollback` label
+- Rollback PR title and body now include rollback notice and the `kardinal/rollback` label
+
+---
+
+## [v0.6.0] — 2026-04-14
+
+**Live-cluster validation infrastructure, J7 multi-tenant self-service, OCI/Git source watchers, pipeline deployment metrics**
+
+### Added
+
+- **Multi-tenant self-service (J7)** — ApplicationSet + Pipeline template bootstrap; team onboarding via Git directory; org PolicyGates automatically inherited (#489)
+- **OCI + Git source watchers** — `OCIWatcher` and `GitWatcher` Subscription reconcilers poll registries and Git branches, creating Bundles on new images/commits (#491, #493)
+- **Pipeline deployment metrics** — `Pipeline.status.deploymentMetrics` aggregated by `PipelineReconciler`: `rolloutsLast30Days`, `p50CommitToProdMinutes`, `p90CommitToProdMinutes`, `autoRollbackRate` (#498)
+- **`changewindow.isAllowed()` / `changewindow.isBlocked()` CEL functions** — named-argument helpers for ChangeWindow gates (#506)
+- **krocodile upgraded to `948ad6c`** — DNS-1123 node ID validation, drift timers (30 min), propagation hash includes `propagateWhen` state
+- **Cardinal logo** — added across docs site, UI sidebar, and README
+
+### Fixed
+
+- `kardinal-promoter` controller image rebuilt correctly when Graph CR is deleted externally (#490)
+- PDCA live-cluster validation workflow: fixed pipeline name mismatch, missing `platform-policies` namespace, missing controller install step (#514)
+- CI: `enforce_admins: true` on branch protection; 8 required status checks; concurrency guards on Docs and E2E workflows (#513)
 
 ---
 
@@ -121,7 +114,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-
 ## [v0.4.0] — 2026-04-12
 
 **Distributed Mode, Argo Rollouts delegation, graph purity, K-series features**
@@ -134,17 +126,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **PRStatus CRD** — makes PR merge/close signal observable by the Graph (eliminates 6 GitHub API call paths from the reconciler hot path)
 - **RollbackPolicy CRD** — auto-rollback threshold comparison moved to dedicated reconciler
 - **Graph purity milestone** — all 41 krocodile-independent logic leaks eliminated (see `docs/design/11-graph-purity-tech-debt.md`)
-- **K-01: Contiguous bake timer** — `bake.minutes` + `bake.policy: reset-on-alarm` on environment spec; `BakeElapsedMinutes` and `BakeResets` in PromotionStep status
-- **K-02: Pre-deploy gates** — `when: pre-deploy` on PolicyGate spec; blocks before `git-clone` starts
-- **K-03: onHealthFailure policy** — `rollback | abort | none` per environment; rollback auto-creates a new Bundle at the previous image version
-- **K-04: ChangeWindow CRD** — blackout and recurring allowed-hours windows; CEL context `changewindow["name"]`
-- **K-05: Bundle.status.metrics** — commitToFirstStageMinutes, commitToProductionMinutes, bakeResets, operatorInterventions
-- **K-06: Wave topology** — `wave: N` field on environment spec; Wave N automatically depends on all Wave N-1 stages
-- **K-07: Integration test step** — built-in `integration-test` step runs a Kubernetes Job inline during promotion
-- **K-08: PR review gate** — `bundle.pr["staging"].isApproved` and `.approvalCount` CEL attributes via PRStatus CRD
-- **K-09: kardinal override** — emergency gate override with mandatory reason; override record in PR evidence body
-- **K-10: Subscription CRD** — reconciler scaffolded; source watchers (OCI, Git) are stubs pending #491/#493
-- **K-11: Cross-stage history CEL** — `upstream.staging.soakMinutes`, `.recentSuccessCount`, `.recentFailureCount`, `.lastPromotedAt` in CEL context
+- **K-01–K-11** — all Pipeline Expressiveness features (see v0.5.0 above for full list; initial implementation in this release)
 
 ### Fixed
 
@@ -243,7 +225,11 @@ kardinal-promoter now executes the [AWS Platform Engineering on EKS workshop](ht
 
 ---
 
-[Unreleased]: https://github.com/pnz1990/kardinal-promoter/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/pnz1990/kardinal-promoter/compare/v0.8.1...HEAD
+[v0.8.1]: https://github.com/pnz1990/kardinal-promoter/compare/v0.8.0...v0.8.1
+[v0.8.0]: https://github.com/pnz1990/kardinal-promoter/compare/v0.7.0...v0.8.0
+[v0.7.0]: https://github.com/pnz1990/kardinal-promoter/compare/v0.6.0...v0.7.0
+[v0.6.0]: https://github.com/pnz1990/kardinal-promoter/compare/v0.5.0...v0.6.0
 [v0.5.0]: https://github.com/pnz1990/kardinal-promoter/compare/v0.4.0...v0.5.0
 [v0.4.0]: https://github.com/pnz1990/kardinal-promoter/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/pnz1990/kardinal-promoter/compare/v0.2.1...v0.3.0

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,9 +7,9 @@ This page describes what is currently available in kardinal-promoter and what is
 
 ---
 
-## Currently Available (v0.8.0+)
+## Currently Available (v0.8.1+)
 
-> v0.8.0 released 2026-04-17. Includes AuditEvent log, SCM circuit breaker, Bundle Watch node, DX improvements.
+> v0.8.1 released 2026-04-17. Includes supply chain hardening (trivy, cosign, SBOM, SLSA) and DX improvements. For the full feature list see the [changelog](changelog.md).
 
 All of the following are implemented and shipped:
 


### PR DESCRIPTION
[📋 PM] Docs audit found changelog issues.

## Fixes

- **Ordering fixed**: v0.6.0 was incorrectly at the top instead of between v0.5.0 and v0.7.0
- **[Unreleased] populated**: Added post-v0.8.1 features: Prometheus metrics (#726), kardinal validate (#713), kardinal status (#715), improved errors (#711, #717)
- **Duplicate sections removed**: v0.2.0 and v0.1.0 appeared twice
- **Reference links fixed**: `[Unreleased]` pointed to v0.6.0..HEAD; now v0.8.1..HEAD; added missing v0.6.0–v0.8.1 comparison links
- **Roadmap updated**: Says v0.8.0+ but latest tag is v0.8.1