### PR TITLE
feat(cli): add --dry-run flag to kardinal create bundle (#739)

### DIFF
--- a/cmd/kardinal/cmd/create_bundle.go
+++ b/cmd/kardinal/cmd/create_bundle.go
@@ -18,13 +18,16 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/graph"
 )
 
 // imageRepoPattern matches valid OCI image repository references.
@@ -46,6 +49,7 @@ func newCreateBundleCmd() *cobra.Command {
 	var (
 		images     []string
 		bundleType string
+		dryRun     bool
 	)
 
 	cmd := &cobra.Command{
@@ -54,12 +58,17 @@ func newCreateBundleCmd() *cobra.Command {
 		Long: `Create a Bundle to trigger promotion through a Pipeline.
 
 The pipeline name is a required positional argument.
-Specify one or more container images with --image.`,
+Specify one or more container images with --image.
+
+Use --dry-run to preview the promotion graph without creating any resources.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, ns, err := buildClient()
 			if err != nil {
 				return fmt.Errorf("create bundle: %w", err)
+			}
+			if dryRun {
+				return createBundleDryRun(cmd.OutOrStdout(), c, ns, args[0], images, bundleType)
 			}
 			return createBundleFn(cmd.OutOrStdout(), c, ns, args[0], images, bundleType)
 		},
@@ -67,6 +76,8 @@ Specify one or more container images with --image.`,
 
 	cmd.Flags().StringArrayVar(&images, "image", nil, "Container image reference (can be specified multiple times)")
 	cmd.Flags().StringVar(&bundleType, "type", "image", "Bundle type: image, config, or mixed")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"Preview the promotion graph without creating any cluster resources")
 
 	return cmd
 }
@@ -112,6 +123,78 @@ func createBundleFn(w interface{ Write([]byte) (int, error) }, c sigs_client.Cli
 		return fmt.Errorf("write output: %w", err)
 	}
 
+	return nil
+}
+
+// createBundleDryRun previews the promotion graph that would be created for a Bundle,
+// without writing any resources to the cluster. It fetches the Pipeline CRD,
+// builds an in-memory Bundle, runs it through graph.Builder.Build, and prints
+// the resulting graph summary.
+func createBundleDryRun(w io.Writer, c sigs_client.Client, ns, pipelineName string, images []string, bundleType string) error {
+	// Validate images
+	var imageRefs []v1alpha1.ImageRef
+	for _, img := range images {
+		repo, tag := splitImageRef(img)
+		if repo != "" && !imageRepoPattern.MatchString(repo) {
+			return fmt.Errorf("invalid image repository %q: must match [a-zA-Z0-9][a-zA-Z0-9._-/]* (e.g. ghcr.io/org/image)", repo)
+		}
+		imageRefs = append(imageRefs, v1alpha1.ImageRef{
+			Repository: repo,
+			Tag:        tag,
+		})
+	}
+
+	// Fetch the Pipeline from the cluster (read-only — dry-run is cluster-aware but not cluster-mutating)
+	var pipe v1alpha1.Pipeline
+	if err := c.Get(context.Background(), sigs_client.ObjectKey{Namespace: ns, Name: pipelineName}, &pipe); err != nil {
+		return fmt.Errorf("dry-run: fetch pipeline %q: %w", pipelineName, err)
+	}
+
+	// Build an in-memory Bundle (not created on cluster)
+	bundle := &v1alpha1.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipelineName + "-dry-run",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.BundleSpec{
+			Type:     bundleType,
+			Pipeline: pipelineName,
+			Images:   imageRefs,
+		},
+	}
+
+	// Run graph.Builder.Build — pure function, no cluster writes
+	b := graph.NewBuilder()
+	result, err := b.Build(graph.BuildInput{
+		Pipeline:    &pipe,
+		Bundle:      bundle,
+		PolicyGates: nil, // dry-run uses no gates (preview mode)
+	})
+	if err != nil {
+		return fmt.Errorf("dry-run: graph build failed: %w", err)
+	}
+
+	// Print a human-readable summary
+	_, _ = fmt.Fprintf(w, "[DRY-RUN] Bundle %q for pipeline %q\n", bundle.Name, pipelineName)
+	_, _ = fmt.Fprintf(w, "\nPromotion graph: %d node(s)\n", result.NodeCount)
+	_, _ = fmt.Fprintf(w, "\nEnvironments in promotion order:\n")
+
+	// Show the environments by iterating the graph nodes
+	seen := map[string]bool{}
+	for _, node := range result.Graph.Spec.Nodes {
+		// Node IDs have format: <celSafeSlug(pipeline)>-<env>-<type>
+		// Split on first two hyphens to extract the environment segment.
+		parts := strings.SplitN(node.ID, "-", 3)
+		if len(parts) >= 2 {
+			env := parts[1]
+			if !seen[env] {
+				seen[env] = true
+				_, _ = fmt.Fprintf(w, "  \u2022 %s\n", env)
+			}
+		}
+	}
+
+	_, _ = fmt.Fprintf(w, "\nNo resources were created. Remove --dry-run to apply.\n")
 	return nil
 }
 

--- a/cmd/kardinal/cmd/create_bundle_test.go
+++ b/cmd/kardinal/cmd/create_bundle_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+)
+
+func buildCreateBundleScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(s)
+	return s
+}
+
+// TestCreateBundle_DryRunFlagRegistered verifies --dry-run is registered.
+func TestCreateBundle_DryRunFlagRegistered(t *testing.T) {
+	cmd := newCreateBundleCmd()
+	f := cmd.Flags().Lookup("dry-run")
+	require.NotNil(t, f, "--dry-run must be registered on 'create bundle'")
+	assert.Equal(t, "false", f.DefValue, "--dry-run must default to false")
+}
+
+// TestCreateBundle_DryRun_NoAPICallsMade verifies that --dry-run does NOT call
+// c.Create (i.e., no Bundle is created on the cluster).
+func TestCreateBundle_DryRun_NoAPICallsMade(t *testing.T) {
+	pipe := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-demo",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.PipelineSpec{
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test"},
+				{Name: "uat"},
+				{Name: "prod"},
+			},
+		},
+	}
+
+	s := buildCreateBundleScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipe).Build()
+
+	var buf bytes.Buffer
+	err := createBundleDryRun(&buf, c, "default", "nginx-demo",
+		[]string{"ghcr.io/org/app:sha-abc123"}, "image")
+	require.NoError(t, err)
+
+	// No Bundle should exist after dry-run
+	var bundleList v1alpha1.BundleList
+	require.NoError(t, c.List(context.Background(), &bundleList))
+	assert.Empty(t, bundleList.Items, "dry-run must not create any Bundles")
+}
+
+// TestCreateBundle_DryRun_OutputContainsKeyInfo verifies the dry-run output mentions
+// the pipeline name and dry-run indicator.
+func TestCreateBundle_DryRun_OutputContainsKeyInfo(t *testing.T) {
+	pipe := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-demo",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.PipelineSpec{
+			Environments: []v1alpha1.EnvironmentSpec{
+				{Name: "test"},
+				{Name: "uat"},
+				{Name: "prod"},
+			},
+		},
+	}
+
+	s := buildCreateBundleScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pipe).Build()
+
+	var buf bytes.Buffer
+	err := createBundleDryRun(&buf, c, "default", "nginx-demo",
+		[]string{"ghcr.io/org/app:sha-abc123"}, "image")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "[DRY-RUN]", "output must contain DRY-RUN marker")
+	assert.Contains(t, out, "nginx-demo", "output must contain pipeline name")
+	assert.Contains(t, out, "No resources were created", "output must confirm nothing was written")
+}
+
+// TestCreateBundle_DryRun_PipelineNotFound returns an error when the Pipeline does not exist.
+func TestCreateBundle_DryRun_PipelineNotFound(t *testing.T) {
+	s := buildCreateBundleScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	var buf bytes.Buffer
+	err := createBundleDryRun(&buf, c, "default", "nonexistent",
+		[]string{"ghcr.io/org/app:sha-abc123"}, "image")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dry-run", "error must mention dry-run context")
+}
+
+// TestCreateBundle_DryRun_InvalidImage returns an error for malformed image refs.
+func TestCreateBundle_DryRun_InvalidImage(t *testing.T) {
+	s := buildCreateBundleScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	var buf bytes.Buffer
+	err := createBundleDryRun(&buf, c, "default", "nginx-demo",
+		[]string{"not valid @@@"}, "image")
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "invalid image") ||
+		strings.Contains(err.Error(), "dry-run"),
+		"error must describe the failure: got %q", err.Error())
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -175,6 +175,26 @@ Bundle my-app-v1-29-0-1712567890 created.
   Next:   dev (gate: auto)
 ```
 
+Use `--dry-run` to preview the promotion graph without creating any resources:
+
+```bash
+kardinal create bundle my-app --image ghcr.io/myorg/my-app:1.29.0 --dry-run
+```
+
+Output:
+```
+[DRY-RUN] Bundle "my-app-dry-run" for pipeline "my-app"
+
+Promotion graph: 7 node(s)
+
+Environments in promotion order:
+  • dev
+  • staging
+  • prod
+
+No resources were created. Remove --dry-run to apply.
+```
+
 ### kardinal promote
 
 Manually trigger promotion by creating a Bundle targeting a specific environment. The Bundle flows through all upstream environments before reaching the target environment. PolicyGates and approval mode apply as configured.

--- a/docs/reference/cli/kardinal-create-bundle.md
+++ b/docs/reference/cli/kardinal-create-bundle.md
@@ -9,6 +9,8 @@ Create a Bundle to trigger promotion through a Pipeline.
 The pipeline name is a required positional argument.
 Specify one or more container images with --image.
 
+Use --dry-run to preview the promotion graph without creating any resources.
+
 ```
 kardinal create bundle <pipeline> [flags]
 ```
@@ -16,6 +18,7 @@ kardinal create bundle <pipeline> [flags]
 ### Options
 
 ```
+      --dry-run             Preview the promotion graph without creating any cluster resources
   -h, --help                help for bundle
       --image stringArray   Container image reference (can be specified multiple times)
       --type string         Bundle type: image, config, or mixed (default "image")

--- a/docs/reference/cli/kardinal-explain.md
+++ b/docs/reference/cli/kardinal-explain.md
@@ -9,6 +9,7 @@ It shows the current state, reason, and any PR URLs for each environment.
 
 Use --env to filter to a specific environment.
 Use --watch to stream live updates.
+Use --color to force ANSI color output (auto-detected when writing to a TTY).
 
 ```
 kardinal explain <pipeline> [flags]
@@ -17,6 +18,7 @@ kardinal explain <pipeline> [flags]
 ### Options
 
 ```
+      --color        Force ANSI color output (auto-detected when TTY)
       --env string   Filter to a specific environment
   -h, --help         help for explain
       --watch        Stream updates (polling)


### PR DESCRIPTION
## Summary

Adds `--dry-run` to `kardinal create bundle`. When set, the command previews the promotion graph without creating any cluster resources.

## How it works

1. Validates image refs (same as normal path)
2. Fetches the Pipeline CRD (read-only)
3. Builds an in-memory Bundle (never `c.Create`'d)
4. Calls `graph.Builder.Build()` — a pure function with no cluster writes
5. Prints: node count, environments in order, and a confirmation that nothing was created

## Example output

```
[DRY-RUN] Bundle "my-app-dry-run" for pipeline "my-app"

Promotion graph: 7 node(s)

Environments in promotion order:
  • dev
  • staging
  • prod

No resources were created. Remove --dry-run to apply.
```

## Tests

5 new tests: flag registered, no Bundles created, output contains key info, pipeline-not-found error, invalid-image error.

Closes #739
Part of epic #577