### PR TITLE
fix(ci): gh auth login fails when GH_TOKEN env var is set

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -72,7 +72,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          echo "$GH_TOKEN" | gh auth login --with-token
+          # GH_TOKEN env var is sufficient for `gh` CLI auth.
+          # `gh auth login --with-token` fails when GH_TOKEN is already set in env.
+          # We only need `gh auth setup-git` to configure the git credential helper.
           gh auth setup-git
           gh auth status
 


### PR DESCRIPTION
## Root cause

`gh auth login --with-token` exits 1 when `GH_TOKEN` is already present as an
environment variable. GitHub Actions auto-injects `GH_TOKEN` from the secret, so
the login command always fails with:

```
The value of the GH_TOKEN environment variable is being used for authentication.
To have GitHub CLI store credentials instead, first clear the value from the environment.
```

## Fix

Remove the `gh auth login` call. `GH_TOKEN` in the environment is sufficient for
all `gh` CLI operations. Keep only `gh auth setup-git` which configures the git
credential helper for push operations.

## Verified

Run [24634290489](https://github.com/pnz1990/kardinal-promoter/actions/runs/24634290489) shows the exact failure.