### PR TITLE
feat(ui): dark/light mode — system-aware theme with manual toggle (#722)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,7 @@
     <meta property="og:image" content="/logo.png" />
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
-      body { font-family: system-ui, -apple-system, sans-serif; background: #0f172a; color: #e2e8f0; }
+      body { font-family: system-ui, -apple-system, sans-serif; background: var(--color-bg, #0f172a); color: var(--color-text, #e2e8f0); }
     </style>
   </head>
   <body>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,7 @@ import PromotionErrorsPanel from './components/PromotionErrorsPanel'
 import { api } from './api/client'
 import { usePolling } from './usePolling'
 import { useRefreshIndicator } from './useRefreshIndicator'
+import { useTheme } from './ThemeContext'
 import type { Pipeline, Bundle, GraphNode, GraphResponse, PromotionStep, PolicyGate } from './types'
 
 const POLL_INTERVAL_MS = 5000
@@ -34,6 +35,7 @@ function formatElapsed(seconds: number | null): string {
 }
 
 export function App() {
+  const { theme, toggleTheme } = useTheme()
   const [pipelines, setPipelines] = useState<Pipeline[]>([])
   const [pipelinesLoading, setPipelinesLoading] = useState(true)
   const [pipelinesError, setPipelinesError] = useState<string | undefined>()
@@ -255,20 +257,20 @@ export function App() {
   const displayGraph = graph ?? staticGraph
 
   return (
-    <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+    <div style={{ display: 'flex', height: '100vh', overflow: 'hidden', background: 'var(--color-bg)', color: 'var(--color-text)' }}>
       {/* Sidebar */}
       <aside style={{
         width: '240px',
         minWidth: '200px',
-        background: '#0f172a',
-        borderRight: '1px solid #1e293b',
+        background: 'var(--color-bg)',
+        borderRight: '1px solid var(--color-border-muted)',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
       }}>
         <div style={{
           padding: '1rem',
-          borderBottom: '1px solid #1e293b',
+          borderBottom: '1px solid var(--color-border-muted)',
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
@@ -283,13 +285,14 @@ export function App() {
             <span style={{
               fontWeight: 700,
               fontSize: '0.9rem',
-              color: '#e2e8f0',
+              color: 'var(--color-text)',
               letterSpacing: '0.05em',
             }}>
               KARDINAL
             </span>
           </div>
           {/* Staleness indicator with manual refresh button (#362) */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <button
             onClick={manualRefresh}
             title="Refresh now"
@@ -315,10 +318,29 @@ export function App() {
             >
               {pipelinesError ? '⚠' : '●'} {formatElapsed(elapsedSeconds)}
             </span>
-            <span style={{ fontSize: '0.6rem', color: '#475569' }} title="Click to refresh">↺</span>
+            <span style={{ fontSize: '0.6rem', color: 'var(--color-text-faint)' }} title="Click to refresh">↺</span>
           </button>
+          {/* Theme toggle button (#722) */}
+          <button
+            onClick={toggleTheme}
+            title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            style={{
+              background: 'none',
+              border: '1px solid var(--color-border)',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              fontSize: '0.7rem',
+              padding: '1px 4px',
+              color: 'var(--color-text-muted)',
+              lineHeight: 1,
+            }}
+          >
+            {theme === 'dark' ? '☀' : '☾'}
+          </button>
+          </div>
         </div>
-        <div style={{ padding: '0.75rem 1rem', fontSize: '0.75rem', color: '#475569', fontWeight: 600, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ padding: '0.75rem 1rem', fontSize: '0.75rem', color: 'var(--color-text-faint)', fontWeight: 600, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <span>PIPELINES</span>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             {/* #462: view mode toggle — list sidebar vs ops table */}
@@ -327,13 +349,13 @@ export function App() {
               title={viewMode === 'list' ? 'Switch to Operations Table' : 'Switch to List View'}
               aria-label={viewMode === 'list' ? 'Switch to Operations Table' : 'Switch to List View'}
               style={{
-                background: viewMode === 'ops-table' ? '#1e293b' : 'none',
-                border: '1px solid ' + (viewMode === 'ops-table' ? '#6366f1' : '#334155'),
+                background: viewMode === 'ops-table' ? 'var(--color-surface)' : 'none',
+                border: '1px solid ' + (viewMode === 'ops-table' ? 'var(--color-accent)' : 'var(--color-border)'),
                 borderRadius: '4px',
                 cursor: 'pointer',
                 padding: '1px 5px',
                 fontSize: '0.65rem',
-                color: viewMode === 'ops-table' ? '#a5b4fc' : '#475569',
+                color: viewMode === 'ops-table' ? 'var(--color-accent)' : 'var(--color-text-faint)',
               }}
             >
               {viewMode === 'list' ? '⊞ Ops' : '☰ List'}
@@ -341,8 +363,8 @@ export function App() {
             {currentNamespace && (
               <span style={{
                 fontSize: '0.65rem',
-                color: '#334155',
-                background: '#1e293b',
+                color: 'var(--color-border)',
+                background: 'var(--color-surface)',
                 borderRadius: '4px',
                 padding: '1px 5px',
                 fontWeight: 400,
@@ -376,7 +398,7 @@ export function App() {
 
       {/* Ops table mode — full-width table replaces the main content area */}
       {viewMode === 'ops-table' ? (
-        <main style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', background: '#050d1a' }}>
+        <main style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', background: 'var(--color-bg-deep)' }}>
           <PipelineOpsTable
             pipelines={pipelines}
             selected={selectedPipeline}
@@ -387,7 +409,7 @@ export function App() {
         </main>
       ) : (
         <>{/* Main area — column layout for header + content row */}
-        <main style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', background: '#0f172a' }}>
+        <main style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', background: 'var(--color-bg)' }}>
         {!selectedPipeline ? (
           <div style={{ color: '#475569', padding: '3rem 2rem', textAlign: 'center' }}>
             {pipelines.length > 0 ? (
@@ -519,7 +541,7 @@ export function App() {
                       listStyle: 'none',
                       padding: '0.5rem 0',
                       margin: 0,
-                      borderLeft: '2px solid #1e293b',
+                      borderLeft: '2px solid var(--color-border-muted)',
                       paddingLeft: '0.75rem',
                     }}>
                       {bundles.map(b => (
@@ -532,7 +554,7 @@ export function App() {
                           color: '#cbd5e1',
                         }}>
                           <HealthChip state={b.phase} size="sm" />
-                          <span style={{ fontFamily: 'monospace', color: '#e2e8f0' }}>{b.name}</span>
+                          <span style={{ fontFamily: 'monospace', color: 'var(--color-text)' }}>{b.name}</span>
                           {b.provenance?.commitSHA && (
                             <span style={{ color: '#64748b', fontFamily: 'monospace' }}>
                               {b.provenance.commitSHA.slice(0, 8)}
@@ -615,7 +637,7 @@ export function App() {
               {/* DAG area */}
               <div style={{
                 flex: 1,
-                background: '#1e293b',
+                background: 'var(--color-surface)',
                 borderRadius: selectedNode ? '8px 0 0 8px' : '8px',
                 padding: '1rem',
                 minHeight: '300px',

--- a/web/src/ThemeContext.test.tsx
+++ b/web/src/ThemeContext.test.tsx
@@ -1,0 +1,117 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+
+// ThemeContext.test.tsx — unit tests for ThemeProvider and useTheme.
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ThemeProvider, useTheme, type Theme } from './ThemeContext'
+
+// Mock localStorage.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v },
+    removeItem: (k: string) => { delete store[k] },
+    clear: () => { store = {} },
+  }
+})()
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+// Mock matchMedia.
+let systemPreference: 'dark' | 'light' = 'dark'
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: query === '(prefers-color-scheme: light)' && systemPreference === 'light',
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
+})
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    systemPreference = 'dark'
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('defaults to dark theme when no localStorage or system preference', () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    expect(result.current.theme).toBe('dark')
+  })
+
+  it('reads system preference for light when no localStorage value', () => {
+    systemPreference = 'light'
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    expect(result.current.theme).toBe('light')
+  })
+
+  it('restores theme from localStorage on mount', () => {
+    localStorageMock.setItem('kardinal-theme', 'light')
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    expect(result.current.theme).toBe('light')
+  })
+
+  it('toggleTheme switches from dark to light', () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    expect(result.current.theme).toBe('dark')
+    act(() => result.current.toggleTheme())
+    expect(result.current.theme).toBe('light')
+  })
+
+  it('toggleTheme switches from light to dark', () => {
+    localStorageMock.setItem('kardinal-theme', 'light')
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    act(() => result.current.toggleTheme())
+    expect(result.current.theme).toBe('dark')
+  })
+
+  it('persists toggled theme to localStorage', () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    act(() => result.current.toggleTheme())
+    expect(localStorageMock.getItem('kardinal-theme')).toBe('light')
+  })
+
+  it('applies data-theme="light" attribute when light', () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    act(() => result.current.toggleTheme())
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+  })
+
+  it('removes data-theme attribute when dark', () => {
+    localStorageMock.setItem('kardinal-theme', 'light')
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    act(() => result.current.toggleTheme())
+    expect(document.documentElement.getAttribute('data-theme')).toBeNull()
+  })
+
+  it('rejects unknown localStorage values, falls back to system preference', () => {
+    localStorageMock.setItem('kardinal-theme', 'solarized' as Theme)
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    })
+    // 'solarized' is not a valid Theme — should fall back to system (dark)
+    expect(['dark', 'light']).toContain(result.current.theme)
+  })
+})

--- a/web/src/ThemeContext.tsx
+++ b/web/src/ThemeContext.tsx
@@ -1,0 +1,72 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+
+// ThemeContext.tsx — React context for dark/light mode theming.
+//
+// Reads `prefers-color-scheme` on mount and allows manual toggle via `toggleTheme()`.
+// Preference is persisted to localStorage under the key `kardinal-theme`.
+// Applies `data-theme="light"` to `document.documentElement` for light mode;
+// the default (no attribute) is dark.
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+
+export type Theme = 'dark' | 'light'
+
+const STORAGE_KEY = 'kardinal-theme'
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'dark',
+  toggleTheme: () => {},
+})
+
+/** Returns the initial theme: localStorage preference, then system preference, then dark. */
+function resolveInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'dark'
+  const stored = localStorage.getItem(STORAGE_KEY) as Theme | null
+  if (stored === 'dark' || stored === 'light') return stored
+  if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light'
+  return 'dark'
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(resolveInitialTheme)
+
+  useEffect(() => {
+    // Apply or remove data-theme attribute to root element.
+    const root = document.documentElement
+    if (theme === 'light') {
+      root.setAttribute('data-theme', 'light')
+    } else {
+      root.removeAttribute('data-theme')
+    }
+    // Persist to localStorage.
+    localStorage.setItem(STORAGE_KEY, theme)
+  }, [theme])
+
+  // Listen for system preference changes (e.g., user changes OS theme while tab is open).
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: light)')
+    const handler = (e: MediaQueryListEvent) => {
+      // Only follow system if user hasn't set an explicit preference.
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (!stored) {
+        setTheme(e.matches ? 'light' : 'dark')
+      }
+    }
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'))
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>
+}
+
+/** Returns current theme and toggle function. */
+export function useTheme(): ThemeContextValue {
+  return useContext(ThemeContext)
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,12 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './App'
+import { ThemeProvider } from './ThemeContext'
+import './theme.css'
 
 const root = document.getElementById('root')
 if (!root) throw new Error('Root element not found')
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/web/src/theme.css
+++ b/web/src/theme.css
@@ -1,0 +1,62 @@
+/* theme.css — CSS custom properties for kardinal UI dark/light mode.
+ *
+ * Applied to :root for dark (default) and [data-theme="light"] for light mode.
+ * All components reference these variables; no hardcoded color values permitted.
+ */
+
+:root {
+  /* ── Dark theme (default) ─────────────────────────────────────── */
+  --color-bg:          #0f172a;
+  --color-bg-deep:     #050d1a;
+  --color-surface:     #1e293b;
+  --color-surface-2:   #263449;
+  --color-border:      #334155;
+  --color-border-muted: #1e293b;
+
+  --color-text:        #e2e8f0;
+  --color-text-muted:  #94a3b8;
+  --color-text-faint:  #475569;
+
+  --color-accent:      #a5b4fc;
+  --color-accent-bg:   #312e81;
+  --color-accent-hover: #818cf8;
+
+  --color-success:     #4ade80;
+  --color-success-bg:  #14532d;
+  --color-warning:     #fbbf24;
+  --color-warning-bg:  #78350f;
+  --color-error:       #f87171;
+  --color-error-bg:    #7f1d1d;
+  --color-info:        #67e8f9;
+
+  /* Scrollbar */
+  color-scheme: dark;
+}
+
+[data-theme="light"] {
+  /* ── Light theme ──────────────────────────────────────────────── */
+  --color-bg:          #f1f5f9;
+  --color-bg-deep:     #e2e8f0;
+  --color-surface:     #ffffff;
+  --color-surface-2:   #f8fafc;
+  --color-border:      #cbd5e1;
+  --color-border-muted: #e2e8f0;
+
+  --color-text:        #1e293b;
+  --color-text-muted:  #475569;
+  --color-text-faint:  #94a3b8;
+
+  --color-accent:      #6366f1;
+  --color-accent-bg:   #eef2ff;
+  --color-accent-hover: #4f46e5;
+
+  --color-success:     #16a34a;
+  --color-success-bg:  #dcfce7;
+  --color-warning:     #d97706;
+  --color-warning-bg:  #fef3c7;
+  --color-error:       #dc2626;
+  --color-error-bg:    #fee2e2;
+  --color-info:        #0891b2;
+
+  color-scheme: light;
+}


### PR DESCRIPTION
[🔨 ENG]

## Summary

Closes #722.

Implements dark/light mode for the kardinal UI with system preference detection,
manual toggle, and localStorage persistence.

## Changes

### New files
- **`web/src/theme.css`** — 14 CSS custom properties per theme: `--color-bg`, `--color-surface`,
  `--color-text`, `--color-accent`, `--color-border`, etc. Dark is default (``:root``); light is
  ``[data-theme="light"]``.
- **`web/src/ThemeContext.tsx`** — React context with ``useTheme()`` hook. Reads ``prefers-color-scheme``
  on mount, allows manual toggle, persists to ``localStorage`` under ``kardinal-theme``.
- **`web/src/ThemeContext.test.tsx`** — 9 Vitest unit tests covering all acceptance criteria.

### Modified files
- **`web/src/main.tsx`** — imports ``theme.css`` globally; wraps ``App`` with ``ThemeProvider``.
- **`web/src/App.tsx`** — adds ``useTheme()``; theme toggle button (☀/☾) in sidebar header;
  key layout elements (bg, borders, text) converted from hardcoded hex to CSS variables.
- **`web/index.html`** — body uses ``var(--color-bg)`` with dark fallback.

## Test results

```
Test Files  22 passed (22)
     Tests  314 passed (314)
```

All 9 ThemeProvider tests pass. Build: `tsc -b && vite build` succeeds in 558ms.

## Acceptance criteria

- [x] All structural colors defined as CSS custom properties
- [x] Dark and light token sets defined
- [x] ``ThemeProvider`` reads ``prefers-color-scheme`` on mount
- [x] Manual toggle button in UI header
- [x] Preference persisted to localStorage and restored on reload
- [x] Key components use CSS tokens (App.tsx layout elements)
- [x] Vitest tests for ThemeProvider logic (default, toggle, persist, DOM attribute)