### PR TITLE
docs: mark 4 agent discipline items ✅ Present in 12-autonomous-loop-discipline.md (#813)

### DIFF
--- a/.specify/specs/issue-813/spec.md
+++ b/.specify/specs/issue-813/spec.md
@@ -1,0 +1,17 @@
+# Spec: docs — mark 4 agent items ✅ Present in 12-autonomous-loop-discipline.md
+
+## Design reference
+- **Design doc**: `docs/design/12-autonomous-loop-discipline.md`
+- **Section**: `§ Future`
+- **Implements**: 4 autonomous loop discipline items (🔲 → ✅)
+
+## Zone 1 — Obligations
+- O1: All 4 Future items moved to Present with agent file references
+- O2: Each Present entry names the specific agent file where implemented
+- O3: Future section is empty after this change
+
+## Zone 2 — Implementer's judgment
+Entries should be concise. The full implementation is in the agent files.
+
+## Zone 3 — Scoped out
+Modifying the agent files themselves.

--- a/docs/design/12-autonomous-loop-discipline.md
+++ b/docs/design/12-autonomous-loop-discipline.md
@@ -95,15 +95,29 @@ in-review items using the autonomous merge protocol. If all are genuinely unmerg
 
 ## Present (✅)
 
-*(Not yet implemented — this is the design doc for a new behavior.)*
+- ✅ **qa.md §3e — 3-step autonomous merge protocol** (`_merge_pr()` function):
+  normal → `--admin` → clear branch protection (PUT) → restore. Never posts
+  `[NEEDS HUMAN: pr-approval-required]` before attempting all three steps.
+  `_RESTORE_TRAP` with `trap ... EXIT` ensures branch protection is always restored.
+  Implemented in `~/.otherness/agents/phases/qa.md §3e`.
+
+- ✅ **qa.md §3e — enforce_admins toggle error handling**: The `_RESTORE_TRAP`
+  environment variable captures the restore curl command; `trap "$_RESTORE_TRAP" EXIT`
+  fires on both normal exit and error. Explicit `eval "$_RESTORE_TRAP"` + `trap - EXIT`
+  on normal exit. Implemented alongside the 3-step protocol in qa.md §3e.
+
+- ✅ **coord.md §1c — queue gate (in_review ≥ 3)**: When total `in_review` items ≥ 3,
+  queue generation is skipped and the queue-gen lock is released immediately. Prevents
+  saturating the review queue when items accumulate. Implemented in coord.md §1c.
+
+- ✅ **standalone.md HARD RULES — `[NEEDS HUMAN]` as last resort**: The HARD RULES
+  section states: "Before posting `[NEEDS HUMAN]` for any merge failure: attempt all 3
+  steps in qa.md §3e. Only post `[NEEDS HUMAN]` when step 3 fails with a specific error
+  (403 = no admin rights). Log the exact error." Implemented in standalone.md §HARD RULES.
 
 ## Future (🔲)
 
-- 🔲 qa.md §3e (in otherness agents): codify the 3-step autonomous merge protocol above
-- 🔲 qa.md §3e: wrap enforce_admins toggle in error handling that always restores the setting
-- 🔲 coord.md §1c (in otherness agents): add gate — skip queue generation when in_review >= 3
-- 🔲 standalone.md HARD RULES: rewrite `[NEEDS HUMAN]` rule — attempt autonomous resolution first;
-  post [NEEDS HUMAN] only after all autonomous paths have been tried and failed with specific errors
+_(no items)_
 
 ---
 


### PR DESCRIPTION
## Summary
All 4 Future items in `docs/design/12-autonomous-loop-discipline.md` were already
implemented in the otherness agent files. This PR marks them ✅ Present.

## Items moved 🔲 → ✅

1. **qa.md §3e** — 3-step `_merge_pr()` autonomous merge protocol  
2. **qa.md §3e** — `enforce_admins` toggle with `_RESTORE_TRAP` and `trap ... EXIT`  
3. **coord.md §1c** — queue gate: skip generation when `in_review ≥ 3`  
4. **standalone.md HARD RULES** — `[NEEDS HUMAN]` is last resort after all 3 merge paths fail

## Design doc
Updated `docs/design/12-autonomous-loop-discipline.md`: moved 4 items 🔲 → ✅.
Future section is now empty.

Closes #813