### PR TITLE
docs(pm): update competitor versions — Kargo v1.10.x, GitOps Promoter v0.27.x

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -38,7 +38,7 @@ This page compares kardinal-promoter with the two most similar tools in the GitO
 | **Artifact discovery** | Bundle created by CI/CLI; Subscription CRD with OCI + Git watchers | Warehouse (automatic OCI/git scanning) | Git commit-based |
 | **Multi-artifact bundle** | Yes (image + config in one Bundle) | Yes (Freight) | No |
 | **Architecture** | Graph-first (krocodile DAG) | Stage/controller | Controller |
-| **Maturity** | v0.8.1, active development | v1.9.x, production-grade | v0.26.x, experimental |
+| **Maturity** | v0.8.1, active development | v1.10.x, production-grade | v0.27.x, experimental |
 | **License** | Apache 2.0 | Apache 2.0 | Apache 2.0 |
 
 ---


### PR DESCRIPTION
## Summary

Kargo released v1.10.0 today (2026-04-17). GitOps Promoter is at v0.27.0. Updated the maturity row in comparison.md.

**Kargo v1.10.0 notable new features (no action required on kardinal):**
- argocd-wait, oci-push, github-push, git-tag, fail, set-freight-alias promotion steps
- toml-parse/update steps
- Webhook path filtering for monorepos
- git-commit author field deprecated (consolidating to git-clone)

No new gaps in the feature matrix for kardinal — all new Kargo steps are niche capabilities outside kardinal's scope (OCI retag, TOML parsing).