### PR TITLE
feat(pdca): run daily not weekly — change cron to 0 2 * * *

### DIFF
--- a/.github/workflows/pdca.yml
+++ b/.github/workflows/pdca.yml
@@ -8,8 +8,8 @@ name: PDCA Product Validation
 
 on:
   schedule:
-    # Weekly on Sundays at 04:00 UTC — after any weekday CI fixes land
-    - cron: '0 4 * * 0'
+    # Daily at 02:00 UTC — matches demo-validate cadence for continuous coverage
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       scenario:

--- a/.specify/specs/issue-840/spec.md
+++ b/.specify/specs/issue-840/spec.md
@@ -1,0 +1,20 @@
+# Spec: PDCA daily cadence
+
+## Design reference
+- **Design doc**: N/A — infrastructure change with no user-visible behavior
+- **Issue**: #840
+
+## Zone 1 — Obligations
+
+1. The PDCA workflow `pdca.yml` schedule cron expression MUST be `0 2 * * *` (daily at 02:00 UTC).
+2. The prior cron expression `0 4 * * 0` (weekly Sunday only) MUST be removed.
+3. All other workflow behavior MUST remain unchanged.
+
+## Zone 2 — Implementer's judgment
+
+- Comment text updated to explain daily cadence rationale.
+
+## Zone 3 — Scoped out
+
+- Changing the workflow trigger inputs or scenario list.
+- Adding new scenarios (tracked in #841–843).


### PR DESCRIPTION
## Summary

Change PDCA workflow cron from weekly (Sundays 04:00 UTC) to daily (02:00 UTC) for continuous coverage.

## Design doc

N/A — infrastructure change with no user-visible behavior.

## Changes

- `.github/workflows/pdca.yml`: update `schedule.cron` from `0 4 * * 0` to `0 2 * * *`

Closes #840