### PR TITLE
docs(cli): sync kardinal-explain.md with --color flag

### DIFF
--- a/cmd/kardinal/cmd/color.go
+++ b/cmd/kardinal/cmd/color.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmd provides ANSI color utilities for CLI output.
+//
+// Color rules:
+//   - Colors are enabled only when writing to a TTY (os.Stdout), or when
+//     --color flag is set explicitly.
+//   - The NO_COLOR environment variable (https://no-color.org/) always takes
+//     precedence and disables colors even if --color is set.
+//   - Non-TTY output (pipes, redirects, CI) is always plain text.
+
+package cmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// ANSI escape codes for common colors and resets.
+const (
+	ansiReset  = "\033[0m"
+	ansiRed    = "\033[31m"
+	ansiGreen  = "\033[32m"
+	ansiYellow = "\033[33m"
+	ansiBold   = "\033[1m"
+)
+
+// colorizer wraps a writer and provides state-aware coloring.
+type colorizer struct {
+	enabled bool
+}
+
+// newColorizer returns a colorizer for the given writer.
+// It enables colors when:
+//   - NO_COLOR is not set AND (force is true OR w is a TTY).
+//
+// NO_COLOR (https://no-color.org/) always takes precedence over --color.
+func newColorizer(w io.Writer, force bool) colorizer {
+	// NO_COLOR always wins regardless of force.
+	if os.Getenv("NO_COLOR") != "" {
+		return colorizer{enabled: false}
+	}
+	if force {
+		return colorizer{enabled: true}
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return colorizer{enabled: false}
+	}
+	return colorizer{enabled: isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())}
+}
+
+// colorState wraps a promotion state string with an appropriate ANSI color:
+//   - Pass / Succeeded / Verified → green
+//   - Block / Failed              → red
+//   - Pending / Running           → yellow
+//   - anything else (Superseded)  → no color
+func (c colorizer) colorState(state string) string {
+	if !c.enabled {
+		return state
+	}
+	switch state {
+	case "Pass", "PASS", "Succeeded", "Verified":
+		return ansiGreen + state + ansiReset
+	case "Block", "FAIL", "Failed":
+		return ansiRed + state + ansiReset
+	case "Pending", "PENDING", "Running":
+		return ansiYellow + state + ansiReset
+	default:
+		return state
+	}
+}
+
+// bold wraps text in bold ANSI if colors are enabled.
+func (c colorizer) bold(s string) string {
+	if !c.enabled {
+		return s
+	}
+	return ansiBold + s + ansiReset
+}

--- a/cmd/kardinal/cmd/color_test.go
+++ b/cmd/kardinal/cmd/color_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColorizer_Disabled(t *testing.T) {
+	cr := newColorizer(&bytes.Buffer{}, false) // non-TTY writer, no force
+	assert.Equal(t, "Pass", cr.colorState("Pass"), "disabled: Pass must be unchanged")
+	assert.Equal(t, "Block", cr.colorState("Block"), "disabled: Block must be unchanged")
+	assert.Equal(t, "Pending", cr.colorState("Pending"), "disabled: Pending must be unchanged")
+	assert.Equal(t, "Superseded", cr.colorState("Superseded"), "disabled: Superseded must be unchanged")
+	assert.Equal(t, "foo", cr.bold("foo"), "disabled: bold must be unchanged")
+}
+
+func TestColorizer_Forced(t *testing.T) {
+	cr := newColorizer(&bytes.Buffer{}, true) // force=true
+	assert.Equal(t, "\033[32mPass\033[0m", cr.colorState("Pass"), "forced: Pass must be green")
+	assert.Equal(t, "\033[31mBlock\033[0m", cr.colorState("Block"), "forced: Block must be red")
+	assert.Equal(t, "\033[33mPending\033[0m", cr.colorState("Pending"), "forced: Pending must be yellow")
+	assert.Equal(t, "\033[33mRunning\033[0m", cr.colorState("Running"), "forced: Running must be yellow")
+	assert.Equal(t, "\033[32mSucceeded\033[0m", cr.colorState("Succeeded"), "forced: Succeeded must be green")
+	assert.Equal(t, "\033[31mFailed\033[0m", cr.colorState("Failed"), "forced: Failed must be red")
+	assert.Equal(t, "Superseded", cr.colorState("Superseded"), "forced: Superseded has no color")
+	assert.Equal(t, "\033[1mfoo\033[0m", cr.bold("foo"), "forced: bold must wrap in bold codes")
+}
+
+func TestColorizer_NoColorEnv(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	cr := newColorizer(&bytes.Buffer{}, true) // force=true but NO_COLOR overrides
+	assert.Equal(t, "Pass", cr.colorState("Pass"), "NO_COLOR: color must be disabled")
+}

