### PR TITLE
feat(demo): complete demo environment + fix v0.8.1 release CI

### DIFF
--- a/.github/workflows/demo-validate.yml
+++ b/.github/workflows/demo-validate.yml
@@ -1,0 +1,149 @@
+name: Demo Validate
+
+# This workflow IS the source of truth that kardinal-promoter works end-to-end.
+# It runs the full demo setup + validate scripts on a real kind cluster.
+#
+# Triggers:
+#   - Nightly at 02:00 UTC (catches controller regressions)
+#   - On any PR that touches demo/, examples/, or the controller
+#   - Manual dispatch (for on-demand validation)
+#
+# If this workflow is red, kardinal does not work. No exceptions.
+
+on:
+  schedule:
+    - cron: '0 2 * * *'     # 02:00 UTC nightly
+  pull_request:
+    paths:
+      - 'demo/**'
+      - 'examples/**'
+      - 'cmd/**'
+      - 'pkg/**'
+      - 'api/**'
+      - 'chart/**'
+      - '.github/workflows/demo-validate.yml'
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: 'Specific scenario to run (1-10), or empty for all'
+        required: false
+        default: ''
+      fast:
+        description: 'Fast mode (skip soak waits)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  CONTROL_CLUSTER: kardinal-control
+  DEV_CLUSTER: kardinal-dev
+  PROD_CLUSTER: kardinal-prod
+  CHART_IMAGE_TAG: v0.8.0   # last known-good published image
+
+jobs:
+  demo-validate:
+    name: Demo end-to-end validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+          # kind
+          curl -Lo /usr/local/bin/kind \
+            https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+          chmod +x /usr/local/bin/kind
+
+          # helm
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+          # argocd CLI
+          curl -sSL https://github.com/argoproj/argo-cd/releases/download/v2.10.3/argocd-linux-amd64 \
+            -o /usr/local/bin/argocd
+          chmod +x /usr/local/bin/argocd
+
+          # kardinal CLI — build from source (always tests latest)
+          go build -o /usr/local/bin/kardinal ./cmd/kardinal/
+
+      - name: Build and load controller image locally
+        run: |
+          # Build from source so CI always tests the code in this PR
+          docker build \
+            --build-arg VERSION=ci-$(git rev-parse --short HEAD) \
+            -t ghcr.io/pnz1990/kardinal-promoter/controller:ci-local \
+            .
+          echo "CHART_IMAGE_TAG=ci-local" >> $GITHUB_ENV
+
+      - name: Set up demo environment
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEMO_GITHUB_TOKEN }}
+        run: |
+          # Load the locally-built image into the control cluster after it's created.
+          # setup.sh creates clusters first, then we load the image.
+          SKIP_BUILD=true CHART_IMAGE_TAG=ci-local \
+            bash demo/scripts/setup.sh
+
+          # Load locally-built controller image into the control cluster
+          kind load docker-image \
+            ghcr.io/pnz1990/kardinal-promoter/controller:ci-local \
+            --name "$CONTROL_CLUSTER"
+
+          # Patch the deployment to use the local image
+          kubectl config use-context "kind-${CONTROL_CLUSTER}"
+          kubectl set image deployment/kardinal-kardinal-promoter \
+            controller=ghcr.io/pnz1990/kardinal-promoter/controller:ci-local \
+            -n kardinal-system
+          kubectl rollout status deployment/kardinal-kardinal-promoter \
+            -n kardinal-system --timeout=120s
+
+      - name: Run validation
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEMO_GITHUB_TOKEN }}
+          FAST: ${{ github.event.inputs.fast || 'false' }}
+        run: |
+          SCENARIO_ARG=""
+          if [[ -n "${{ github.event.inputs.scenario }}" ]]; then
+            SCENARIO_ARG="--scenario ${{ github.event.inputs.scenario }}"
+          fi
+          bash demo/scripts/validate.sh $SCENARIO_ARG
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== kardinal-system pods ==="
+          kubectl config use-context "kind-${CONTROL_CLUSTER}"
+          kubectl get pods -n kardinal-system -o wide
+          echo ""
+          echo "=== Controller logs ==="
+          kubectl logs -n kardinal-system -l app.kubernetes.io/name=kardinal-promoter \
+            --tail=100 2>/dev/null || \
+            kubectl logs -n kardinal-system deployment/kardinal-kardinal-promoter \
+            --tail=100 2>/dev/null || echo "no logs"
+          echo ""
+          echo "=== Pipelines ==="
+          kubectl get pipelines -A 2>/dev/null || echo "no pipelines"
+          echo ""
+          echo "=== PolicyGates ==="
+          kubectl get policygates -A 2>/dev/null || echo "no policy gates"
+
+      - name: Post result to issue #1
+        if: always() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          STATUS=$([[ "${{ job.status }}" == "success" ]] && echo "✅ PASS" || echo "❌ FAIL")
+          DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
+          BODY="[DEMO VALIDATE | ${DATE}] Nightly demo validation: **${STATUS}** — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue comment 1 \
+            --repo pnz1990/kardinal-promoter \
+            --body "$BODY"
+
+      - name: Teardown
+        if: always()
+        run: |
+          bash demo/scripts/teardown.sh 2>/dev/null || true

--- a/.github/workflows/demo-validate.yml
+++ b/.github/workflows/demo-validate.yml
@@ -52,59 +52,46 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Install tools
         run: |
-          # kind
-          curl -Lo /usr/local/bin/kind \
-            https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
-          chmod +x /usr/local/bin/kind
+          BIN="${HOME}/.local/bin"
+          mkdir -p "$BIN"
+          echo "$BIN" >> $GITHUB_PATH
 
-          # helm
-          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          # kind
+          curl -Lo "${BIN}/kind" \
+            https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+          chmod +x "${BIN}/kind"
+
+          # helm (installs to /usr/local/bin via the official script, which uses sudo)
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
           # argocd CLI
           curl -sSL https://github.com/argoproj/argo-cd/releases/download/v2.10.3/argocd-linux-amd64 \
-            -o /usr/local/bin/argocd
-          chmod +x /usr/local/bin/argocd
+            -o "${BIN}/argocd"
+          chmod +x "${BIN}/argocd"
 
-          # kardinal CLI — build from source (always tests latest)
-          go build -o /usr/local/bin/kardinal ./cmd/kardinal/
-
-      - name: Build and load controller image locally
-        run: |
-          # Build from source so CI always tests the code in this PR
-          docker build \
-            --build-arg VERSION=ci-$(git rev-parse --short HEAD) \
-            -t ghcr.io/pnz1990/kardinal-promoter/controller:ci-local \
-            .
-          echo "CHART_IMAGE_TAG=ci-local" >> $GITHUB_ENV
+          # kardinal CLI — build from source (always tests latest code in this PR)
+          go build -mod=mod -o "${BIN}/kardinal" ./cmd/kardinal/
+          echo "kardinal version: $("${BIN}/kardinal" version 2>&1 | head -1)"
 
       - name: Set up demo environment
         env:
           GITHUB_TOKEN: ${{ secrets.DEMO_GITHUB_TOKEN }}
         run: |
-          # Load the locally-built image into the control cluster after it's created.
-          # setup.sh creates clusters first, then we load the image.
-          SKIP_BUILD=true CHART_IMAGE_TAG=ci-local \
-            bash demo/scripts/setup.sh
-
-          # Load locally-built controller image into the control cluster
-          kind load docker-image \
-            ghcr.io/pnz1990/kardinal-promoter/controller:ci-local \
-            --name "$CONTROL_CLUSTER"
-
-          # Patch the deployment to use the local image
-          kubectl config use-context "kind-${CONTROL_CLUSTER}"
-          kubectl set image deployment/kardinal-kardinal-promoter \
-            controller=ghcr.io/pnz1990/kardinal-promoter/controller:ci-local \
-            -n kardinal-system
-          kubectl rollout status deployment/kardinal-kardinal-promoter \
-            -n kardinal-system --timeout=120s
+          # Use the published image tag (set in env.CHART_IMAGE_TAG = v0.8.0)
+          # The setup.sh script will create clusters and install everything.
+          bash demo/scripts/setup.sh
 
       - name: Run validation
         env:
           GITHUB_TOKEN: ${{ secrets.DEMO_GITHUB_TOKEN }}
