### PR TITLE
chore(graph): upgrade krocodile 05db829 → cdc4bb9 — schema-aware CEL + forEach fix

### DIFF
--- a/chart/kardinal-promoter/Chart.yaml
+++ b/chart/kardinal-promoter/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 annotations:
   # The krocodile commit bundled in this chart version.
   # Built and pushed to ghcr.io/pnz1990/kardinal-promoter/krocodile:<commit>
-  krocodile.commit: "05db829"
+  krocodile.commit: "cdc4bb9"

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -127,9 +127,9 @@ krocodile:
 
   # Pinned source commit from github.com/ellistarn/kro (krocodile branch).
   # This is the commit the release pipeline built the image from.
-   # Used as the default image tag when image.tag is not set.
-   # Update via the krocodile upgrade protocol in AGENTS.md.
-   pinnedCommit: "cdc4bb9"
+  # Used as the default image tag when image.tag is not set.
+  # Update via the krocodile upgrade protocol in AGENTS.md.
+  pinnedCommit: "cdc4bb9"
 
   # -- API group for Graph CRDs.
   apiGroup: "experimental.kro.run"

--- a/chart/kardinal-promoter/values.yaml
+++ b/chart/kardinal-promoter/values.yaml
@@ -127,9 +127,9 @@ krocodile:
 
   # Pinned source commit from github.com/ellistarn/kro (krocodile branch).
   # This is the commit the release pipeline built the image from.
-  # Used as the default image tag when image.tag is not set.
-  # Update via the krocodile upgrade protocol in AGENTS.md.
-  pinnedCommit: "05db829"
+   # Used as the default image tag when image.tag is not set.
+   # Update via the krocodile upgrade protocol in AGENTS.md.
+   pinnedCommit: "cdc4bb9"
 
   # -- API group for Graph CRDs.
   apiGroup: "experimental.kro.run"

--- a/hack/install-krocodile.sh
+++ b/hack/install-krocodile.sh
@@ -16,16 +16,19 @@ set -euo pipefail
 # ── Pinned version ─────────────────────────────────────────────────────────────
 # Update this when intentionally upgrading krocodile.
 # Minimum required: 1b0ce353 (fixes double-dispatch race in DAG coordinator)
-# Last verified:    05db829 (2026-04-17 — 5 commits since 81c5a03; highlights:
-#                           - BREAKING: explicit-keyword schema for Graph nodes (#150)
-#                             template: → Own, patch: → Contribute, ref: → Ref (single),
-#                             watch: → Watch (collection), def: → Definition
-#                             kardinal compat: Watch nodes → ref:, WatchKind → watch:
-#                           - stdlib: rename Kind items, Singleton holder (#155)
+# Last verified:    cdc4bb9 (2026-04-17 — 6 commits since 05db829; highlights:
+#                           - schema-aware CEL: typed resource schemas + runtime
+#                             value wrapping; no dyn() wrappers needed (#161)
+#                           - forEach fix: silent data loss + unchecked type
+#                             assertions resolved (#160)
+#                           - NodeTypeOwn → NodeTypeTemplate (cosmetic rename,
+#                             YAML keywords unchanged) (#158)
+#                           - startup hydration: skip dynamic-GVR nodes (#157)
+# Previously verified: 05db829 (explicit-keyword schema)
 #                           - stdlib: cluster-scoped Kind, printer columns (#152)
 #                           - RGD stdlib: instance GVK labels + force-apply (#149))
 KROCODILE_REPO="https://github.com/ellistarn/kro.git"
-KROCODILE_COMMIT="${KROCODILE_COMMIT:-05db829}"
+KROCODILE_COMMIT="${KROCODILE_COMMIT:-cdc4bb9}"
 KROCODILE_IMAGE="krocodile-graph-controller:${KROCODILE_COMMIT}"
 KIND_CLUSTER="${KIND_CLUSTER:-kardinal-e2e}"
 


### PR DESCRIPTION
## Summary

Routine krocodile upgrade. 6 commits ahead of our pin — mandatory upgrade per AGENTS.md §krocodile Upgrade Cadence.

## Changes

| Commit | Title | Breaking for kardinal? |
|---|---|---|
| cdc4bb9 | schema-aware CEL: typed resource schemas + runtime value wrapping (#161) | No — backwards-compatible improvement |
| 1899079 | fix: forEach multi-variable silent data loss and unchecked type assertions (#160) | No — bug fix |
| a1709a7 | simplicity: dead code, naming accuracy (#159) | No — internal refactor |
| 99a4232 | NodeTypeOwn → NodeTypeTemplate, NodeTypeContribute → NodeTypePatch (#158) | No — Go constant rename only; YAML keywords unchanged |
| 6cacd2e | startup hydration: skip dynamic-GVR nodes via HasDynamicGVR() (#157) | No |
| 851a8a8 | observable startup + health-gated readiness (#156) | No |

## Breaking change analysis

No breaking changes for kardinal.
- YAML keywords (`template:`, `ref:`, `watch:`, `def:`) are unchanged
- Schema-aware CEL is backwards-compatible (better type inference in Graph CEL)
- `forEach` fix improves correctness for multi-region fan-out — no API change
- `NodeTypeOwn → NodeTypeTemplate` is Go source rename; we don't use these constants directly

## Notable improvement: forEach bug fix (#160)

The forEach fix resolves silent data loss when forEach nodes had multi-variable iteration. This may improve reliability of multi-environment pipeline Graph generation.

## Schema-aware CEL (#161)

Our `readyWhen`/`propagateWhen` expressions benefit from better type resolution. No changes needed to our Graph builder.

🤖 Generated with [Claude Code](https://claude.ai/code)
