### PR TITLE
fix(ci): add use_github_token=true to skip OpenCode App OIDC exchange

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -88,6 +88,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           model: amazon-bedrock/global.anthropic.claude-sonnet-4-6
+          # use_github_token: true — skip the OpenCode App OIDC exchange.
+          # The exchange calls api.opencode.ai; without the opencode GitHub App
+          # installed, it returns an HTML error page that fails JSON parsing.
+          # With use_github_token=true the action uses GITHUB_TOKEN directly.
+          use_github_token: "true"
           prompt: |
             AGENTS_PATH=$(python3 -c "
             import re, os


### PR DESCRIPTION
## Root cause

The `anomalyco/opencode/github` action, by default, calls `api.opencode.ai` to exchange the `GITHUB_TOKEN` for an opencode App token. This requires the [opencode GitHub App](https://github.com/apps/opencode-agent) to be installed on the repo.

Without the app, the endpoint returns an HTML error page. `JSON.parse(html)` throws with the message `Failed to parse JSON`, which is what we saw in runs [24634290489](https://github.com/pnz1990/kardinal-promoter/actions/runs/24634290489) and [24634315716](https://github.com/pnz1990/kardinal-promoter/actions/runs/24634315716).

## Fix

`use_github_token: "true"` makes the action use `GITHUB_TOKEN` directly, bypassing the OIDC exchange entirely. No opencode App installation required.

This is the correct approach for self-hosted autonomous agents where we control the token (our `GH_TOKEN` PAT has full `repo` + `workflow` scopes).