--- a/cmd/kardinal/cmd/explain.go
+++ b/cmd/kardinal/cmd/explain.go
@@ -34,6 +34,7 @@ func newExplainCmd() *cobra.Command {
 	var (
 		envFlag   string
 		watchFlag bool
+		colorFlag bool
 	)
 
 	cmd := &cobra.Command{
@@ -43,20 +44,22 @@ func newExplainCmd() *cobra.Command {
 It shows the current state, reason, and any PR URLs for each environment.
 
 Use --env to filter to a specific environment.
-Use --watch to stream live updates.`,
+Use --watch to stream live updates.
+Use --color to force ANSI color output (auto-detected when writing to a TTY).`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runExplain(cmd, args, envFlag, watchFlag)
+			return runExplain(cmd, args, envFlag, watchFlag, colorFlag)
 		},
 	}
 
 	cmd.Flags().StringVar(&envFlag, "env", "", "Filter to a specific environment")
 	cmd.Flags().BoolVar(&watchFlag, "watch", false, "Stream updates (polling)")
+	cmd.Flags().BoolVar(&colorFlag, "color", false, "Force ANSI color output (auto-detected when TTY)")
 
 	return cmd
 }
 
-func runExplain(cmd *cobra.Command, args []string, envFilter string, watch bool) error {
+func runExplain(cmd *cobra.Command, args []string, envFilter string, watch bool, forceColor bool) error {
 	c, ns, err := buildClient()
 	if err != nil {
 		return fmt.Errorf("explain: %w", err)
@@ -65,14 +68,14 @@ func runExplain(cmd *cobra.Command, args []string, envFilter string, watch bool)
 	pipeline := args[0]
 
 	if !watch {
-		return explainOnce(cmd.OutOrStdout(), c, ns, pipeline, envFilter)
+		return explainOnce(cmd.OutOrStdout(), c, ns, pipeline, envFilter, forceColor)
 	}
 
 	// Watch mode: poll every 3 seconds and refresh the output.
 	for {
 		// Clear screen using ANSI escape.
 		_, _ = fmt.Fprint(cmd.OutOrStdout(), "\033[H\033[2J")
-		if err := explainOnce(cmd.OutOrStdout(), c, ns, pipeline, envFilter); err != nil {
+		if err := explainOnce(cmd.OutOrStdout(), c, ns, pipeline, envFilter, forceColor); err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\n(watching — press Ctrl-C to quit)")
@@ -80,7 +83,7 @@ func runExplain(cmd *cobra.Command, args []string, envFilter string, watch bool)
 	}
 }
 
-func explainOnce(w io.Writer, c sigs_client.Client, ns, pipeline, envFilter string) error {
+func explainOnce(w io.Writer, c sigs_client.Client, ns, pipeline, envFilter string, forceColor bool) error {
 	ctx := context.Background()
 
 	var steps v1alpha1.PromotionStepList
@@ -212,12 +215,13 @@ func explainOnce(w io.Writer, c sigs_client.Client, ns, pipeline, envFilter stri
 	})
 
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "ENVIRONMENT\tTYPE\tNAME\tSTATE\tEXPRESSION\tREASON"); err != nil {
+	cr := newColorizer(w, forceColor)
+	if _, err := fmt.Fprintln(tw, cr.bold("ENVIRONMENT")+"\t"+cr.bold("TYPE")+"\t"+cr.bold("NAME")+"\t"+cr.bold("STATE")+"\t"+cr.bold("EXPRESSION")+"\t"+cr.bold("REASON")); err != nil {
 		return fmt.Errorf("write explain header: %w", err)
 	}
 	for _, row := range rows {
 		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			row.environment, row.kind, row.name, row.state, row.expression, row.reason,
+			row.environment, row.kind, row.name, cr.colorState(row.state), row.expression, row.reason,
 		); err != nil {
 			return fmt.Errorf("write explain row: %w", err)
 		}

--- a/cmd/kardinal/cmd/explain.go
+++ b/cmd/kardinal/cmd/explain.go
@@ -214,17 +214,44 @@ func explainOnce(w io.Writer, c sigs_client.Client, ns, pipeline, envFilter stri
 		return rows[i].name < rows[j].name
 	})
 
-	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	cr := newColorizer(w, forceColor)
-	if _, err := fmt.Fprintln(tw, cr.bold("ENVIRONMENT")+"\t"+cr.bold("TYPE")+"\t"+cr.bold("NAME")+"\t"+cr.bold("STATE")+"\t"+cr.bold("EXPRESSION")+"\t"+cr.bold("REASON")); err != nil {
+
+	// When color is enabled, render the table to a buffer first (plain text,
+	// no ANSI codes), then post-process each line to colorize the STATE value.
+	// This avoids the tabwriter byte-width alignment bug caused by inserting
+	// ANSI escape sequences into a middle column while tabwriter is computing
+	// column widths from byte counts.
+	var tableBuf strings.Builder
+	tw := tabwriter.NewWriter(&tableBuf, 0, 0, 3, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "ENVIRONMENT\tTYPE\tNAME\tSTATE\tEXPRESSION\tREASON"); err != nil {
 		return fmt.Errorf("write explain header: %w", err)
 	}
 	for _, row := range rows {
 		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			row.environment, row.kind, row.name, cr.colorState(row.state), row.expression, row.reason,
+			row.environment, row.kind, row.name, row.state, row.expression, row.reason,
 		); err != nil {
 			return fmt.Errorf("write explain row: %w", err)
 		}
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("flush explain table: %w", err)
+	}
+
+	// Post-process: if color is enabled, wrap state keywords in ANSI codes.
+	// Each line has already been aligned by tabwriter; we only replace the
+	// exact state word (surrounded by spaces or at end of line) to avoid
+	// touching the header or embedded text.
+	output := tableBuf.String()
+	if cr.enabled {
+		for _, state := range []string{"Pass", "Block", "Pending", "Running", "Succeeded", "Verified", "Failed"} {
+			colored := cr.colorState(state)
+			// Only replace whole-word occurrences (space-bounded or end of line).
+			output = strings.ReplaceAll(output, " "+state+" ", " "+colored+" ")
+			output = strings.ReplaceAll(output, " "+state+"\n", " "+colored+"\n")
+		}
+	}
+	if _, err := fmt.Fprint(w, output); err != nil {
+		return fmt.Errorf("write explain output: %w", err)
 	}
 
 	if len(rows) == 0 {
@@ -249,10 +276,10 @@ func explainOnce(w io.Writer, c sigs_client.Client, ns, pipeline, envFilter stri
 		} else {
 			emptyMsg = fmt.Sprintf("No steps or gates found for pipeline %q\n", pipeline)
 		}
-		if _, err := fmt.Fprint(tw, emptyMsg); err != nil {
+		if _, err := fmt.Fprint(w, emptyMsg); err != nil {
 			return fmt.Errorf("write empty message: %w", err)
 		}
 	}
 
-	return tw.Flush()
+	return nil
 }

--- a/cmd/kardinal/cmd/explain_test.go
+++ b/cmd/kardinal/cmd/explain_test.go
@@ -78,7 +78,7 @@ func TestExplain_ShowsStepsAndGates(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ps, gate).Build()
 
 	var buf bytes.Buffer
-	err := explainOnce(&buf, c, "default", "nginx-demo", "")
+	err := explainOnce(&buf, c, "default", "nginx-demo", "", false)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -124,7 +124,7 @@ func TestExplain_FilterByEnv(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(testStep, prodStep).Build()
 
 	var buf bytes.Buffer
-	err := explainOnce(&buf, c, "default", "nginx-demo", "prod")
+	err := explainOnce(&buf, c, "default", "nginx-demo", "prod", false)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -140,7 +140,7 @@ func TestExplain_EmptyOutput(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).Build()
 
 	var buf bytes.Buffer
-	err := explainOnce(&buf, c, "default", "nginx-demo", "")
+	err := explainOnce(&buf, c, "default", "nginx-demo", "", false)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -167,7 +167,7 @@ func TestExplain_UnevaluatedGateExpression(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(gate).Build()
 
 	var buf bytes.Buffer
-	err := explainOnce(&buf, c, "default", "nginx-demo", "")
+	err := explainOnce(&buf, c, "default", "nginx-demo", "", false)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -201,8 +201,6 @@ func TestExplain_ShowsOnlyActiveBundleRows(t *testing.T) {
 				"kardinal.io/pipeline":    "my-app",
 				"kardinal.io/environment": "prod",
 				// Per-bundle Graph instance — must be filtered out by explain (#297).
-				// The kardinal.io/bundle label is the sole guard (krocodile e082fe9+
-				// no longer stamps internal.kro.run/graph-name on managed resources).
 				"kardinal.io/bundle": "old-bundle",
 			},
 		},
@@ -228,30 +226,23 @@ func TestExplain_ShowsOnlyActiveBundleRows(t *testing.T) {
 			Labels: map[string]string{
 				"kardinal.io/pipeline":    "my-app",
 				"kardinal.io/environment": "prod",
-				// Note: no kardinal.io/bundle label — template gates are shown by explain;
-				// per-bundle Graph instances (with bundle label) are filtered out (#297).
 			},
 		},
 		Spec:   v1alpha1.PolicyGateSpec{Expression: "!schedule.isWeekend"},
 		Status: v1alpha1.PolicyGateStatus{Ready: false, LastEvaluatedAt: &now},
 	}
-	// oldGate is also template-style for consistency.
-	// The test verifies that explain shows gates scoped to the active environment,
-	// not that it filters by bundle. Gate-by-bundle filtering is an API concern (#297).
 
 	s := buildExplainScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(oldStep, oldGate, newStep, newGate).Build()
 
 	var buf bytes.Buffer
-	err := explainOnce(&buf, c, "default", "my-app", "")
+	err := explainOnce(&buf, c, "default", "my-app", "", false)
 	require.NoError(t, err)
 
 	out := buf.String()
-	// New bundle's step and gate should appear.
 	assert.Contains(t, out, "new-step", "active bundle step must be shown")
 	assert.Contains(t, out, "new-gate", "active bundle gate must be shown")
 	assert.Contains(t, out, "Promoting", "active bundle step state must be shown")
-	// Old bundle's step and gate should NOT appear.
 	assert.NotContains(t, out, "old-step", "superseded bundle step must not appear")
 	assert.NotContains(t, out, "old-gate", "superseded bundle gate must not appear")
 }
@@ -278,7 +269,7 @@ func TestExplain_UnknownEnvSuggestsAvailable(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipe).Build()
 
 	var buf bytes.Buffer
-	err := explainOnce(&buf, c, "default", "nginx-demo", "bogus")
+	err := explainOnce(&buf, c, "default", "nginx-demo", "bogus", false)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -287,4 +278,37 @@ func TestExplain_UnknownEnvSuggestsAvailable(t *testing.T) {
 	assert.Contains(t, out, "test", "available env 'test' must be listed")
 	assert.Contains(t, out, "uat", "available env 'uat' must be listed")
 	assert.Contains(t, out, "prod", "available env 'prod' must be listed")
+}
+
+// TestExplain_ColorOutput verifies that forceColor=true wraps Pass/Block/Pending
+// states in ANSI codes, and forceColor=false produces plain text (issue #719).
+func TestExplain_ColorOutput(t *testing.T) {
+	gate := &v1alpha1.PolicyGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gate-pass",
+			Namespace: "default",
+			Labels:    map[string]string{"kardinal.io/pipeline": "nginx-demo", "kardinal.io/environment": "prod"},
+		},
+		Spec:   v1alpha1.PolicyGateSpec{Expression: "true"},
+		Status: v1alpha1.PolicyGateStatus{Ready: true},
+	}
+	s := buildExplainScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(gate).Build()
+
+	t.Run("force color enabled", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := explainOnce(&buf, c, "default", "nginx-demo", "", true)
+		require.NoError(t, err)
+		out := buf.String()
+		// Pass state (gate ready=true) should be wrapped in green + reset
+		assert.Contains(t, out, "\033[32mPass\033[0m", "Pass state must be wrapped in green ANSI code")
+	})
+
+	t.Run("color disabled plain text", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := explainOnce(&buf, c, "default", "nginx-demo", "", false)
+		require.NoError(t, err)
+		out := buf.String()
+		assert.NotContains(t, out, "\033[", "plain text output must not contain ANSI escape codes")
+	})
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -214,6 +214,7 @@ Flags:
 - `--watch`: continuous output, re-evaluates and reprints when gate states change
 - `--bundle <version>`: explain a specific Bundle (default: latest active)
 - `--env <env>`: filter by environment