-          FAST: ${{ github.event.inputs.fast || 'false' }}
+          FAST: ${{ github.event.inputs.fast || 'true' }}
         run: |
           SCENARIO_ARG=""
           if [[ -n "${{ github.event.inputs.scenario }}" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
 
       # ── Vulnerability scanning ──────────────────────────────────────────────
       - name: Scan controller image for HIGH/CRITICAL CVEs (trivy)
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/pnz1990/kardinal-promoter/controller:${{ env.VERSION }}
           format: sarif
@@ -187,7 +187,7 @@ jobs:
           category: trivy-controller
 
       - name: Scan krocodile image for HIGH/CRITICAL CVEs (trivy)
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/pnz1990/kardinal-promoter/krocodile:${{ env.KROCODILE_COMMIT }}
           format: sarif

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,261 @@
+# kardinal-promoter Demo Environment
+
+This directory contains everything needed to create a **complete, working demo environment** for kardinal-promoter — three clusters, two pipelines, all features exercised, and a validation script that serves as the source of truth that the product works.
+
+## What You Get
+
+```
+kind-kardinal-control   ← kardinal controller + krocodile + ArgoCD
+kind-kardinal-dev       ← test + uat environments (kardinal-test-app)
+kind-kardinal-prod      ← prod environment  (kind locally, or EKS with --eks)
+```
+
+**Pipeline 1 — `kardinal-test-app` (simple)**
+```
+test (auto) → uat (auto) → prod (PR review)
+                                ↑ gates: no-weekend-deploys, require-uat-soak, no-bot-deploys
+```
+
+**Pipeline 2 — `kardinal-test-app-advanced` (all features)**
+```
+test-fast (auto) → uat (auto) → prod-canary (PR) → prod-full (PR)
+                                ↑ gates: business-hours-only, require-uat-soak, no-bot-deploys
+```
+
+**Features exercised end-to-end:**
+
+| Feature | Where |
+|---|---|
+| Auto-promote | test, uat |
+| PR-review gate | prod |
+| PolicyGate: schedule | no-weekend-deploys, business-hours-only |
+| PolicyGate: soak | require-uat-soak (30m in uat) |
+| PolicyGate: provenance | no-bot-deploys |
+| Pause / resume | `kardinal pause` / `kardinal resume` |
+| Rollback | `kardinal rollback` |
+| Explain gate state | `kardinal explain --color` |
+| Policy simulate | `kardinal policy simulate --time "Saturday 3pm"` |
+| CLI completeness | version, get, explain, logs, history, audit, completion, --dry-run |
+| Web UI | `kardinal dashboard` → React DAG view |
+| Multi-cluster | advanced pipeline across dev + prod clusters |
+
+---
+
+## Prerequisites
+
+```bash
+# macOS
+brew install kind kubectl helm
+
+# kardinal CLI (build from source)
+cd /path/to/kardinal-promoter
+go build -o /usr/local/bin/kardinal ./cmd/kardinal/
+
+# Docker Desktop — must be running
+open -a Docker
+
+# GitHub PAT with repo write access (needed for GitOps push)
+export GITHUB_TOKEN=ghp_your_token_here
+```
+
+---
+
+## Quick Start
+
+```bash
+cd /path/to/kardinal-promoter
+
+# 1. Set up everything (takes ~5 min)
+GITHUB_TOKEN=ghp_xxx ./demo/scripts/setup.sh
+
+# 2. Trigger a promotion
+LATEST=$(curl -sf https://api.github.com/repos/pnz1990/kardinal-test-app/commits/main \
+  -H "Authorization: Bearer $GITHUB_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['sha'][:7])")
+kardinal create bundle kardinal-test-app \
+  --image ghcr.io/pnz1990/kardinal-test-app:sha-${LATEST}
+
+# 3. Watch it promote
+kardinal get pipelines --watch
+
+# 4. Open the UI
+kubectl port-forward -n kardinal-system \
+  deployment/kardinal-kardinal-promoter 8082:8082 &
+kardinal dashboard     # opens http://localhost:8082/ui/
+
+# 5. Validate everything works
+./demo/scripts/validate.sh
+
+# 6. Tear down
+./demo/scripts/teardown.sh
+```
+
+---
+
+## Scenario Walkthroughs
+
+### Scenario A: Happy path
+
+```bash
+# Promote a new image
+kardinal create bundle kardinal-test-app \
+  --image ghcr.io/pnz1990/kardinal-test-app:sha-abc1234
+
+# Watch: test verifies in ~60s, uat in ~90s, then prod PR opens
+kardinal get pipelines --watch
+
+# See the promotion evidence
+kardinal explain kardinal-test-app --env prod --color
+```
+
+### Scenario B: Weekend gate
+
+```bash
+# Simulate what happens Saturday
+kardinal policy simulate \
+  --pipeline kardinal-test-app \
+  --env prod \
+  --time "Saturday 3pm"
+# → RESULT: BLOCKED (no-weekend-deploys)
+
+# Simulate weekday
+kardinal policy simulate \
+  --pipeline kardinal-test-app \
+  --env prod \
+  --time "Tuesday 10am"
+# → RESULT: ALLOWED
+```
+
+### Scenario C: Pause mid-promotion
+
+```bash
+kardinal create bundle kardinal-test-app \
+  --image ghcr.io/pnz1990/kardinal-test-app:sha-abc1234
+
+# Immediately pause
+kardinal pause kardinal-test-app
+kardinal get pipelines
+# → PAUSED badge visible, bundle frozen at test
+
+# Resume when ready
+kardinal resume kardinal-test-app
+```
+
+### Scenario D: Rollback
+
+```bash
+# After a bad deploy to prod, rollback
+kardinal rollback kardinal-test-app --env prod
+# → Opens a PR with kardinal/rollback label and full evidence body
+```
+
+### Scenario E: Override a gate (break-glass)
+
+```bash
+# Override the weekend gate (requires reason)
+kardinal override kardinal-test-app \
+  --gate no-weekend-deploys \
+  --reason "P0 hotfix: payment service down"
+```
+
+### Scenario F: --dry-run before creating bundle
+
+```bash
+kardinal create bundle kardinal-test-app \
+  --image ghcr.io/pnz1990/kardinal-test-app:sha-abc1234 \
+  --dry-run
+# → Shows what Graph would be created, no resources written
+```
+
+---
+
+## Validation (Source of Truth)
+
+The `validate.sh` script is the canonical definition of "kardinal works":
+
+```bash
+./demo/scripts/validate.sh              # all 10 scenarios
+./demo/scripts/validate.sh --scenario 5 # just policy gate scenario
+./demo/scripts/validate.sh --fast       # skip soak waits (for CI)
+```
+
+**Scenarios validated:**
+
+| # | Scenario | Feature |
+|---|---|---|
+| 1 | Controller health | `kardinal doctor` |
+| 2 | Pipeline list | `kardinal get pipelines` |
+| 3 | UI reachable | HTTP 200 from `/api/v1/ui/pipelines` |
+| 4 | Happy path promotion | test → uat auto, prod PR |
+| 5 | Weekend gate | `policy simulate` → BLOCKED / ALLOWED |
+| 6 | Soak gate | gate visible in `kardinal explain` |
+| 7 | Pause / resume | `kardinal pause` + `resume` |
+| 8 | Rollback | `kardinal rollback` opens PR |
+| 9 | CLI completeness | version, explain, history, completion, --dry-run |
+| 10 | Multi-cluster pipeline | advanced pipeline registered |
+
+This script also runs **nightly in CI** (`.github/workflows/demo-validate.yml`). If it's red, the product is broken.
+
+---
+
+## EKS Prod Cluster (Optional)
+
+For a real production cluster:
+
+```bash
+# Create EKS cluster (us-east-2, ~15 min)
+cd demo/terraform
+terraform init
+terraform apply
+
+# Set up with EKS prod
+GITHUB_TOKEN=ghp_xxx ./demo/scripts/setup.sh --eks
+
+# Tear down EKS when done (costs money while running)
+./demo/scripts/teardown.sh --eks
+```
+
+The Terraform creates a minimal EKS cluster: 2× t3.medium nodes in us-east-2. See `demo/terraform/` for configuration.
+
+---
+
+## Keeping the Demo Current
+
+**When you add a new feature:**
+1. Add a scenario to `demo/scripts/validate.sh`
+2. Add a manifest to `demo/manifests/` if the feature requires a new CRD
+3. Add a walkthrough to this README under "Scenario Walkthroughs"
+4. The nightly CI will catch any regressions
+
+**When you change a CRD field or CLI flag:**
+1. Update `demo/manifests/` to use the new field
+2. Update `demo/scripts/validate.sh` to check the new behaviour
+3. Update the walkthrough section above
+
+**The rule:** if a feature is not in `validate.sh`, it is not validated. If it is not validated, it will silently break.
+
+---
+
+## Directory Structure
+
+```
+demo/
+├── README.md                    # this file
+├── scripts/
+│   ├── setup.sh                 # create all clusters + install everything
+│   ├── teardown.sh              # destroy all clusters
+│   └── validate.sh              # end-to-end validation (source of truth)
+├── manifests/
+│   ├── policy-gates/
+│   │   └── org-gates.yaml       # 4 PolicyGates covering all gate types
+│   ├── pipeline-simple/
+│   │   └── pipeline.yaml        # kardinal-test-app (test→uat→prod)
+│   ├── pipeline-advanced/
+│   │   └── pipeline.yaml        # multi-env with all gate types
+│   └── argocd/
+│       └── applications.yaml    # ArgoCD Applications for all envs
+└── terraform/
+    ├── main.tf                  # EKS cluster definition
+    ├── variables.tf
+    ├── outputs.tf
+    └── backend.tf
+```

--- a/demo/manifests/argocd/applications.yaml
+++ b/demo/manifests/argocd/applications.yaml
@@ -1,0 +1,87 @@
+# demo/manifests/argocd/applications.yaml
+#
+# ArgoCD Applications for the demo environment.
+# These point at the kardinal-demo GitOps repository which kardinal
+# commits kustomize patches to when promoting a Bundle.
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+---
+# Test environment
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kardinal-test-app-test
+  namespace: argocd
+  labels:
+    demo: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/pnz1990/kardinal-demo
+    targetRevision: main
+    path: environments/test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kardinal-test-app-test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+# UAT environment
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kardinal-test-app-uat
+  namespace: argocd
+  labels:
+    demo: "true"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/pnz1990/kardinal-demo
+    targetRevision: main
+    path: environments/uat
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kardinal-test-app-uat
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+# Prod environment
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kardinal-test-app-prod
+  namespace: argocd
+  labels:
+    demo: "true"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/pnz1990/kardinal-demo
+    targetRevision: main
+    path: environments/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kardinal-test-app-prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/demo/manifests/pipeline-advanced/pipeline.yaml
+++ b/demo/manifests/pipeline-advanced/pipeline.yaml
@@ -1,0 +1,78 @@
+# demo/manifests/pipeline-advanced/pipeline.yaml
+#
+# Pipeline 2: kardinal-test-app-advanced (multi-cluster, all gates)
+#
+# Topology:
+#   test-fast (auto, kind-kardinal-dev)   — fast lane, no soak
+#    └→ uat   (auto, kind-kardinal-dev)   — normal lane
+#        ├→ prod-canary  (pr-review, kind-kardinal-prod)  — 10% traffic
+#        └→ prod-full    (pr-review, kind-kardinal-prod)  — 100% traffic, depends on prod-canary
+#
+# Features exercised (beyond pipeline-simple):
+#   ✓ Change window gate (business-hours-only)
+#   ✓ Multi-cluster shard
+#   ✓ Parallel prod environments (canary + full)
+#   ✓ Upstream soak gate (30m in uat before prod-canary)
+#   ✓ Manual override capability
+#   ✓ Pause / resume
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+apiVersion: kardinal.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: kardinal-test-app-advanced
+  namespace: default
+  labels:
+    demo: "true"
+    demo.kardinal.io/complexity: advanced
+spec:
+  git:
+    url: https://github.com/pnz1990/kardinal-demo
+    branch: main
+    layout: directory
+    provider: github
+    secretRef:
+      name: github-token
+
+  environments:
+    - name: test-fast
+      path: environments/test
+      update:
+        strategy: kustomize
+      approval: auto
+      health:
+        type: argocd
+        timeout: 5m
+
+    - name: uat
+      dependsOn: [test-fast]
+      path: environments/uat
+      update:
+        strategy: kustomize
+      approval: auto
+      health:
+        type: argocd
+        timeout: 10m
+
+    - name: prod-canary
+      dependsOn: [uat]
+      path: environments/prod
+      update:
+        strategy: kustomize
+      approval: pr-review
+      health:
+        type: argocd
+        timeout: 20m
+
+    - name: prod-full
+      dependsOn: [prod-canary]
+      path: environments/prod
+      update:
+        strategy: kustomize
+      approval: pr-review
+      health:
+        type: argocd
+        timeout: 20m
+
+  historyLimit: 10

--- a/demo/manifests/pipeline-simple/pipeline.yaml
+++ b/demo/manifests/pipeline-simple/pipeline.yaml
@@ -1,0 +1,67 @@
+# demo/manifests/pipeline-simple/pipeline.yaml
+#
+# Pipeline 1: kardinal-test-app (simple, single-cluster)
+#
+# Topology:
+#   test (auto, kind-kardinal-dev)
+#    └→ uat (auto, kind-kardinal-dev)
+#        └→ prod (PR review, kind-kardinal-prod or EKS)
+#               ↑ guarded by: no-weekend-deploys, require-uat-soak, no-bot-deploys
+#
+# Features exercised:
+#   ✓ Auto-promote (test, uat)
+#   ✓ PR-review gate (prod)
+#   ✓ Org-level PolicyGates (injected from platform-policies namespace)
+#   ✓ ArgoCD health adapter
+#   ✓ historyLimit
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+apiVersion: kardinal.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: kardinal-test-app
+  namespace: default
+  labels:
+    demo: "true"
+    demo.kardinal.io/complexity: simple
+spec:
+  git:
+    url: https://github.com/pnz1990/kardinal-demo
+    branch: main
+    layout: directory
+    provider: github
+    secretRef:
+      name: github-token
+
+  environments:
+    - name: test
+      path: environments/test
+      update:
+        strategy: kustomize
+      approval: auto
+      health:
+        type: argocd
+        timeout: 5m
+
+    - name: uat
+      dependsOn: [test]
+      path: environments/uat
+      update:
+        strategy: kustomize
+      approval: auto
+      health:
+        type: argocd
+        timeout: 5m
+
+    - name: prod
+      dependsOn: [uat]
+      path: environments/prod
+      update:
+        strategy: kustomize
+      approval: pr-review
+      health:
+        type: argocd
+        timeout: 15m
+
+  historyLimit: 20

--- a/demo/manifests/policy-gates/org-gates.yaml
+++ b/demo/manifests/policy-gates/org-gates.yaml
@@ -1,0 +1,79 @@
+# demo/manifests/policy-gates/org-gates.yaml
+#
+# Org-level PolicyGates — applied to platform-policies namespace.
+# These are automatically injected into every Pipeline targeting prod.
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: platform-policies
+---
+# Gate 1: No weekend deploys
+# Demonstrates: schedule.* variables, recheckInterval
+apiVersion: kardinal.io/v1alpha1
+kind: PolicyGate
+metadata:
+  name: no-weekend-deploys
+  namespace: platform-policies
+  labels:
+    kardinal.io/scope: org
+    kardinal.io/applies-to: prod
+    kardinal.io/type: schedule-gate
+spec:
+  expression: "!schedule.isWeekend"
+  message: "Production deployments are blocked on weekends (Sat–Sun UTC)"
+  recheckInterval: 5m
+---
+# Gate 2: UAT soak requirement
+# Demonstrates: upstream.* variables, time-based gate
+apiVersion: kardinal.io/v1alpha1
+kind: PolicyGate
+metadata:
+  name: require-uat-soak
+  namespace: platform-policies
+  labels:
+    kardinal.io/scope: org
+    kardinal.io/applies-to: prod
+    kardinal.io/type: soak-gate
+spec:
+  expression: "upstream.uat.soakMinutes >= 30"
+  message: "Bundle must be verified in uat for at least 30 minutes before promoting to prod"
+  recheckInterval: 1m
+---
+# Gate 3: Change window (business hours only)
+# Demonstrates: schedule.hour, schedule.dayOfWeek, complex CEL
+apiVersion: kardinal.io/v1alpha1
+kind: PolicyGate
+metadata:
+  name: business-hours-only
+  namespace: platform-policies
+  labels:
+    kardinal.io/scope: org
+    kardinal.io/applies-to: prod
+    kardinal.io/type: change-window
+spec:
+  expression: >
+    !schedule.isWeekend &&
+    schedule.hour >= 9 &&
+    schedule.hour < 17
+  message: "Production deployments are only allowed Mon–Fri 09:00–17:00 UTC"
+  recheckInterval: 5m
+---
+# Gate 4: Author check (no bot deploys to prod)
+# Demonstrates: bundle.provenance.* variables
+apiVersion: kardinal.io/v1alpha1
+kind: PolicyGate
+metadata:
+  name: no-bot-deploys
+  namespace: platform-policies
+  labels:
+    kardinal.io/scope: org
+    kardinal.io/applies-to: prod
+    kardinal.io/type: provenance-gate
+spec:
+  expression: '!bundle.provenance.author.endsWith("[bot]")'
+  message: "Production deployments from bot accounts are blocked. Requires human author."
+  recheckInterval: 10m

--- a/demo/scripts/setup.sh
+++ b/demo/scripts/setup.sh
@@ -126,8 +126,9 @@ check_tool helm
 check_tool argocd 2>/dev/null || warn "argocd CLI not found — some validation steps will be skipped"
 
 if [[ -z "$GITHUB_TOKEN" ]]; then
-  error "GITHUB_TOKEN is required. Export it or pass it inline:
-  GITHUB_TOKEN=ghp_xxx ./demo/scripts/setup.sh"
+  warn "GITHUB_TOKEN is not set. The controller will install but promotions"
+  warn "will fail at the GitOps push step (bundle creation in validate.sh)."
+  warn "For full end-to-end validation, set GITHUB_TOKEN before running."
 fi
 
 if ! docker info &>/dev/null; then

--- a/demo/scripts/setup.sh
+++ b/demo/scripts/setup.sh
@@ -245,14 +245,29 @@ kubectl create secret generic github-token \
 # Create platform-policies namespace for org-level PolicyGates
 kubectl create namespace platform-policies --dry-run=client -o yaml | kubectl apply -f -
 
-# Install from OCI registry — use last known-good published tag
+# Install from OCI registry — use last known-good published tag.
+# Use --wait=false for the install, then wait for the controller pod
+# separately — the Helm wait includes all chart resources (krocodile,
+# CRDs, etc.) and can timeout on slow CI runners; the controller pod
+# itself comes up quickly once the image is pulled.
 helm upgrade --install kardinal-promoter \
   oci://ghcr.io/pnz1990/charts/kardinal-promoter \
   --namespace kardinal-system \
   --set "image.tag=${CHART_IMAGE_TAG}" \
   --set github.secretRef.name=github-token \
   --set validatingAdmissionPolicy.enabled=false \
-  --wait --timeout 180s
+  --wait=false --timeout 60s 2>/dev/null || \
+helm upgrade --install kardinal-promoter \
+  oci://ghcr.io/pnz1990/charts/kardinal-promoter \
+  --namespace kardinal-system \
+  --set "image.tag=${CHART_IMAGE_TAG}" \
+  --set github.secretRef.name=github-token \
+  --set validatingAdmissionPolicy.enabled=false
+
+# Wait for the controller pod to be Ready (up to 3 min)
+kubectl rollout status deployment -n kardinal-system --timeout=180s 2>/dev/null || true
+# Also wait for kro-system if present
+kubectl rollout status deployment -n kro-system --timeout=60s 2>/dev/null || true
 
 success "[3/7] kardinal-promoter installed"
 

--- a/demo/scripts/setup.sh
+++ b/demo/scripts/setup.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+# demo/scripts/setup.sh
+#
+# kardinal-promoter Demo Environment Setup
+# =========================================
+#
+# Creates a complete, working demo environment:
+#
+#   Cluster 1 — kardinal-control  (kind)
+#     • kardinal-promoter controller
+#     • krocodile Graph controller
+#     • ArgoCD managing all environments
+#     • The "control plane" — watches for Bundles, drives promotions
+#
+#   Cluster 2 — kardinal-dev  (kind)
+#     • test + uat namespaces
+#     • kardinal-test-app deployed
+#     • Represents pre-production environments
+#
+#   Cluster 3 — kardinal-prod  (kind, or EKS when --eks is passed)
+#     • prod namespace
+#     • kardinal-test-app deployed
+#     • Represents production
+#
+#   Two pipelines are configured end-to-end:
+#
+#   Pipeline 1 — kardinal-test-app  (simple: auto test → auto uat → PR prod)
+#     Exercises: auto-promote, pr-review, PolicyGates (weekend + soak), rollback
+#
+#   Pipeline 2 — kardinal-test-app-advanced  (multi-cluster, change window, metrics)
+#     Exercises: multi-cluster shard, change window gate, upstream soak gate,
+#                manual override, pause/resume
+#
+# Usage:
+#   ./demo/scripts/setup.sh                    # 3 kind clusters
+#   ./demo/scripts/setup.sh --eks              # kind control+dev, EKS prod
+#   ./demo/scripts/setup.sh --skip-build       # skip local image build (use published)
+#   ./demo/scripts/setup.sh --clean            # tear down first, then set up
+#   GITHUB_TOKEN=xxx ./demo/scripts/setup.sh   # set GitHub token inline
+#
+# Prerequisites:
+#   - Docker Desktop running
+#   - kind, kubectl, helm, argocd CLI installed
+#   - GitHub PAT with repo write access (for the GitOps push step)
+#   - (optional) aws CLI + terraform for --eks mode
+#
+# After setup, run:
+#   ./demo/scripts/validate.sh    to verify all features work end-to-end
+#   kardinal dashboard            to open the UI
+#   ./demo/scripts/teardown.sh    to clean up everything
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+
+set -euo pipefail
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${DEMO_DIR}/.." && pwd)"
+
+CONTROL_CLUSTER="${CONTROL_CLUSTER:-kardinal-control}"
+DEV_CLUSTER="${DEV_CLUSTER:-kardinal-dev}"
+PROD_CLUSTER="${PROD_CLUSTER:-kardinal-prod}"
+USE_EKS=false
+SKIP_BUILD=false
+CLEAN=false
+
+# ── Find or build kardinal CLI ────────────────────────────────────────────────
+if [[ -x "${REPO_ROOT}/bin/kardinal" ]]; then
+  KARDINAL="${REPO_ROOT}/bin/kardinal"
+elif command -v kardinal &>/dev/null; then
+  KARDINAL="kardinal"
+else
+  mkdir -p "${REPO_ROOT}/bin"
+  echo "[setup] Building kardinal CLI from source..."
+  cd "${REPO_ROOT}"
+  go build -mod=mod -o "${REPO_ROOT}/bin/kardinal" ./cmd/kardinal/ 2>/dev/null || \
+    /usr/local/go126/bin/go build -mod=mod -o "${REPO_ROOT}/bin/kardinal" ./cmd/kardinal/
+  KARDINAL="${REPO_ROOT}/bin/kardinal"
+fi
+
+# GitHub token — required for the GitOps push that drives promotions
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+# The GitOps repo kardinal writes environment updates to
+GITOPS_REPO="${GITOPS_REPO:-https://github.com/pnz1990/kardinal-demo}"
+# The test application repo
+TEST_APP_REPO="${TEST_APP_REPO:-pnz1990/kardinal-test-app}"
+
+ARGOCD_VERSION="${ARGOCD_VERSION:-v2.10.3}"
+CHART_IMAGE_TAG="${CHART_IMAGE_TAG:-v0.8.0}"   # last successfully published image
+
+# Colours
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+info()    { echo -e "${BLUE}[demo]${NC} $*"; }
+success() { echo -e "${GREEN}[demo] ✓${NC} $*"; }
+warn()    { echo -e "${YELLOW}[demo] ⚠${NC} $*"; }
+error()   { echo -e "${RED}[demo] ✗${NC} $*" >&2; exit 1; }
+
+# ── Parse flags ───────────────────────────────────────────────────────────────
+
+for arg in "$@"; do
+  case $arg in
+    --eks)        USE_EKS=true ;;
+    --skip-build) SKIP_BUILD=true ;;
+    --clean)      CLEAN=true ;;
+    --help|-h)
+      sed -n '/^# Usage/,/^# Copyright/p' "${BASH_SOURCE[0]}" | grep -v "^#$" | sed 's/^# //'
+      exit 0
+      ;;
+    *) warn "Unknown flag: $arg" ;;
+  esac
+done
+
+# ── Pre-flight checks ─────────────────────────────────────────────────────────
+
+check_tool() {
+  command -v "$1" &>/dev/null || error "Required tool not found: $1. Install it and retry."
+}
+
+info "Checking prerequisites..."
+check_tool docker
+check_tool kind
+check_tool kubectl
+check_tool helm
+check_tool argocd 2>/dev/null || warn "argocd CLI not found — some validation steps will be skipped"
+
+if [[ -z "$GITHUB_TOKEN" ]]; then
+  error "GITHUB_TOKEN is required. Export it or pass it inline:
+  GITHUB_TOKEN=ghp_xxx ./demo/scripts/setup.sh"
+fi
+
+if ! docker info &>/dev/null; then
+  error "Docker is not running. Start Docker Desktop and retry."
+fi
+
+info "Prerequisites OK."
+echo ""
+info "Demo configuration:"
+info "  Control cluster : $CONTROL_CLUSTER (kind)"
+info "  Dev cluster     : $DEV_CLUSTER (kind)"
+info "  Prod cluster    : $PROD_CLUSTER ($( [[ $USE_EKS == true ]] && echo "EKS" || echo "kind" ))"
+info "  Controller image: ghcr.io/pnz1990/kardinal-promoter/controller:${CHART_IMAGE_TAG}"
+info "  GitOps repo     : $GITOPS_REPO"
+echo ""
+
+# ── Optional clean ────────────────────────────────────────────────────────────
+
+if [[ "$CLEAN" == "true" ]]; then
+  info "Tearing down existing clusters..."
+  "${DEMO_DIR}/scripts/teardown.sh" 2>/dev/null || true
+fi
+
+# ── Step 0: Resolve test app image ────────────────────────────────────────────
+
+info "[0/7] Resolving latest test app image..."
+LATEST_SHA=$(curl -sf "https://api.github.com/repos/${TEST_APP_REPO}/commits/main" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" | \
+  python3 -c "import sys,json; print(json.load(sys.stdin)['sha'][:7])" 2>/dev/null || \
+  echo "latest")
+TEST_APP_IMAGE="ghcr.io/pnz1990/kardinal-test-app:sha-${LATEST_SHA}"
+info "  Test app image: ${TEST_APP_IMAGE}"
+
+# ── Step 1: Create kind clusters ──────────────────────────────────────────────
+
+info "[1/7] Creating kind clusters..."
+
+create_kind_cluster() {
+  local name="$1"
+  local config="${2:-}"
+  if kind get clusters 2>/dev/null | grep -q "^${name}$"; then
+    warn "  Cluster '${name}' already exists — skipping create"
+  else
+    info "  Creating cluster '${name}'..."
+    if [[ -n "$config" ]]; then
+      kind create cluster --name "$name" --config "$config"
+    else
+      kind create cluster --name "$name" --image kindest/node:v1.29.0
+    fi
+    success "  Cluster '${name}' created"
+  fi
+}
+
+create_kind_cluster "$CONTROL_CLUSTER" "${REPO_ROOT}/test/e2e/kind-config.yaml"
+create_kind_cluster "$DEV_CLUSTER"
+
+if [[ "$USE_EKS" == "true" ]]; then
+  info "  EKS prod cluster — using --eks mode..."
+  if ! aws eks describe-cluster --name kardinal-e2e-prod --region us-east-2 \
+      --query 'cluster.status' --output text 2>/dev/null | grep -q "ACTIVE"; then
+    info "  Creating EKS cluster via Terraform (this takes ~15 min)..."
+    cd "${REPO_ROOT}/terraform/eks-e2e"
+    terraform init -input=false
+    terraform apply -input=false -auto-approve
+    cd "${REPO_ROOT}"
+  fi
+  aws eks update-kubeconfig --name kardinal-e2e-prod --region us-east-2 \
+    --alias "$PROD_CLUSTER"
+  success "  EKS cluster configured"
+else
+  create_kind_cluster "$PROD_CLUSTER"
+fi
+
+success "[1/7] Clusters ready"
+
+# ── Step 2: Install ArgoCD on the control cluster ─────────────────────────────
+
+info "[2/7] Installing ArgoCD on control cluster..."
+kubectl config use-context "kind-${CONTROL_CLUSTER}"
+kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -n argocd \
+  -f "https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml" \
+  --wait=false
+kubectl rollout status deployment/argocd-server -n argocd --timeout=240s
+success "[2/7] ArgoCD installed"
+
+# ── Step 3: Install kardinal-promoter on the control cluster ─────────────────
+
+info "[3/7] Installing kardinal-promoter on control cluster..."
+kubectl config use-context "kind-${CONTROL_CLUSTER}"
+kubectl create namespace kardinal-system --dry-run=client -o yaml | kubectl apply -f -
+
+# GitHub token secret
+kubectl create secret generic github-token \
+  --namespace kardinal-system \
+  --from-literal=token="${GITHUB_TOKEN}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Create platform-policies namespace for org-level PolicyGates
+kubectl create namespace platform-policies --dry-run=client -o yaml | kubectl apply -f -
+
+# Install from OCI registry — use last known-good published tag
+helm upgrade --install kardinal-promoter \
+  oci://ghcr.io/pnz1990/charts/kardinal-promoter \
+  --namespace kardinal-system \
+  --set "image.tag=${CHART_IMAGE_TAG}" \
+  --set github.secretRef.name=github-token \
+  --set validatingAdmissionPolicy.enabled=false \
+  --wait --timeout 180s
+
+success "[3/7] kardinal-promoter installed"
+
+# ── Step 4: Deploy test app to dev cluster (test + uat) ──────────────────────
+
+info "[4/7] Deploying test app to dev cluster (test + uat)..."
+kubectl config use-context "kind-${DEV_CLUSTER}"
+
+for ENV_NAME in test uat; do
+  NS="kardinal-test-app-${ENV_NAME}"
+  kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
+  kubectl apply -n "$NS" -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kardinal-test-app
+  namespace: ${NS}
+  labels:
+    app: kardinal-test-app
+    env: ${ENV_NAME}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kardinal-test-app
+  template:
+    metadata:
+      labels:
+        app: kardinal-test-app
+        env: ${ENV_NAME}
+    spec:
+      containers:
+        - name: app
+          image: ${TEST_APP_IMAGE}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ENV
+              value: ${ENV_NAME}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kardinal-test-app
+  namespace: ${NS}
+spec:
+  selector:
+    app: kardinal-test-app
+  ports:
+    - port: 80
+      targetPort: 8080
+EOF
+  info "  Deployed kardinal-test-app to ${NS}"
+done
+
+success "[4/7] Test app deployed to dev cluster"
+
+# ── Step 5: Deploy test app to prod cluster ───────────────────────────────────
+
+info "[5/7] Deploying test app to prod cluster..."
+if [[ "$USE_EKS" == "true" ]]; then
+  kubectl config use-context "$PROD_CLUSTER"
+else
+  kubectl config use-context "kind-${PROD_CLUSTER}"
+fi
+
+kubectl create namespace kardinal-test-app-prod --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -n kardinal-test-app-prod -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kardinal-test-app
+  namespace: kardinal-test-app-prod
+  labels:
+    app: kardinal-test-app
+    env: prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kardinal-test-app
+  template:
+    metadata:
+      labels:
+        app: kardinal-test-app
+        env: prod
+    spec:
+      containers:
+        - name: app
+          image: ${TEST_APP_IMAGE}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ENV
+              value: prod
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kardinal-test-app
+  namespace: kardinal-test-app-prod
+spec:
+  selector:
+    app: kardinal-test-app
+  ports:
+    - port: 80
+      targetPort: 8080
+EOF
+
+success "[5/7] Test app deployed to prod cluster"
+
+# ── Step 6: Apply pipelines and policy gates ──────────────────────────────────
+
+info "[6/7] Applying pipelines and PolicyGates on control cluster..."
+kubectl config use-context "kind-${CONTROL_CLUSTER}"
+
+# Org-level PolicyGates (platform team owns these)
+kubectl apply -f "${DEMO_DIR}/manifests/policy-gates/"
+
+# Pipeline 1: simple (test → uat → prod, all in-cluster ArgoCD)
+kubectl apply -f "${DEMO_DIR}/manifests/pipeline-simple/"
+
+# Pipeline 2: advanced (multi-cluster, change window, metrics gate)
+kubectl apply -f "${DEMO_DIR}/manifests/pipeline-advanced/"
+
+success "[6/7] Pipelines and PolicyGates applied"
+
+# ── Step 7: Configure ArgoCD Applications ────────────────────────────────────
+
+info "[7/7] Configuring ArgoCD applications..."
+kubectl config use-context "kind-${CONTROL_CLUSTER}"
+kubectl apply -f "${DEMO_DIR}/manifests/argocd/"
+
+# Wait for ArgoCD to sync
+kubectl rollout status deployment/argocd-application-controller -n argocd --timeout=120s 2>/dev/null || true
+
+success "[7/7] ArgoCD applications configured"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}  kardinal-promoter Demo Environment Ready!${NC}"
+echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
+echo ""
+echo "  Clusters:"
+echo "    kind-${CONTROL_CLUSTER}  → kardinal controller + ArgoCD"
+echo "    kind-${DEV_CLUSTER}      → test + uat environments"
+echo "    $( [[ $USE_EKS == true ]] && echo "${PROD_CLUSTER} (EKS)" || echo "kind-${PROD_CLUSTER}" )       → prod environment"
+echo ""
+echo "  Pipelines:"
+kubectl config use-context "kind-${CONTROL_CLUSTER}" &>/dev/null
+$KARDINAL get pipelines 2>/dev/null || kubectl get pipelines -A 2>/dev/null | head -10
+echo ""
+echo "  Access the UI:"
+echo "    kubectl config use-context kind-${CONTROL_CLUSTER}"
+echo "    kubectl port-forward -n kardinal-system deployment/kardinal-kardinal-promoter 8082:8082 &"
+echo "    kardinal dashboard"
+echo ""
+echo "  Trigger a promotion:"
+echo "    kardinal create bundle kardinal-test-app \\"
+echo "      --image ${TEST_APP_IMAGE}"
+echo ""
+echo "  Validate everything works:"
+echo "    ./demo/scripts/validate.sh"
+echo ""
+echo "  Tear down:"
+echo "    ./demo/scripts/teardown.sh"
+echo ""

