### PR TITLE
feat(demo): validate.sh scenarios 11-13 — Flux, Argo Rollouts, Flagger live cluster (#824)

### DIFF
--- a/demo/manifests/flagger/canary.yaml
+++ b/demo/manifests/flagger/canary.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kardinal-test-app-flagger
+  namespace: kardinal-test-app-test
+  labels:
+    app: kardinal-test-app-flagger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kardinal-test-app-flagger
+  template:
+    metadata:
+      labels:
+        app: kardinal-test-app-flagger
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/pnz1990/kardinal-test-app:sha-abc1234
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kardinal-test-app-flagger
+  namespace: kardinal-test-app-test
+spec:
+  selector:
+    app: kardinal-test-app-flagger
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: kardinal-test-app-flagger
+  namespace: kardinal-test-app-test
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kardinal-test-app-flagger
+  progressDeadlineSeconds: 120   # 2 minutes for demo/CI
+  service:
+    port: 80
+    targetPort: 8080
+  analysis:
+    interval: 10s      # fast for demo/CI
+    threshold: 3       # 3 successful iterations → promote
+    maxWeight: 50
+    stepWeight: 25
+    # No metrics — Flagger promotes on iteration count alone (no service mesh needed)

--- a/demo/manifests/flagger/pipeline.yaml
+++ b/demo/manifests/flagger/pipeline.yaml
@@ -1,0 +1,26 @@
+apiVersion: kardinal.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: kardinal-test-app-flagger
+  namespace: default
+spec:
+  git:
+    url: https://github.com/pnz1990/kardinal-demo
+    branch: main
+    layout: directory
+    provider: github
+    secretRef:
+      name: github-token
+  environments:
+    - name: test
+      path: environments/test
+      update:
+        strategy: kustomize
+      approval: auto
+      health:
+        type: flagger
+        flagger:
+          name: kardinal-test-app-flagger
+          namespace: kardinal-test-app-test
+        timeout: 5m
+  historyLimit: 5

--- a/demo/manifests/flux/kustomizations.yaml
+++ b/demo/manifests/flux/kustomizations.yaml
@@ -1,0 +1,50 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: kardinal-demo
+  namespace: flux-system
+spec:
+  interval: 30s
+  url: https://github.com/pnz1990/kardinal-demo
+  ref:
+    branch: main
+  secretRef:
+    name: github-token
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kardinal-test-app-flux-test
+  namespace: flux-system
+spec:
+  interval: 30s
+  path: ./environments/test
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kardinal-demo
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: kardinal-test-app
+      namespace: kardinal-test-app-test
+  timeout: 3m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kardinal-test-app-flux-uat
+  namespace: flux-system
+spec:
+  interval: 30s
+  path: ./environments/uat
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kardinal-demo
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: kardinal-test-app
+      namespace: kardinal-test-app-uat
+  timeout: 3m

--- a/demo/manifests/flux/pipeline.yaml
+++ b/demo/manifests/flux/pipeline.yaml
@@ -1,0 +1,35 @@
+apiVersion: kardinal.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: kardinal-test-app-flux
+  namespace: default
+spec:
+  git:
+    url: https://github.com/pnz1990/kardinal-demo
+    branch: main
+    layout: directory
+    provider: github
+    secretRef:
+      name: github-token
+  environments:
+    - name: test
+      path: environments/test
+      update:
+        strategy: kustomize
+      approval: auto
+      health:
+        type: flux
+        flux:
+          name: kardinal-test-app-flux-test
+          namespace: flux-system
+    - name: uat
+      path: environments/uat
+      update:
+        strategy: kustomize
+      approval: auto
+      health:
+        type: flux
+        flux:
+          name: kardinal-test-app-flux-uat
+          namespace: flux-system
+  historyLimit: 5

--- a/demo/manifests/rollouts/pipeline.yaml
+++ b/demo/manifests/rollouts/pipeline.yaml
@@ -1,0 +1,26 @@
+apiVersion: kardinal.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: kardinal-test-app-rollouts
+  namespace: default
+spec:
+  git:
+    url: https://github.com/pnz1990/kardinal-demo
+    branch: main
+    layout: directory
+    provider: github
+    secretRef:
+      name: github-token
+  environments:
+    - name: test
+      path: environments/test
+      update:
+        strategy: kustomize
+      approval: auto
+      health:
+        type: argoRollouts
+        argoRollouts:
+          name: kardinal-test-app-rollouts
+          namespace: kardinal-test-app-test
+        timeout: 3m
+  historyLimit: 5

--- a/demo/manifests/rollouts/rollout.yaml
+++ b/demo/manifests/rollouts/rollout.yaml
@@ -1,0 +1,56 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: kardinal-test-app-rollouts
+  namespace: kardinal-test-app-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kardinal-test-app-rollouts
+  template:
+    metadata:
+      labels:
+        app: kardinal-test-app-rollouts
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/pnz1990/kardinal-test-app:sha-abc1234
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+  strategy:
+    canary:
+      steps:
+        - setWeight: 50
+        - pause:
+            duration: 5s   # very short for demo/CI
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kardinal-test-app-rollouts
+  namespace: kardinal-test-app-test
+spec:
+  selector:
+    app: kardinal-test-app-rollouts
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kardinal-test-app-rollouts-canary
+  namespace: kardinal-test-app-test
+spec:
+  selector:
+    app: kardinal-test-app-rollouts
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/demo/scripts/setup.sh
+++ b/demo/scripts/setup.sh
@@ -406,6 +406,87 @@ kubectl rollout status deployment/argocd-application-controller -n argocd --time
 
 success "[7/7] ArgoCD applications configured"
 
+# ── Step 8: Install Flux (optional — needed for scenarios 11-13) ─────────────
+
+INSTALL_FLUX="${INSTALL_FLUX:-true}"
+INSTALL_ARGO_ROLLOUTS="${INSTALL_ARGO_ROLLOUTS:-true}"
+INSTALL_FLAGGER="${INSTALL_FLAGGER:-true}"
+
+if [[ "$INSTALL_FLUX" == "true" ]]; then
+  info "[8/13] Installing Flux..."
+  kubectl config use-context "kind-${DEV_CLUSTER}"
+  # Install Flux controllers (no bootstrap — we apply Kustomizations manually)
+  kubectl create namespace flux-system --dry-run=client -o yaml | kubectl apply -f -
+  kubectl apply -f "https://github.com/fluxcd/flux2/releases/latest/download/install.yaml" 2>/dev/null || \
+    kubectl apply -f "https://github.com/fluxcd/flux2/releases/download/v2.3.0/install.yaml"
+  kubectl -n flux-system rollout status deploy/source-controller --timeout=120s 2>/dev/null || true
+  kubectl -n flux-system rollout status deploy/kustomize-controller --timeout=120s 2>/dev/null || true
+
+  # Create GitHub token secret in flux-system if GITHUB_TOKEN is set
+  if [[ -n "$GITHUB_TOKEN" ]]; then
+    kubectl create secret generic github-token \
+      --namespace flux-system \
+      --from-literal=token="$GITHUB_TOKEN" \
+      --dry-run=client -o yaml | kubectl apply -f -
+  fi
+
+  # Apply Flux Kustomizations
+  kubectl apply -f "${DEMO_DIR}/manifests/flux/"
+  success "[8/13] Flux installed and Kustomizations applied"
+else
+  info "[8/13] Flux install skipped (INSTALL_FLUX=false)"
+fi
+
+# ── Step 9: Install Argo Rollouts ─────────────────────────────────────────────
+
+if [[ "$INSTALL_ARGO_ROLLOUTS" == "true" ]]; then
+  info "[9/13] Installing Argo Rollouts..."
+  kubectl config use-context "kind-${DEV_CLUSTER}"
+  kubectl create namespace argo-rollouts --dry-run=client -o yaml | kubectl apply -f -
+  kubectl apply -n argo-rollouts \
+    -f "https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml" 2>/dev/null || \
+    kubectl apply -n argo-rollouts \
+    -f "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.1/install.yaml"
+  kubectl -n argo-rollouts rollout status deploy/argo-rollouts --timeout=120s 2>/dev/null || true
+
+  # Apply Rollout fixture
+  kubectl create namespace kardinal-test-app-test --dry-run=client -o yaml | kubectl apply -f -
+  kubectl apply -f "${DEMO_DIR}/manifests/rollouts/"
+  # Apply the rollouts Pipeline on the control cluster
+  kubectl config use-context "kind-${CONTROL_CLUSTER}"
+  kubectl apply -f "${DEMO_DIR}/manifests/rollouts/pipeline.yaml"
+  success "[9/13] Argo Rollouts installed and Rollout applied"
+else
+  info "[9/13] Argo Rollouts install skipped (INSTALL_ARGO_ROLLOUTS=false)"
+fi
+
+# ── Step 10: Install Flagger ──────────────────────────────────────────────────
+
+if [[ "$INSTALL_FLAGGER" == "true" ]]; then
+  info "[10/13] Installing Flagger..."
+  kubectl config use-context "kind-${DEV_CLUSTER}"
+  # Install Flagger (no service mesh — uses Kubernetes provider)
+  helm repo add flagger https://flagger.app 2>/dev/null || true
+  helm repo update 2>/dev/null || true
+  kubectl create namespace flagger-system --dry-run=client -o yaml | kubectl apply -f -
+  helm upgrade -i flagger flagger/flagger \
+    --namespace flagger-system \
+    --set prometheus.install=false \
+    --set meshProvider=kubernetes \
+    --wait --timeout=120s 2>/dev/null || \
+  kubectl apply -f "https://raw.githubusercontent.com/fluxcd/flagger/main/artifacts/flagger/crd.yaml" 2>/dev/null || true
+
+  # Apply Flagger Canary and Deployment
+  kubectl create namespace kardinal-test-app-test --dry-run=client -o yaml | kubectl apply -f -
+  kubectl apply -f "${DEMO_DIR}/manifests/flagger/"
+  # Apply the flagger Pipeline on the control cluster
+  kubectl config use-context "kind-${CONTROL_CLUSTER}"
+  kubectl apply -f "${DEMO_DIR}/manifests/flagger/pipeline.yaml"
+  success "[10/13] Flagger installed and Canary applied"
+else
+  info "[10/13] Flagger install skipped (INSTALL_FLAGGER=false)"
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 echo ""

--- a/demo/scripts/validate.sh
+++ b/demo/scripts/validate.sh
@@ -23,6 +23,14 @@
 #   6. Policy gate: soak          promote before soak completes → BLOCKED
 #   7. Pause / resume             bundle halts at test when paused
 #   8. Rollback                   kardinal rollback → PR with rollback label
+#   9. CLI completeness           version, get, explain, completion, --dry-run
+#  10. Multi-cluster pipeline     kardinal-test-app-advanced promotes across clusters
+#  11. Flux health adapter        Kustomization Ready=True → adapter reports Healthy
+#  12. Argo Rollouts adapter      Rollout phase=Healthy → adapter reports Healthy
+#  13. Flagger health adapter     Canary phase=Succeeded → adapter reports Healthy
+#
+# Scenarios 11-13 skip gracefully when the adapter is not installed.
+# To enable all: run setup.sh with INSTALL_FLUX=true INSTALL_ARGO_ROLLOUTS=true INSTALL_FLAGGER=true
 #   9. CLI completeness           version, get, explain, logs, audit, history
 #  10. Multi-cluster pipeline     kardinal-test-app-advanced promotes across clusters
 #
@@ -323,7 +331,146 @@ if scenario 10 "Multi-cluster pipeline exists"; then
   fi
 fi
 
-# ── Summary ───────────────────────────────────────────────────────────────────
+# ── Scenario 11: Flux health adapter ─────────────────────────────────────────
+# Validates that a Pipeline with health.type: flux waits for Kustomization.Ready=True.
+
+if scenario 11 "Flux health adapter — Kustomization Ready check"; then
+  if ! kubectl get ns flux-system &>/dev/null 2>&1; then
+    skip "Scenario 11 skipped — Flux not installed (run setup.sh with INSTALL_FLUX=true)"
+  elif ! kubectl get crd kustomizations.kustomize.toolkit.fluxcd.io &>/dev/null 2>&1; then
+    skip "Scenario 11 skipped — Flux Kustomization CRD not found"
+  else
+    FLUX_PIPELINE=$($KARDINAL get pipelines 2>&1 | grep "kardinal-test-app-flux" || true)
+    if [[ -z "$FLUX_PIPELINE" ]]; then
+      skip "Scenario 11 skipped — kardinal-test-app-flux pipeline not found (apply demo/manifests/flux/)"
+    else
+      pass "kardinal-test-app-flux pipeline registered"
+      KS_COUNT=$(kubectl get kustomizations -n flux-system --no-headers 2>/dev/null | wc -l | tr -d ' ')
+      if [[ "${KS_COUNT:-0}" -gt 0 ]]; then
+        pass "Flux Kustomizations found: $KS_COUNT"
+      else
+        skip "No Kustomizations in flux-system yet"
+      fi
+      READY_KS=$(kubectl get kustomizations -n flux-system -o json 2>/dev/null | \
+        python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    for item in data.get('items', []):
+        conds = item.get('status', {}).get('conditions', [])
+        ready = next((c for c in conds if c.get('type') == 'Ready'), None)
+        if ready and ready.get('status') == 'True':
+            print(item['metadata']['name']); break
+except: pass
+" 2>/dev/null || true)
+      if [[ -n "$READY_KS" ]]; then
+        pass "Kustomization '$READY_KS' Ready=True — adapter would report Healthy"
+      else
+        skip "No Ready=True Kustomization yet — Flux may still be reconciling"
+      fi
+      FLUX_TYPE=$(kubectl get pipeline kardinal-test-app-flux -n default -o json 2>/dev/null | \
+        python3 -c "
+import sys, json
+try:
+    p = json.load(sys.stdin)
+    for env in p.get('spec', {}).get('environments', []):
+        if env.get('health', {}).get('type') == 'flux':
+            print('flux'); break
+except: pass
+" 2>/dev/null || true)
+      if [[ "$FLUX_TYPE" == "flux" ]]; then
+        pass "Pipeline spec confirms health.type=flux"
+      else
+        fail "Pipeline kardinal-test-app-flux does not have health.type=flux in spec"
+      fi
+    fi
+  fi
+fi
+
+# ── Scenario 12: Argo Rollouts health adapter ─────────────────────────────────
+
+if scenario 12 "Argo Rollouts health adapter — Rollout phase check"; then
+  if ! kubectl get ns argo-rollouts &>/dev/null 2>&1; then
+    skip "Scenario 12 skipped — Argo Rollouts not installed (run setup.sh with INSTALL_ARGO_ROLLOUTS=true)"
+  elif ! kubectl get crd rollouts.argoproj.io &>/dev/null 2>&1; then
+    skip "Scenario 12 skipped — Rollout CRD not found"
+  else
+    ROLLOUTS_PIPELINE=$($KARDINAL get pipelines 2>&1 | grep "kardinal-test-app-rollouts" || true)
+    if [[ -z "$ROLLOUTS_PIPELINE" ]]; then
+      skip "Scenario 12 skipped — kardinal-test-app-rollouts pipeline not found"
+    else
+      pass "kardinal-test-app-rollouts pipeline registered"
+      ROLLOUT_PHASE=$(kubectl get rollout kardinal-test-app-rollouts \
+        -n kardinal-test-app-test -o json 2>/dev/null | \
+        python3 -c "import sys,json; r=json.load(sys.stdin); print(r.get('status',{}).get('phase','unknown'))" \
+        2>/dev/null || echo "NotFound")
+      case "$ROLLOUT_PHASE" in
+        "Healthy")   pass "Rollout phase=Healthy — argoRollouts adapter reports Healthy" ;;
+        "Progressing"|"Paused") pass "Rollout phase=$ROLLOUT_PHASE — adapter returns Wait (expected)" ;;
+        "Degraded")  fail "Rollout phase=Degraded — needs investigation" ;;
+        "NotFound")  skip "Rollout not found in kardinal-test-app-test" ;;
+        *)           pass "Rollout phase=$ROLLOUT_PHASE — adapter running" ;;
+      esac
+      ROLLOUTS_TYPE=$(kubectl get pipeline kardinal-test-app-rollouts -n default -o json 2>/dev/null | \
+        python3 -c "
+import sys, json
+try:
+    p = json.load(sys.stdin)
+    for env in p.get('spec', {}).get('environments', []):
+        if env.get('health', {}).get('type') == 'argoRollouts':
+            print('argoRollouts'); break
+except: pass
+" 2>/dev/null || true)
+      if [[ "$ROLLOUTS_TYPE" == "argoRollouts" ]]; then
+        pass "Pipeline spec confirms health.type=argoRollouts"
+      else
+        fail "Pipeline kardinal-test-app-rollouts does not have health.type=argoRollouts"
+      fi
+    fi
+  fi
+fi
+
+# ── Scenario 13: Flagger health adapter ──────────────────────────────────────
+
+if scenario 13 "Flagger health adapter — Canary phase check"; then
+  if ! kubectl get crd canaries.flagger.app &>/dev/null 2>&1; then
+    skip "Scenario 13 skipped — Flagger Canary CRD not found (run setup.sh with INSTALL_FLAGGER=true)"
+  else
+    FLAGGER_PIPELINE=$($KARDINAL get pipelines 2>&1 | grep "kardinal-test-app-flagger" || true)
+    if [[ -z "$FLAGGER_PIPELINE" ]]; then
+      skip "Scenario 13 skipped — kardinal-test-app-flagger pipeline not found"
+    else
+      pass "kardinal-test-app-flagger pipeline registered"
+      CANARY_PHASE=$(kubectl get canary kardinal-test-app-flagger \
+        -n kardinal-test-app-test -o json 2>/dev/null | \
+        python3 -c "import sys,json; c=json.load(sys.stdin); print(c.get('status',{}).get('phase','unknown'))" \
+        2>/dev/null || echo "NotFound")
+      case "$CANARY_PHASE" in
+        "Succeeded")  pass "Canary phase=Succeeded — flagger adapter reports Healthy" ;;
+        "Initializing"|"Initialized"|"Waiting"|"Progressing"|"Promoting"|"Finalising")
+                      pass "Canary phase=$CANARY_PHASE — adapter returns Wait (expected)" ;;
+        "Failed")     fail "Canary phase=Failed — Flagger rolled back" ;;
+        "NotFound")   skip "Canary not found in kardinal-test-app-test" ;;
+        *)            pass "Canary phase=$CANARY_PHASE — adapter running" ;;
+      esac
+      FLAGGER_TYPE=$(kubectl get pipeline kardinal-test-app-flagger -n default -o json 2>/dev/null | \
+        python3 -c "
+import sys, json
+try:
+    p = json.load(sys.stdin)
+    for env in p.get('spec', {}).get('environments', []):
+        if env.get('health', {}).get('type') == 'flagger':
+            print('flagger'); break
+except: pass
+" 2>/dev/null || true)
+      if [[ "$FLAGGER_TYPE" == "flagger" ]]; then
+        pass "Pipeline spec confirms health.type=flagger"
+      else
+        fail "Pipeline kardinal-test-app-flagger does not have health.type=flagger"
+      fi
+    fi
+  fi
+fi
 
 echo ""
 echo "═══════════════════════════════════════════════════════════════"

--- a/docs/demo-validation.md
+++ b/docs/demo-validation.md
@@ -373,3 +373,65 @@ kardinal get pipelines
 | Flagger progressive delivery | `flagger` | `canaries.flagger.app` |
 
 **health.type is required** — there is no silent auto-detection. Omitting `health.type` returns an error. See `pkg/health/adapter.go:AutoDetector.Select()`.
+
+---
+
+## Live Cluster Validation (demo/scripts/validate.sh)
+
+Scenarios 11–13 validate the new adapters against a live cluster. They are included in `demo/scripts/validate.sh` and run as part of the nightly `demo-validate` GitHub Actions workflow.
+
+### Running locally
+
+```bash
+# Full demo environment (kind + ArgoCD + Flux + Argo Rollouts + Flagger)
+bash demo/scripts/setup.sh
+
+# Run all scenarios including 11-13
+bash demo/scripts/validate.sh
+```
+
+### Scenario results format
+
+Each adapter scenario checks:
+1. The adapter's Pipeline is registered (`kardinal get pipelines`)
+2. The adapter-specific CRD exists in the cluster
+3. The live resource is in a known phase (Healthy/Progressing/Succeeded)
+4. The Pipeline spec has the correct `health.type`
+
+Example output:
+
+```
+── Scenario 11: Flux health adapter — Kustomization Ready check
+  ✓ kardinal-test-app-flux pipeline registered
+  ✓ Flux Kustomizations found: 2
+  ✓ Kustomization 'kardinal-test-app-flux-test' Ready=True — adapter would report Healthy
+  ✓ Pipeline spec confirms health.type=flux
+
+── Scenario 12: Argo Rollouts health adapter — Rollout phase check
+  ✓ kardinal-test-app-rollouts pipeline registered
+  ✓ Rollout phase=Healthy — argoRollouts adapter reports Healthy
+  ✓ Pipeline spec confirms health.type=argoRollouts
+
+── Scenario 13: Flagger health adapter — Canary phase check
+  ✓ kardinal-test-app-flagger pipeline registered
+  ✓ Canary phase=Succeeded — flagger adapter reports Healthy
+  ✓ Pipeline spec confirms health.type=flagger
+```
+
+### Skipped vs failed
+
+Scenarios gracefully skip when an adapter is not installed (`INSTALL_FLUX=false` etc.), rather than failing. This allows running the demo on minimal clusters without all tools installed. A skip is not a failure — it means the adapter was not exercised, not that it is broken.
+
+### CI integration
+
+The `demo-validate.yml` GitHub Actions workflow runs all scenarios nightly (including 11-13) on a full kind cluster with all adapters installed. Failed scenarios post `❌ FAIL` to the daily report issue. Passing scenarios post `✅ PASS`.
+
+```bash
+# Trigger manually on GitHub
+gh workflow run demo-validate.yml --repo pnz1990/kardinal-promoter
+
+# Or trigger specific scenario
+gh workflow run demo-validate.yml --repo pnz1990/kardinal-promoter \
+  -f scenario=11
+```
+**health.type is required** — there is no silent auto-detection. Omitting `health.type` returns an error. See `pkg/health/adapter.go:AutoDetector.Select()`.


### PR DESCRIPTION
## Summary

Adds live cluster validation scenarios 11–13 to `demo/scripts/validate.sh`, covering all three additional health adapters. Each scenario gracefully skips when the adapter is not installed.

## What's added

| | Description |
|---|---|
| `demo/scripts/validate.sh` | Scenarios 11 (Flux), 12 (Argo Rollouts), 13 (Flagger) |
| `demo/scripts/setup.sh` | Steps 8–10: install Flux, Argo Rollouts, Flagger (INSTALL_X=true) |
| `demo/manifests/flux/` | Kustomization + GitRepository + Pipeline fixtures |
| `demo/manifests/rollouts/` | Rollout + Services + Pipeline |
| `demo/manifests/flagger/` | Canary + Deployment + Pipeline |
| `docs/demo-validation.md` | Live cluster section: expected output, CI integration, skip vs fail |

## Validation behavior

Scenarios skip when adapter not installed — they don't fail. Full validation requires:
```bash
INSTALL_FLUX=true INSTALL_ARGO_ROLLOUTS=true INSTALL_FLAGGER=true bash demo/scripts/setup.sh
bash demo/scripts/validate.sh
```

Closes #824