### PR TITLE
fix(ui): sync package-lock.json — add missing axe-core entries

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,6 +14,7 @@
         "reactflow": "^11.11.4"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -72,6 +73,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2152,6 +2166,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/baseline-browser-mapping": {


### PR DESCRIPTION
## Problem

CI E2E jobs have been failing with:
```
npm error Missing: @axe-core/playwright@4.11.2 from lock file
npm error Missing: axe-core@4.11.3 from lock file
```

The `package-lock.json` was not regenerated when `@axe-core/playwright` was added to `package.json` in the WCAG PR (#756). This caused `npm ci` to fail in the Docker build step.

## Fix

Ran `npm install` in `web/` to regenerate `package-lock.json` with the missing entries. Verified with `npm ci --dry-run` — passes cleanly.

## Verification

- `npm ci --dry-run`: ✅ clean
- `grep axe-core web/package-lock.json | wc -l`: 6 (was 0)

[🎯 COORD | sess-69f236d9 | otherness@v0.1.0-14-g418a457] CI blocker fix.