### PR TITLE
feat(ci): GH_TOKEN scope preflight — detect expired token before agent run

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -79,6 +79,69 @@ jobs:
           gh auth setup-git
           gh auth status
 
+      - name: Verify GH_TOKEN scopes
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          # Preflight: verify GH_TOKEN has the required OAuth scopes (repo + workflow).
+          # If the token is expired or missing scopes, post a [NEEDS HUMAN] issue so the
+          # failure is visible rather than producing a confusing mid-run failure.
+          #
+          # gh api /user returns a 200 with X-OAuth-Scopes header when the token is valid.
+          # We use -i (include headers) and grep for the required scopes.
+          SCOPES=$(gh api /user -i 2>/dev/null | grep -i '^x-oauth-scopes:' | head -1 || true)
+          echo "Token scopes header: $SCOPES"
+
+          MISSING=""
+          echo "$SCOPES" | grep -qi 'repo' || MISSING="${MISSING}repo "
+          echo "$SCOPES" | grep -qi 'workflow' || MISSING="${MISSING}workflow "
+
+          if [ -n "$MISSING" ]; then
+            echo "ERROR: GH_TOKEN is missing required scopes: $MISSING"
+            REPO=$(git remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||')
+            # Read report_issue from otherness-config.yaml
+            REPORT_ISSUE=$(python3 -c "
+          import re
+          section = None
+          for line in open('otherness-config.yaml'):
+              s = re.match(r'^(\w[\w_]*):', line)
+              if s: section = s.group(1)
+              if section == 'project':
+                  m = re.match(r'^\s+report_issue:\s*(\S+)', line)
+                  if m: print(m.group(1)); break
+          " 2>/dev/null || echo "1")
+            # Avoid duplicate issues
+            EXISTING=$(gh issue list --repo "$REPO" --state open \
+              --search "[NEEDS HUMAN] GH_TOKEN expired" --json number --jq 'length' 2>/dev/null || echo "0")
+            if [ "${EXISTING:-0}" -eq 0 ]; then
+              gh issue create --repo "$REPO" \
+                --title "[NEEDS HUMAN] GH_TOKEN expired or missing scopes — scheduled run blocked" \
+                --label "needs-human" \
+                --body "## Problem
+The otherness scheduled workflow detected that \`GH_TOKEN\` is missing required scopes or has expired.
+
+**Missing scopes**: \`$MISSING\`
+
+## Fix
+Generate a new PAT at https://github.com/settings/tokens with \`repo\` + \`workflow\` scopes, then:
+\`\`\`
+echo \"<new-token>\" | gh secret set GH_TOKEN --repo $REPO
+\`\`\`
+
+## Notes
+- Run started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+- Preflight check: \`docs/design/13-scheduled-execution.md\` §Present" 2>/dev/null \
+                && echo "Opened [NEEDS HUMAN] issue." || echo "Issue creation failed."
+            else
+              echo "NEEDS HUMAN issue already open — not creating duplicate."
+              gh issue comment "$REPORT_ISSUE" --repo "$REPO" \
+                --body "[PREFLIGHT] GH_TOKEN missing scopes: $MISSING. Scheduled run skipped." 2>/dev/null || true
+            fi
+            exit 1
+          fi
+
+          echo "GH_TOKEN scopes OK (repo + workflow present)."
+
       - name: Run otherness
         uses: anomalyco/opencode/github@latest
         env:

--- a/.specify/specs/832-token-preflight/spec.md
+++ b/.specify/specs/832-token-preflight/spec.md
@@ -1,0 +1,43 @@
+# Spec: 832-token-preflight
+
+> feat(ci): GH_TOKEN scope preflight — detect expired token before agent run
+
+## Design reference
+- **Design doc**: `docs/design/13-scheduled-execution.md`
+- **Section**: `§ Future`
+- **Implements**: Token expiry preflight (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: A workflow step named `Verify GH_TOKEN scopes` MUST execute before `Run otherness`.
+- Violation: no preflight step, or it runs after `Run otherness`.
+
+**O2**: The step MUST check that `GH_TOKEN` has `repo` and `workflow` scopes.
+- Mechanism: `gh auth status` output; if either scope is absent, the step must call
+  `gh issue create` to post a `[NEEDS HUMAN]` issue on report issue #1, then `exit 1`
+  to fail the workflow run visibly.
+- Violation: expired/missing-scope token does not produce a GitHub issue.
+
+**O3**: If `GH_TOKEN` is valid with required scopes, the step MUST exit 0 (no side effects).
+- Violation: preflight fails on a valid token.
+
+**O4**: The preflight step MUST use `GH_TOKEN` from the secrets, not `GITHUB_TOKEN`.
+- Violation: using `GITHUB_TOKEN` in the preflight step env.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Whether to use `gh auth status` or `gh api user` to detect expiry.
+- How to identify the report issue number (hardcode 1, or read from `otherness-config.yaml`).
+- Whether to create a new issue each time or check for an existing open issue with the same title.
+
+---
+
+## Zone 3 — Scoped out
+
+- Automatic token rotation (PATs are long-lived; rotation is a manual operation).
+- Checking scopes beyond `repo` and `workflow`.
+- Any changes to Go code, CRDs, or UI.

--- a/docs/design/13-scheduled-execution.md
+++ b/docs/design/13-scheduled-execution.md
@@ -116,10 +116,9 @@ If secrets expire or need rotation:
 - ✅ `GH_TOKEN` secret set — PAT with `repo` + `workflow` scopes (2026-04-19)
 - ✅ `otherness-config.yaml` `schedule.cron` field — `0 * * * *` (existing)
 - ✅ Cadence reduced to `0 */6 * * *` (every 6h) — all 7 journeys passing, steady-state standby (PR #834, 2026-04-19)
+- ✅ Token expiry preflight step — `Verify GH_TOKEN scopes` step before `Run otherness`; posts `[NEEDS HUMAN]` issue on expired/missing-scope token (PR #836, 2026-04-19)
 
 ## Future (🔲)
-
-- 🔲 Token expiry preflight: add a step before `Run otherness` that verifies `GH_TOKEN` has required scopes; post a `[NEEDS HUMAN]` issue on the report issue (#1) if the token is expired or missing scopes, so the failure is visible rather than silent
 
 ---
 


### PR DESCRIPTION
## Summary
Add a preflight step `Verify GH_TOKEN scopes` between `Authenticate gh CLI` and `Run otherness`. When `GH_TOKEN` is expired or missing `repo`/`workflow` scopes, the step opens a `[NEEDS HUMAN]` issue with rotation instructions and exits 1. Previously such failures produced confusing mid-run errors with no escalation.

## Changes
- `.github/workflows/otherness-scheduled.yml`: added `Verify GH_TOKEN scopes` step

## Design doc
Updated `docs/design/13-scheduled-execution.md`: moved token expiry preflight from 🔲 Future to ✅ Present. The Future section is now empty — all scheduled execution items are shipped.

## Customer doc
N/A — infrastructure change. The `[NEEDS HUMAN]` issue is the user-facing output.