### PR TITLE
fix(ci): set OPENCODE_PERMISSION to auto-allow all tools in CI

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -86,12 +86,12 @@ jobs:
           # GitHub — full PAT for push, PR, review, issue, and workflow trigger
           GH_TOKEN:     ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Auto-approve all tool permissions in CI — no interactive TTY available.
+          # Without this, ctx.ask() blocks indefinitely waiting for user approval.
+          OPENCODE_PERMISSION: '{"bash":"allow","read":"allow","edit":"allow","write":"allow","glob":"allow","grep":"allow","list":"allow","external_directory":"allow","webfetch":"allow","task":"allow","todowrite":"allow","skill":"allow"}'
         with:
           model: amazon-bedrock/global.anthropic.claude-sonnet-4-6
           # use_github_token: true — skip the OpenCode App OIDC exchange.
-          # The exchange calls api.opencode.ai; without the opencode GitHub App
-          # installed, it returns an HTML error page that fails JSON parsing.
-          # With use_github_token=true the action uses GITHUB_TOKEN directly.
           use_github_token: "true"
           prompt: |
             AGENTS_PATH=$(python3 -c "


### PR DESCRIPTION
## Root cause

Every scheduled run hung after its first Bash tool call. Root cause confirmed by log analysis:

```
19:15:05 - Bash {"command":"ls ~/.otherness/agents/","description":"Check if agents directory exists"}
19:53:26 - ##[error]The operation was canceled.   ← 38 min later, still blocked
```

opencode's Bash tool calls `ctx.ask()` before executing any shell command to request user permission. In an interactive session the user clicks approve. In GitHub Actions there is no TTY — `ctx.ask()` waits forever. The 2-minute Bash timeout fires, the agent retries, hangs again, cycles for hours.

## Fix

Set `OPENCODE_PERMISSION` env var to pre-approve all tool types the agent needs. This is the correct CI pattern — equivalent to `--dangerously-skip-permissions` but scoped to specific tool types.