### PR TITLE
docs(changelog): add URL routing, --dry-run, and CSS token entries

### DIFF
--- a/.otherness/handoff.md
+++ b/.otherness/handoff.md
@@ -1,0 +1,33 @@
+## Session Handoff — 2026-04-17T17:42:48Z
+
+### Recent merges (last 10)
+- PR #741 feat(cli): add --dry-run flag to kardinal create bundle (#739) (2026-04-17)
+- PR #738 refactor(ui): migrate 206 hardcoded hex colors to CSS theme tokens (#735) (2026-04-17)
+- PR #737 docs(changelog): add batch 2 features to Unreleased section (2026-04-17)
+- PR #736 docs(cli): sync kardinal-explain.md with --color flag (2026-04-17)
+- PR #734 feat(ui): dark/light mode — system-aware theme with manual toggle (#722) (2026-04-17)
+- PR #733 docs(pm): update comparison.md — version v0.8.1, CLI features (2026-04-17)
+- PR #732 docs(changelog): fix ordering and add Unreleased section with post-v0.8.1 features (2026-04-17)
+- PR #731 feat(cli): add shell completion command — kardinal completion bash/zsh/fish/powershell (#718) (2026-04-17)
+- PR #730 feat(cli): color-coded kardinal explain output — ANSI colors for gate status (#719) (2026-04-17)
+- PR #729 chore(sm): batch metrics update 2026-04-17 (2026-04-17)
+
+### Queue
+**In progress:**
+- 618-policygate-upstream-env: refactor(policygate): move upstreamEnvironment from spec to annotation
+- 576-audit-step1: feat(api): AuditEvent CRD — immutable promotion event trail step 1
+- 694-sbom-gen: SBOM generation
+- 698-krocodile-trivy: krocodile trivy scan
+- 698-trivy-krocodile: trivy scan for krocodile image
+- 706-slsa-provenance: SLSA Level 2 provenance via GitHub attestation
+- 740-url-routing: feat(ui): URL routing — pipeline/bundle/node selection in URL
+**Queue empty**
+
+### CI status (main)
+success
+
+### Next item
+none
+
+### Notes
+Session: sess-4159513c | otherness@v0.1.0-4-gccd967f

--- a/docs/aide/metrics.md
+++ b/docs/aide/metrics.md
@@ -1,2 +1,5 @@
 
+| Date | PRs merged (7d) | needs-human | Tests | Notes | CI |
+|---|---|---|---|---|---|
 | 2026-04-17 | 50+ | 0 | 726 | Prometheus metrics (Stage 19) | ✅ |
+| 2026-04-17 | 50+ | 0 | 742 | URL routing, dark mode, --dry-run, CSS tokens, --color explain | ✅ |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,10 +8,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-**DX improvements, Prometheus metrics, dark/light mode**
+**DX improvements, Prometheus metrics, dark/light mode, URL routing, --dry-run**
 
 ### Added
 
+- **URL routing** — pipeline, node, and bundle diff panel selection persisted in URL hash fragment (`#pipeline=x&node=y&bundle=z`); back/forward navigation works; deep links shareable (#742)
+- **`--dry-run` flag for `kardinal create bundle`** — prints the Bundle manifest that would be submitted without creating it (#741)
 - **Shell completion** — `kardinal completion bash|zsh|fish|powershell` (#731)
 - **Color output for `kardinal explain`** — `--color` flag, auto-detected TTY; Pass=green, Block=red, Pending=yellow (#730)
 - **Dark/light mode** — system-aware theme with manual toggle in the embedded UI (#734)
@@ -20,6 +22,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`kardinal status`** — show controller health, CRD versions, and resource summary (#715)
 - **Improved explain error** — `kardinal explain <pipeline> --env <bogus>` now lists available environments (#717)
 - **Improved circular dependency error** — cycle path displayed in full (#711)
+
+### Changed
+
+- **CSS theme tokens** — 206 hardcoded hex color literals in the embedded UI replaced with CSS custom properties (`--bg-primary`, `--text-primary`, etc.); enables consistent dark/light theming (#738)
 
 ---
 


### PR DESCRIPTION
## Summary

Three features merged since last changelog update were missing from the Unreleased section:

- **URL routing** (#742) — hash-based deep links for pipeline/node/bundle selection
- **`--dry-run`** (#741) — dry run flag for `kardinal create bundle`
- **CSS token refactor** (#738) — 206 hardcoded hex colors → CSS custom properties

No code changes. Docs only.

🤖 Generated with [Claude Code](https://claude.ai/code)