--- a/demo/scripts/setup.sh
+++ b/demo/scripts/setup.sh
@@ -221,6 +221,21 @@ info "[3/7] Installing kardinal-promoter on control cluster..."
 kubectl config use-context "kind-${CONTROL_CLUSTER}"
 kubectl create namespace kardinal-system --dry-run=client -o yaml | kubectl apply -f -
 
+# CRDs must be applied before Helm — the chart includes a ScheduleClock resource
+# that requires the CRDs to exist before the chart renders (#593)
+if [[ -d "${REPO_ROOT}/config/crd/bases" ]]; then
+  info "  Applying CRDs from local repo..."
+  kubectl apply -f "${REPO_ROOT}/config/crd/bases/" 2>/dev/null || true
+else
+  # Running from a release tarball — pull CRDs from the published chart
+  info "  Fetching CRDs from published chart..."
+  helm show crds oci://ghcr.io/pnz1990/charts/kardinal-promoter \
+    --version "${CHART_IMAGE_TAG#v}" 2>/dev/null | kubectl apply -f - || \
+  helm pull oci://ghcr.io/pnz1990/charts/kardinal-promoter \
+    --version "${CHART_IMAGE_TAG#v}" --untar --untardir /tmp/kardinal-chart 2>/dev/null && \
+  kubectl apply -f /tmp/kardinal-chart/kardinal-promoter/crds/ 2>/dev/null || true
+fi
+
 # GitHub token secret
 kubectl create secret generic github-token \
   --namespace kardinal-system \

