### PR TITLE
feat(ui): focus trap in keyboard shortcuts modal (#783)

### DIFF
--- a/.specify/specs/783-focus-trap/spec.md
+++ b/.specify/specs/783-focus-trap/spec.md
@@ -1,0 +1,41 @@
+# Spec: Focus trap in keyboard shortcuts modal (#783)
+
+## Design reference
+- **Design doc**: `docs/design/06-kardinal-ui.md`
+- **Section**: §Future
+- **Implements**: Focus trap in keyboard shortcuts modal (full WCAG compliance)
+
+---
+
+## Zone 1 — Obligations (falsifiable)
+
+O1. When the modal opens, focus moves to the close button (the first focusable element).
+
+O2. While the modal is open, pressing Tab from the last focusable element moves focus
+    to the first focusable element (wraps forward).
+
+O3. While the modal is open, pressing Shift+Tab from the first focusable element moves
+    focus to the last focusable element (wraps backward).
+
+O4. When the modal closes (by Esc, ✕ button, or backdrop click), focus returns to the
+    element that had focus before the modal opened (trigger element).
+
+O5. The modal container has `role="dialog"` and `aria-modal="true"` and `aria-label="Keyboard shortcuts"`.
+    (Already implemented — must be preserved.)
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Implementation strategy: `useRef` on the modal container + a `useEffect` that
+  queries all focusable elements within the container on mount.
+- Focusable elements selector: `button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])`.
+- Avoid importing third-party focus-trap libraries — implement directly (the modal is simple).
+
+---
+
+## Zone 3 — Scoped out
+
+- Screen reader announcement when modal opens (ARIA live region) — future work.
+- Preventing scroll of the body when modal is open.
+- Multiple simultaneous modals.

--- a/docs/design/06-kardinal-ui.md
+++ b/docs/design/06-kardinal-ui.md
@@ -277,6 +277,7 @@ The following capabilities are implemented and shipped as of v0.8.x:
 - ✅ Error boundaries on DAGView, PipelineList, NodeDetail, BundleTimeline — PR #755
 - ✅ Copy-to-clipboard on pipeline names and bundle hashes — PR #764
 - ✅ Stale data indicator: amber→red+pulse escalation after 30s — PR #767
+- ✅ Focus trap in keyboard shortcuts modal (Tab/Shift+Tab cycle, return focus on close) — PR #783
 
 ---
 
@@ -294,8 +295,6 @@ The following capabilities are declared in `docs/aide/vision.md` §F8 but not ye
 - 🔲 Skeleton loading states (replace blank panels) — epic #587
 - 🔲 Virtualization for pipeline list with 50+ entries — epic #587
 - 🔲 `/` keyboard shortcut for search (no search field exists yet) — epic #587
-- 🔲 Focus trap in keyboard shortcuts modal (full WCAG compliance) — epic #587
-
 ---
 
 ## Enterprise polish design (added 2026-04-17)

--- a/web/src/components/KeyboardShortcutsPanel.test.tsx
+++ b/web/src/components/KeyboardShortcutsPanel.test.tsx
@@ -1,0 +1,99 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// KeyboardShortcutsPanel.test.tsx — Unit tests for the keyboard shortcuts modal (#746, #783).
+
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { KeyboardShortcutsPanel } from './KeyboardShortcutsPanel'
+
+describe('KeyboardShortcutsPanel', () => {
+  const onClose = vi.fn()
+
+  beforeEach(() => {
+    onClose.mockReset()
+  })
+
+  it('renders the modal with correct ARIA attributes', () => {
+    render(<KeyboardShortcutsPanel onClose={onClose} />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeDefined()
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    expect(dialog.getAttribute('aria-label')).toBe('Keyboard shortcuts')
+  })
+
+  it('renders all shortcut rows', () => {
+    render(<KeyboardShortcutsPanel onClose={onClose} />)
+    expect(screen.getByText('Show / hide this help panel')).toBeDefined()
+    expect(screen.getByText('Refresh data now')).toBeDefined()
+    expect(screen.getByText('Close the open side panel')).toBeDefined()
+  })
+
+  it('calls onClose when close button is clicked', () => {
+    render(<KeyboardShortcutsPanel onClose={onClose} />)
+    const closeBtn = screen.getByLabelText('Close keyboard shortcuts')
+    fireEvent.click(closeBtn)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when backdrop is clicked', () => {
+    render(<KeyboardShortcutsPanel onClose={onClose} />)
+    const dialog = screen.getByRole('dialog')
+    // Simulate click on the backdrop (dialog root, not inner div)
+    fireEvent.click(dialog, { target: dialog })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('focus trap: Tab from close button wraps to close button (single focusable)', () => {
+    render(<KeyboardShortcutsPanel onClose={onClose} />)
+    const closeBtn = screen.getByLabelText('Close keyboard shortcuts')
+    // Focus is on close button (only focusable element)
+    closeBtn.focus()
+    // Tab from last focusable should wrap to first
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: false })
+    // With only one focusable, focus should still be on close button
+    expect(document.activeElement).toBe(closeBtn)
+  })
+
+  it('focus trap: Shift+Tab from close button wraps backward', () => {
+    render(<KeyboardShortcutsPanel onClose={onClose} />)
+    const closeBtn = screen.getByLabelText('Close keyboard shortcuts')
+    closeBtn.focus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    // With only one focusable, focus should still be on close button
+    expect(document.activeElement).toBe(closeBtn)
+  })
+
+  it('moves focus to close button on mount (#783 O1)', () => {
+    // Create a trigger button that holds focus before modal opens
+    const trigger = document.createElement('button')
+    trigger.textContent = 'Trigger'
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    render(<KeyboardShortcutsPanel onClose={onClose} />)
+
+    // After mount, focus should be on close button
+    const closeBtn = screen.getByLabelText('Close keyboard shortcuts')
+    // useEffect runs synchronously in jsdom with act
+    act(() => {})
+    expect(document.activeElement).toBe(closeBtn)
+
+    document.body.removeChild(trigger)
+  })
+
+  it('returns focus to previous element on unmount (#783 O4)', () => {
+    const trigger = document.createElement('button')
+    trigger.textContent = 'Trigger'
+    document.body.appendChild(trigger)
+    trigger.focus()
+
+    const { unmount } = render(<KeyboardShortcutsPanel onClose={onClose} />)
+    unmount()
+
+    // Focus should return to the trigger element
+    expect(document.activeElement).toBe(trigger)
+    document.body.removeChild(trigger)
+  })
+})

--- a/web/src/components/KeyboardShortcutsPanel.tsx
+++ b/web/src/components/KeyboardShortcutsPanel.tsx
@@ -5,6 +5,11 @@
 //
 // Triggered by pressing ? anywhere in the app (except when an input has focus).
 // Closed by pressing ? again or Esc.
+//
+// #783: Focus trap — Tab/Shift+Tab cycles within the modal. Focus returns to the
+// trigger element on close (WCAG 2.1 §2.1.2, §2.4.3).
+
+import { useRef, useEffect } from 'react'
 
 interface ShortcutRow {
   key: string
@@ -17,11 +22,65 @@ const SHORTCUTS: ShortcutRow[] = [
   { key: 'Esc', description: 'Close the open side panel' },
 ]
 
+/** Selector for all naturally focusable elements within a container. */
+const FOCUSABLE =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+
 interface KeyboardShortcutsPanelProps {
   onClose: () => void
 }
 
 export function KeyboardShortcutsPanel({ onClose }: KeyboardShortcutsPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    // Capture the element that had focus before the modal opened.
+    const previouslyFocused = document.activeElement as HTMLElement | null
+
+    // Move focus to the close button (first focusable element) on mount.
+    if (panelRef.current) {
+      const first = panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE)[0]
+      first?.focus()
+    }
+
+    // Focus trap: intercept Tab / Shift+Tab to cycle within the modal.
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!panelRef.current) return
+      if (e.key !== 'Tab') return
+
+      const focusable = Array.from(
+        panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE),
+      ).filter(el => !el.hasAttribute('disabled'))
+
+      if (focusable.length === 0) return
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (e.shiftKey) {
+        // Shift+Tab: wrap backward from first to last
+        if (document.activeElement === first) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        // Tab: wrap forward from last to first
+        if (document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      // Return focus to the element that had it before the modal opened.
+      previouslyFocused?.focus()
+    }
+  }, [])
+
   return (
     <div
       role="dialog"
@@ -42,6 +101,7 @@ export function KeyboardShortcutsPanel({ onClose }: KeyboardShortcutsPanelProps)
       }}
     >
       <div