+- `--color`: force ANSI color output (auto-detected when writing to a TTY; respects `NO_COLOR`)
 
 If the environment name is not found, the command prints the available environments:
 

--- a/docs/reference/cli/kardinal-explain.md
+++ b/docs/reference/cli/kardinal-explain.md
@@ -9,6 +9,7 @@ It shows the current state, reason, and any PR URLs for each environment.
 
 Use --env to filter to a specific environment.
 Use --watch to stream live updates.
+Use --color to force ANSI color output (auto-detected when writing to a TTY).
 
 ```
 kardinal explain <pipeline> [flags]
@@ -17,6 +18,7 @@ kardinal explain <pipeline> [flags]
 ### Options
 
 ```
+      --color        Force ANSI color output (auto-detected when TTY)
       --env string   Filter to a specific environment
   -h, --help         help for explain
       --watch        Stream updates (polling)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,11 @@ toolchain go1.25.9
 require (
 	github.com/go-git/go-git/v5 v5.17.1
 	github.com/google/cel-go v0.28.0
+<<<<<<< HEAD
 	github.com/prometheus/client_golang v1.23.2
+=======
+	github.com/mattn/go-isatty v0.0.20
+>>>>>>> 450efd7 (feat(cli): color-coded kardinal explain output — ANSI colors for gate status (#719))
 	github.com/rs/zerolog v1.35.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -54,7 +58,6 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,8 @@ toolchain go1.25.9
 require (
 	github.com/go-git/go-git/v5 v5.17.1
 	github.com/google/cel-go v0.28.0
-<<<<<<< HEAD
-	github.com/prometheus/client_golang v1.23.2
-=======
 	github.com/mattn/go-isatty v0.0.20
->>>>>>> 450efd7 (feat(cli): color-coded kardinal explain output — ANSI colors for gate status (#719))
+	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
Follow-up to PR #730 (merged) — the auto-generated CLI reference page for `kardinal explain` needs to include the new `--color` flag that was added.

Two lines added to `docs/reference/cli/kardinal-explain.md`:
1. Synopsis: mention of `--color` flag
2. Options: `--color` flag with description