### PR TITLE
feat(pdca): anchor score comment — post [ANCHOR] coverage line to issue #1

### DIFF
--- a/.github/workflows/pdca.yml
+++ b/.github/workflows/pdca.yml
@@ -244,13 +244,21 @@ jobs:
           TRIGGER: ${{ github.event_name }}
         run: |
           FAIL_COUNT="${FAIL:-0}"
+          PASS_COUNT="${PASS:-0}"
+          TOTAL=$((PASS_COUNT + FAIL_COUNT))
           STATUS="ALL PASS"
           if [ "${FAIL_COUNT}" -gt 0 ]; then STATUS="${FAIL_COUNT} FAILED"; fi
           RESULTS=$(cat /tmp/pdca-results.txt 2>/dev/null || echo "no results")
           DATE=$(date -u '+%Y-%m-%d')
+          # Compute coverage percentage
+          if [ "$TOTAL" -gt 0 ]; then
+            PCT=$(python3 -c "print(int(${PASS_COUNT}/${TOTAL}*100))")
+          else
+            PCT=0
+          fi
           echo "PDCA AUTOMATED - Product Validation $DATE" > /tmp/comment.txt
           echo "" >> /tmp/comment.txt
-          echo "Status: $STATUS (PASS=$PASS FAIL=$FAIL_COUNT)" >> /tmp/comment.txt
+          echo "Status: $STATUS (PASS=$PASS_COUNT FAIL=$FAIL_COUNT)" >> /tmp/comment.txt
           echo "Image: $TEST_IMAGE" >> /tmp/comment.txt
           echo "CI Run: https://github.com/$GH_REPO/actions/runs/$RUN_ID" >> /tmp/comment.txt
           echo "Trigger: $TRIGGER" >> /tmp/comment.txt
@@ -261,6 +269,9 @@ jobs:
           echo "Note: S2 (pause) and S5 (rollback) require full cluster - run manually." >> /tmp/comment.txt
           echo "Issue: #413" >> /tmp/comment.txt
           gh issue comment 1 --repo "$GH_REPO" --body-file /tmp/comment.txt
+          # Post structured anchor score line to Issue #1 for otherness coverage tracking
+          gh issue comment 1 --repo "$GH_REPO" \
+            --body "[ANCHOR | kardinal-promoter | ${DATE}] coverage: ${PASS_COUNT}/${TOTAL} (${PCT}%) | PASS=${PASS_COUNT} FAIL=${FAIL_COUNT}"
 
       - name: Tear down cluster
         if: always()

--- a/.specify/specs/issue-839/spec.md
+++ b/.specify/specs/issue-839/spec.md
@@ -1,0 +1,24 @@
+# Spec: PDCA anchor score comment
+
+## Design reference
+- **Design doc**: N/A — infrastructure change with no user-visible behavior
+- **Issue**: #839
+
+## Zone 1 — Obligations
+
+1. After each PDCA run, the workflow MUST post a structured comment to Issue #1 in the format:
+   `[ANCHOR | kardinal-promoter | DATE] coverage: N/M (X%) | PASS=A FAIL=B`
+   where N = scenarios passed, M = total scenarios run, X = percentage, A = pass count, B = fail count.
+2. The anchor comment MUST be a separate `gh issue comment` call after the main PDCA evidence comment.
+3. DATE MUST be UTC format `YYYY-MM-DD`.
+4. The anchor comment MUST be posted even if some scenarios fail (step runs with `if: always()`).
+
+## Zone 2 — Implementer's judgment
+
+- Percentage is integer (floor division).
+- The main PDCA evidence comment format is unchanged.
+
+## Zone 3 — Scoped out
+
+- Changing the set of scenarios (tracked in #841–843).
+- Parsing historical anchor comments.


### PR DESCRIPTION
## Summary

Add structured anchor score comment to PDCA workflow, posted to Issue #1 after each run.

Format: `[ANCHOR | kardinal-promoter | DATE] coverage: N/M (X%) | PASS=A FAIL=B`

## Design doc

N/A — infrastructure change with no user-visible behavior.

## Changes

- `.github/workflows/pdca.yml`: add anchor score comment step after PDCA evidence post

Closes #839