### PR TITLE
chore(config): add session_item_limit: 10 for multi-item session throughput

### DIFF
--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -20,6 +20,10 @@ maqa:
   # Enables --admin merge bypass when branch protection requires a human review.
   autonomous_mode: true
 
+  # Max items to complete per session before SM/PM gate fires.
+  # See docs/design/21-session-throughput.md (otherness repo).
+  session_item_limit: 10
+
   # Executive project status update to GitHub Projects board every N cycles.
   # Only the unbounded standalone posts these. 0 = disabled.
   status_update_cycles: 5


### PR DESCRIPTION
Enables the multi-item session loop merged in [pnz1990/otherness#334](https://github.com/pnz1990/otherness/pull/334).

Sessions will now complete up to 10 items before running SM/PM, instead of stopping after 1.