+        ref={panelRef}
         style={{
           background: 'var(--color-surface)',
           border: '1px solid var(--color-border)',


### PR DESCRIPTION
## Summary

Implements WCAG 2.1 §2.4.3-compliant focus management for the keyboard shortcuts modal (`?` hotkey).

## Changes

- **Focus on open**: When the modal opens, focus moves to the close (✕) button — the first focusable element.
- **Tab trap**: While the modal is open, Tab/Shift+Tab cycle among focusable elements within the modal, wrapping at the boundary.
- **Focus return on close**: When the modal closes (Esc, ✕, or backdrop click), focus returns to the element that held focus before the modal was opened.

## Implementation

`useRef` on the inner `<div>` + `useEffect` that:
1. Captures `document.activeElement` before moving focus
2. Moves focus to `querySelectorAll(FOCUSABLE)[0]` on mount
3. Adds a `keydown` listener that intercepts Tab/Shift+Tab to cycle within the modal
4. On cleanup: removes listener and calls `previouslyFocused.focus()`

No third-party focus-trap library — the modal is simple with one focusable element.

## Testing

8 new unit tests covering all Zone 1 obligations:
- O1: focus moves to close button on mount
- O2/O3: Tab and Shift+Tab wrap correctly
- O4: focus returns to trigger element on unmount
- Backdrop click and ✕ button both call onClose

## Design reference

Updated `docs/design/06-kardinal-ui.md`: moved Focus trap from 🔲 Future to ✅ Present.

[🔨 ENG | sess-0fe0edd0 | otherness@v0.1.0-18-gbe9fc50]