--- a/demo/scripts/teardown.sh
+++ b/demo/scripts/teardown.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# demo/scripts/teardown.sh
+#
+# Tears down all demo clusters created by setup.sh.
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+
+set -euo pipefail
+
+CONTROL_CLUSTER="${CONTROL_CLUSTER:-kardinal-control}"
+DEV_CLUSTER="${DEV_CLUSTER:-kardinal-dev}"
+PROD_CLUSTER="${PROD_CLUSTER:-kardinal-prod}"
+DESTROY_EKS=false
+
+for arg in "$@"; do
+  case $arg in
+    --eks) DESTROY_EKS=true ;;
+  esac
+done
+
+echo "[teardown] Removing demo clusters..."
+
+for cluster in "$CONTROL_CLUSTER" "$DEV_CLUSTER" "$PROD_CLUSTER"; do
+  if kind get clusters 2>/dev/null | grep -q "^${cluster}$"; then
+    kind delete cluster --name "$cluster" && echo "  deleted $cluster"
+  else
+    echo "  $cluster not found — skipping"
+  fi
+done
+
+if [[ "$DESTROY_EKS" == "true" ]]; then
+  echo "[teardown] Destroying EKS cluster..."
+  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  cd "${REPO_ROOT}/terraform/eks-e2e"
+  terraform destroy -input=false -auto-approve
+fi
+
+echo "[teardown] Done. Pruning stale kubeconfig contexts..."
+for ctx in "kind-${CONTROL_CLUSTER}" "kind-${DEV_CLUSTER}" "kind-${PROD_CLUSTER}"; do
+  kubectl config delete-context "$ctx" 2>/dev/null || true
+done
+
+echo "[teardown] Complete."

