### PR TITLE
feat(pdca): Scenario 7 — config-only promotion (kardinal apply, no image change)

### DIFF
--- a/.github/workflows/pdca.yml
+++ b/.github/workflows/pdca.yml
@@ -228,6 +228,20 @@ jobs:
             RESULTS="$RESULTS\n⚠️ S6: Concurrent bundles — output: $OUTPUT (supersession timing)"
           fi
 
+          # Scenario 7: Config-only promotion (no image change)
+          echo "=== Scenario 7: Config-only promotion ==="
+          CONFIG_OUTPUT=$(kardinal create bundle kardinal-test-app --type config 2>&1 || true)
+          echo "S7 create output: $CONFIG_OUTPUT"
+          if echo "$CONFIG_OUTPUT" | grep -q "Bundle\|bundle\|created"; then
+            echo "S7: PASS — config bundle created"
+            PASS=$((PASS+1))
+            RESULTS="$RESULTS\n✅ S7: Config-only promotion — bundle created without image"
+          else
+            echo "S7: FAIL — unexpected output: $CONFIG_OUTPUT"
+            FAIL=$((FAIL+1))
+            RESULTS="$RESULTS\n❌ S7: Config-only promotion — expected Bundle created; got: $CONFIG_OUTPUT"
+          fi
+
           echo "PASS=$PASS" >> $GITHUB_OUTPUT
           echo "FAIL=$FAIL" >> $GITHUB_OUTPUT
           # Write results to file for next step

--- a/.specify/specs/issue-841/spec.md
+++ b/.specify/specs/issue-841/spec.md
@@ -1,0 +1,22 @@
+# Spec: PDCA Scenario 7 — config-only promotion
+
+## Design reference
+- **Design doc**: N/A — infrastructure change with no user-visible behavior
+- **Issue**: #841
+
+## Zone 1 — Obligations
+
+1. The PDCA workflow MUST include a Scenario 7 step after Scenario 6.
+2. Scenario 7 MUST test `kardinal create bundle <pipeline> --type config` (no `--image` flag).
+3. Scenario 7 MUST PASS when the command output contains "Bundle" or "bundle" or "created".
+4. Scenario 7 MUST FAIL (increment FAIL counter) when the command returns an error without creating a bundle.
+
+## Zone 2 — Implementer's judgment
+
+- Config bundle creation with no gitCommit field is a valid no-artifact config promotion.
+- The test does not wait for pipeline progression (config-merge step may not have git state to act on).
+
+## Zone 3 — Scoped out
+
+- Testing the full config-merge step execution (requires a configured config source).
+- Testing `--git-commit` flag (not yet implemented in CLI).


### PR DESCRIPTION
## Summary

Add PDCA Scenario 7: config-only promotion test using `kardinal create bundle --type config` without any `--image` flag.

Verifies that a config bundle can be created and accepted by the controller without an image change.

## Design doc

N/A — infrastructure change with no user-visible behavior.

## Changes

- `.github/workflows/pdca.yml`: add Scenario 7 after Scenario 6

Closes #841