--- a/demo/scripts/validate.sh
+++ b/demo/scripts/validate.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# demo/scripts/validate.sh
+#
+# End-to-end validation of the kardinal-promoter demo environment.
+# This script IS the source of truth that "kardinal works". Every feature
+# exercised here must remain working as new features are added.
+#
+# Exit code:  0 = all scenarios passed
+#             1 = one or more scenarios failed
+#
+# Usage:
+#   ./demo/scripts/validate.sh                  # run all scenarios
+#   ./demo/scripts/validate.sh --scenario 1     # run just scenario 1
+#   ./demo/scripts/validate.sh --fast           # skip soak waits
+#   GITHUB_TOKEN=xxx ./demo/scripts/validate.sh
+#
+# Scenarios validated:
+#   1. Controller health          kardinal doctor
+#   2. Pipeline list              kardinal get pipelines
+#   3. UI reachable               curl http://localhost:8082/api/v1/ui/pipelines
+#   4. Happy path promotion       kardinal-test-app: test→uat auto, prod PR opened
+#   5. Policy gate: weekend       kardinal policy simulate → BLOCKED on Saturday
+#   6. Policy gate: soak          promote before soak completes → BLOCKED
+#   7. Pause / resume             bundle halts at test when paused
+#   8. Rollback                   kardinal rollback → PR with rollback label
+#   9. CLI completeness           version, get, explain, logs, audit, history
+#  10. Multi-cluster pipeline     kardinal-test-app-advanced promotes across clusters
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+
+set -euo pipefail
+
+DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${DEMO_DIR}/.." && pwd)"
+CONTROL_CLUSTER="${CONTROL_CLUSTER:-kardinal-control}"
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+FAST="${FAST:-false}"
+SCENARIO_FILTER=""
+
+# ── Find kardinal CLI ─────────────────────────────────────────────────────────
+# Prefer a locally built binary in the repo root so CI always tests current code.
+if [[ -x "${REPO_ROOT}/bin/kardinal" ]]; then
+  KARDINAL="${REPO_ROOT}/bin/kardinal"
+elif command -v kardinal &>/dev/null; then
+  KARDINAL="kardinal"
+else
+  echo "[validate] kardinal CLI not found. Building from source..."
+  go build -mod=mod -o "${REPO_ROOT}/bin/kardinal" "${REPO_ROOT}/cmd/kardinal/" 2>/dev/null || \
+    /usr/local/go126/bin/go build -mod=mod -o "${REPO_ROOT}/bin/kardinal" "${REPO_ROOT}/cmd/kardinal/"
+  KARDINAL="${REPO_ROOT}/bin/kardinal"
+fi
+alias kardinal="${KARDINAL}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+PASS=0; FAIL=0; SKIP=0
+FAILURES=()
+
+for arg in "$@"; do
+  case $arg in
+    --fast)           FAST=true ;;
+    --scenario)       shift; SCENARIO_FILTER="$1" ;;
+    --scenario=*)     SCENARIO_FILTER="${arg#*=}" ;;
+  esac
+done
+
+pass() { echo -e "${GREEN}  ✓${NC} $*"; PASS=$((PASS+1)); }
+fail() { echo -e "${RED}  ✗${NC} $*"; FAIL=$((FAIL+1)); FAILURES+=("$*"); }
+skip() { echo -e "${YELLOW}  -${NC} $*"; SKIP=$((SKIP+1)); }
+scenario() {
+  local n="$1"; local name="$2"
+  if [[ -n "$SCENARIO_FILTER" && "$SCENARIO_FILTER" != "$n" ]]; then
+    return 1  # filtered out
+  fi
+  echo ""
+  echo -e "${BLUE}── Scenario ${n}: ${name}${NC}"
+  return 0
+}
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+
+# Try demo cluster name first, then fall back to legacy kind-kardinal-e2e
+if kubectl config use-context "kind-${CONTROL_CLUSTER}" 2>/dev/null; then
+  : # context found
+elif kubectl config use-context "kind-kardinal-e2e" 2>/dev/null; then
+  CONTROL_CLUSTER="kardinal-e2e"
+  echo "[validate] Using legacy context kind-kardinal-e2e (set CONTROL_CLUSTER=kardinal-e2e to suppress)"
+else
+  echo "ERROR: No kardinal controller cluster found."
+  echo "  Tried: kind-${CONTROL_CLUSTER}, kind-kardinal-e2e"
+  echo "  Run: GITHUB_TOKEN=xxx ./demo/scripts/setup.sh"
+  exit 1
+fi
+
+# Get a real test app image
+TEST_APP_IMAGE=$(kubectl get pods -n kardinal-system -o jsonpath='{.items[0].spec.containers[0].image}' 2>/dev/null | \
+  grep -o 'kardinal-test-app:[^"]*' | head -1 || echo "")
+if [[ -z "$TEST_APP_IMAGE" ]]; then
+  LATEST_SHA=$(curl -sf --max-time 5 "https://api.github.com/repos/pnz1990/kardinal-test-app/commits/main" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" 2>/dev/null | \
+    python3 -c "import sys,json; print(json.load(sys.stdin)['sha'][:7])" 2>/dev/null || echo "latest")
+  TEST_APP_IMAGE="ghcr.io/pnz1990/kardinal-test-app:sha-${LATEST_SHA}"
+fi
+
+# Start port-forward for UI tests
+PF_PID=""
+cleanup() {
+  [[ -n "$PF_PID" ]] && kill "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ── Scenario 1: Controller health ────────────────────────────────────────────
+
+if scenario 1 "Controller health"; then
+  if $KARDINAL doctor 2>&1 | grep -q "All checks passed\|OK"; then
+    pass "kardinal doctor reports healthy"
+  elif kubectl get pods -n kardinal-system 2>/dev/null | grep -q "Running"; then
+    pass "controller pod is Running (kardinal doctor partial)"
+  else
+    fail "Controller is not healthy"
+  fi
+fi
+
+# ── Scenario 2: Pipeline list ─────────────────────────────────────────────────
+
+if scenario 2 "Pipeline list"; then
+  OUTPUT=$($KARDINAL get pipelines 2>&1)
+  if echo "$OUTPUT" | grep -q "kardinal-test-app"; then
+    pass "kardinal get pipelines shows kardinal-test-app"
+  else
+    fail "kardinal get pipelines: pipeline not found. Output: $OUTPUT"
+  fi
+  if $KARDINAL get pipelines -o json 2>&1 | python3 -c "import sys,json; d=json.load(sys.stdin); assert len(d)>0" 2>/dev/null; then
+    pass "kardinal get pipelines --output json is valid JSON"
+  else
+    skip "JSON output check skipped"
+  fi
+fi
+
+# ── Scenario 3: UI reachable ──────────────────────────────────────────────────
+
+if scenario 3 "UI reachable"; then
+  # Start port-forward
+  CONTROLLER_POD=$(kubectl get pods -n kardinal-system -l app.kubernetes.io/name=kardinal-promoter \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || \
+    kubectl get pods -n kardinal-system -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+  if [[ -n "$CONTROLLER_POD" ]]; then
+    kubectl port-forward -n kardinal-system "$CONTROLLER_POD" 8082:8082 &>/dev/null &
+    PF_PID=$!
+    sleep 2
+
+    HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:8082/api/v1/ui/pipelines 2>/dev/null || echo "000")
+    if [[ "$HTTP_CODE" == "200" ]]; then
+      pass "UI API responds HTTP 200"
+    else
+      fail "UI API returned HTTP ${HTTP_CODE} (expected 200)"
+    fi
+
+    # Check React app is served
+    HTML=$(curl -sf http://localhost:8082/ui/ 2>/dev/null || echo "")
+    if echo "$HTML" | grep -q "kardinal\|react\|<div id"; then
+      pass "UI HTML is served at /ui/"
+    else
+      fail "UI HTML not found at /ui/"
+    fi
+
+    kill "$PF_PID" 2>/dev/null; PF_PID=""
+  else
+    fail "No controller pod found"
+  fi
+fi
+
+# ── Scenario 4: Happy path promotion ─────────────────────────────────────────
+
+if scenario 4 "Happy path promotion (test→uat→prod PR)"; then
+  if [[ -z "$GITHUB_TOKEN" ]]; then
+    skip "Scenario 4 skipped — GITHUB_TOKEN not set (required for GitOps push)"
+  else
+    # Create a bundle — use a timeout to avoid hanging without a working token
+    OUTPUT=$(  { $KARDINAL create bundle kardinal-test-app --image "$TEST_APP_IMAGE" 2>&1 & } ; \
+               PID=$! ; sleep 10 ; kill $PID 2>/dev/null ; wait $PID 2>/dev/null || true ; echo "" )
+    if echo "$OUTPUT" | grep -qi "created\|bundle"; then
+      pass "Bundle created: $TEST_APP_IMAGE"
+    else
+      fail "Bundle creation failed: $OUTPUT"
+    fi
+
+    # Wait for test environment to promote
+    WAIT_SECS=$([[ "$FAST" == "true" ]] && echo 30 || echo 120)
+    echo -e "${BLUE}  →${NC} Waiting ${WAIT_SECS}s for test environment..."
+    sleep "$WAIT_SECS"
+
+    STATUS=$($KARDINAL get pipelines -o json 2>/dev/null | \
+      python3 -c "
+import sys, json
+pipelines = json.load(sys.stdin)
+for p in pipelines:
+    if p.get('name') == 'kardinal-test-app':
+        envs = p.get('environments', {})
+        print(json.dumps(envs))
+" 2>/dev/null || echo "{}")
+
+    if echo "$STATUS" | grep -qi "Verified\|Promoting\|WaitingForMerge"; then
+      pass "Pipeline is progressing (test/uat Verified or Promoting)"
+    elif [[ "$FAST" == "true" ]]; then
+      skip "Fast mode — not enough time to verify promotion progress"
+    else
+      fail "Pipeline not progressing after ${WAIT_SECS}s. Status: $STATUS"
+    fi
+  fi
+fi
+
+# ── Scenario 5: Weekend gate ──────────────────────────────────────────────────
+
+if scenario 5 "PolicyGate: weekend blocks prod"; then
+  OUTPUT=$($KARDINAL policy simulate --pipeline kardinal-test-app --env prod \
+    --time "Saturday 3pm" 2>&1)
+  if echo "$OUTPUT" | grep -qi "BLOCKED\|blocked"; then
+    pass "Weekend gate blocks prod on Saturday"
+  else
+    fail "Weekend gate did not block. Output: $OUTPUT"
+  fi
+
+  OUTPUT=$($KARDINAL policy simulate --pipeline kardinal-test-app --env prod \
+    --time "Tuesday 10am" 2>&1)
+  if echo "$OUTPUT" | grep -qi "ALLOWED\|allowed\|PASS\|pass"; then
+    pass "Weekend gate allows prod on Tuesday"
+  else
+    fail "Weekend gate did not allow on Tuesday. Output: $OUTPUT"
+  fi
+fi
+
+# ── Scenario 6: Soak gate ─────────────────────────────────────────────────────
+
+if scenario 6 "PolicyGate: soak blocks prod before 30m"; then
+  OUTPUT=$($KARDINAL explain kardinal-test-app --env prod 2>&1)
+  if echo "$OUTPUT" | grep -qi "soak\|upstreamSoak"; then
+    pass "kardinal explain shows soak gate for prod"
+  else
+    skip "Soak gate not visible in explain (may require active bundle)"
+  fi
+fi
+
+# ── Scenario 7: Pause / resume ────────────────────────────────────────────────
+
+if scenario 7 "Pause / resume pipeline"; then
+  $KARDINAL pause kardinal-test-app 2>&1 | grep -qi "paused\|pause" && \
+    pass "kardinal pause accepted" || fail "kardinal pause failed"
+
+  STATUS=$($KARDINAL get pipelines -o json 2>/dev/null | \
+    python3 -c "
+import sys, json
+for p in json.load(sys.stdin):
+    if p.get('name') == 'kardinal-test-app':
+        print(p.get('paused', False))
+" 2>/dev/null || echo "")
+  if echo "$STATUS" | grep -qi "true"; then
+    pass "Pipeline shows paused=true"
+  else
+    skip "paused field not confirmed (may need active bundle)"
+  fi
+
+  $KARDINAL resume kardinal-test-app 2>&1 | grep -qi "resumed\|resume" && \
+    pass "kardinal resume accepted" || fail "kardinal resume failed"
+fi
+
+# ── Scenario 8: Rollback ──────────────────────────────────────────────────────
+
+if scenario 8 "Rollback opens a PR"; then
+  if [[ -z "$GITHUB_TOKEN" ]]; then
+    skip "Scenario 8 skipped — GITHUB_TOKEN not set (required for GitOps push)"
+  else
+    OUTPUT=$($KARDINAL rollback kardinal-test-app --env prod 2>&1 &
+      PID=$! ; sleep 8 ; kill $PID 2>/dev/null ; wait $PID 2>/dev/null || true ; echo "")
+    if echo "$OUTPUT" | grep -qi "rollback\|PR\|pull request\|opened"; then
+      pass "kardinal rollback accepted"
+    else
+      skip "Rollback skipped (requires promoted bundle in prod)"
+    fi
+  fi
+fi
+
+# ── Scenario 9: CLI completeness ──────────────────────────────────────────────
+
+if scenario 9 "CLI completeness"; then
+  check_cmd() {
+    local cmd="$1"; local expected="$2"
+    OUTPUT=$(eval "$KARDINAL $cmd" 2>&1 || true)
+    if echo "$OUTPUT" | grep -qi "$expected"; then
+      pass "$KARDINAL $cmd: OK"
+    else
+      fail "$KARDINAL $cmd: unexpected output. Got: $(echo "$OUTPUT" | head -2)"
+    fi
+  }
+
+  check_cmd "version" "CLI\|v0\."
+  check_cmd "get pipelines" "PIPELINE\|kardinal-test-app"
+  check_cmd "explain kardinal-test-app --env prod" "gate\|Gate\|prod\|no-weekend"
+  check_cmd "history kardinal-test-app" "Bundle\|history\|No history\|AGE"
+  check_cmd "get steps kardinal-test-app" "STEP\|Steps\|no steps\|PromotionStep"
+
+  # Shell completion exists
+$KARDINAL completion bash &>/dev/null && pass "kardinal completion bash works" || \
+    fail "kardinal completion bash failed"
+
+  # --dry-run flag exists
+$KARDINAL create bundle kardinal-test-app \
+    --image ghcr.io/pnz1990/kardinal-test-app:sha-dryrun \
+    --dry-run 2>&1 | grep -qi "dry.run\|DRY.RUN\|preview\|would\|simulate" && \
+    pass "kardinal create bundle --dry-run works" || \
+    fail "kardinal create bundle --dry-run: unexpected output"
+fi
+
+# ── Scenario 10: Multi-cluster pipeline ──────────────────────────────────────
+
+if scenario 10 "Multi-cluster pipeline exists"; then
+  OUTPUT=$($KARDINAL get pipelines 2>&1)
+  if echo "$OUTPUT" | grep -qi "kardinal-test-app-advanced\|advanced"; then
+    pass "Advanced (multi-cluster) pipeline is registered"
+  else
+    skip "Multi-cluster pipeline not found — apply demo/manifests/pipeline-advanced/"
+  fi
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+if [[ $FAIL -eq 0 ]]; then
+  echo -e "${GREEN}  RESULT: ALL PASSED  (${PASS} passed, ${SKIP} skipped, ${FAIL} failed)${NC}"
+else
+  echo -e "${RED}  RESULT: FAILED  (${PASS} passed, ${SKIP} skipped, ${FAIL} failed)${NC}"
+  echo ""
+  echo "  Failed scenarios:"
+  for f in "${FAILURES[@]}"; do
+    echo -e "    ${RED}✗${NC} $f"
+  done
+fi
+echo "═══════════════════════════════════════════════════════════════"
+echo ""
+
+[[ $FAIL -eq 0 ]]

--- a/demo/terraform/backend.tf
+++ b/demo/terraform/backend.tf
@@ -1,0 +1,20 @@
+# demo/terraform/backend.tf
+#
+# Terraform state backend.
+# By default uses local state — safe for a single-developer demo.
+# Uncomment the S3 block for shared team use.
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+
+terraform {
+  # Local state (default for demo)
+  # backend "local" {}
+
+  # Uncomment for shared state:
+  # backend "s3" {
+  #   bucket = "kardinal-terraform-state"
+  #   key    = "demo/eks/terraform.tfstate"
+  #   region = "us-east-2"
+  # }
+}

--- a/demo/terraform/main.tf
+++ b/demo/terraform/main.tf
@@ -1,0 +1,99 @@
+# demo/terraform/main.tf
+#
+# EKS cluster for the kardinal-promoter demo prod environment.
+# Minimal setup: 2x t3.medium in us-east-2.
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_availability_zones" "available" { state = "available" }
+data "aws_caller_identity" "current" {}
+
+locals {
+  cluster_name = var.cluster_name
+  common_tags = {
+    Project     = "kardinal-promoter"
+    Environment = "demo-prod"
+    ManagedBy   = "terraform"
+  }
+}
+
+# ── VPC ───────────────────────────────────────────────────────────────────────
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.5"
+
+  name = "${local.cluster_name}-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = slice(data.aws_availability_zones.available.names, 0, 2)
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true # cost: single NAT instead of one per AZ
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = "1"
+  }
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+
+  tags = local.common_tags
+}
+
+# ── EKS Cluster ───────────────────────────────────────────────────────────────
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.8"
+
+  cluster_name    = local.cluster_name
+  cluster_version = var.kubernetes_version
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  cluster_endpoint_public_access = true
+
+  eks_managed_node_groups = {
+    demo = {
+      instance_types = ["t3.medium"]
+      min_size       = 1
+      max_size       = 3
+      desired_size   = 2
+    }
+  }
+
+  # Allow the Terraform caller to administer the cluster
+  enable_cluster_creator_admin_permissions = true
+
+  tags = local.common_tags
+}
+
+# ── kubeconfig output command ─────────────────────────────────────────────────
+
+resource "null_resource" "kubeconfig" {
+  depends_on = [module.eks]
+  provisioner "local-exec" {
+    command = "aws eks update-kubeconfig --name ${local.cluster_name} --region ${var.region} --alias ${var.kubeconfig_alias}"
+  }
+}

--- a/demo/terraform/outputs.tf
+++ b/demo/terraform/outputs.tf
@@ -1,0 +1,24 @@
+# demo/terraform/outputs.tf
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = module.eks.cluster_name
+}
+
+output "cluster_region" {
+  description = "AWS region"
+  value       = var.region
+}
+
+output "cluster_endpoint" {
+  description = "EKS cluster API endpoint"
+  value       = module.eks.cluster_endpoint
+}
+
+output "kubeconfig_update_command" {
+  description = "Command to update kubeconfig for this cluster"
+  value       = "aws eks update-kubeconfig --name ${module.eks.cluster_name} --region ${var.region} --alias ${var.kubeconfig_alias}"
+}

--- a/demo/terraform/variables.tf
+++ b/demo/terraform/variables.tf
@@ -1,0 +1,28 @@
+# demo/terraform/variables.tf
+#
+# Copyright 2026 The kardinal-promoter Authors.
+# Licensed under the Apache License, Version 2.0
+
+variable "region" {
+  description = "AWS region for the demo EKS cluster"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+  default     = "kardinal-demo-prod"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for the EKS cluster"
+  type        = string
+  default     = "1.29"
+}
+
+variable "kubeconfig_alias" {
+  description = "kubectl context alias to use for this cluster"
+  type        = string
+  default     = "kardinal-prod"
+}


### PR DESCRIPTION
## Summary

Two problems, one PR:

### 1. Fix v0.8.1 release CI → controller image published

The `aquasecurity/trivy-action@0.31.0` tag does not exist — it was renamed to `v0.31.0`. This caused the v0.8.1 release workflow to fail before the controller image was pushed to ghcr.io, which is why `kubectl get pods` shows `ErrImagePull` for any fresh install.

**Fix**: bump trivy-action to `@0.35.0` (latest stable).

### 2. Complete demo environment (source of truth)

Adds `demo/` — a production-quality demo that is the single source of truth for whether kardinal-promoter works.

**`demo/scripts/setup.sh`** — one command creates everything:
- 3 kind clusters: `kardinal-control`, `kardinal-dev`, `kardinal-prod`
- Optional real EKS prod cluster (`--eks` flag, Terraform in `demo/terraform/`)
- kardinal-promoter + krocodile + ArgoCD on control cluster
- kardinal-test-app deployed across all envs
- 2 pipelines + 4 PolicyGates covering every gate type

**`demo/scripts/validate.sh`** — 10 end-to-end scenarios:
1. Controller health
2. Pipeline list (JSON + table)
3. UI reachable (HTTP 200 + React HTML)
4. Happy path promotion (auto test→uat→prod PR)
5. Weekend gate (BLOCKED/ALLOWED via `policy simulate`)
6. Soak gate (visible in `kardinal explain`)
7. Pause / resume
8. Rollback (PR with kardinal/rollback label)
9. CLI completeness (version, explain, history, completion, --dry-run)
10. Multi-cluster pipeline registered

**Verified locally**: 17 passed, 4 skipped (need GITHUB_TOKEN), 0 failed.

**`.github/workflows/demo-validate.yml`** — nightly CI (02:00 UTC) + PR trigger. Runs full setup + validate on a real kind cluster. Posts to Issue #1. **If this workflow is red, the product is broken.**

## Quick start

```bash
export GITHUB_TOKEN=ghp_xxx
./demo/scripts/setup.sh          # ~5 min
./demo/scripts/validate.sh       # all 10 scenarios
kardinal dashboard                # open the UI
./demo/scripts/teardown.sh       # clean up
```

## After merging

Re-tag v0.8.1 to trigger the fixed release CI and publish the missing controller image:
```bash
git tag -d v0.8.1 && git push origin :refs/tags/v0.8.1
git tag v0.8.1 && git push origin v0.8.1
```