### PR TITLE
fix(ci): replace heredoc with printf in pdca.yml scenario 9

### DIFF
--- a/.github/workflows/pdca.yml
+++ b/.github/workflows/pdca.yml
@@ -279,35 +279,35 @@ jobs:
           kubectl create deployment s9-test-app --image=nginx:alpine -n s9-health-test --dry-run=client -o yaml \
             | kubectl apply -f -
           kubectl scale deployment s9-test-app --replicas=0 -n s9-health-test || true
-          # Apply a minimal pipeline with resource health check
-          cat <<'PEOF' | kubectl apply -f -
-          apiVersion: kardinal.io/v1alpha1
-          kind: Pipeline
-          metadata:
-            name: s9-health-test
-            namespace: default
-          spec:
-            git:
-              url: https://github.com/pnz1990/kardinal-demo
-              branch: main
-              layout: directory
-              provider: github
-              secretRef:
-                name: github-token
-            environments:
-              - name: test
-                path: environments/test
-                update:
-                  strategy: kustomize
-                approval: auto
-                health:
-                  type: resource
-                  timeout: 30s
-                  resource:
-                    kind: Deployment
-                    name: s9-test-app
-                    namespace: s9-health-test
-PEOF
+          # Apply a minimal pipeline with resource health check (using printf to avoid heredoc column-0 YAML issues)
+          printf '%s\n' \
+            'apiVersion: kardinal.io/v1alpha1' \
+            'kind: Pipeline' \
+            'metadata:' \
+            '  name: s9-health-test' \
+            '  namespace: default' \
+            'spec:' \
+            '  git:' \
+            '    url: https://github.com/pnz1990/kardinal-demo' \
+            '    branch: main' \
+            '    layout: directory' \
+            '    provider: github' \
+            '    secretRef:' \
+            '      name: github-token' \
+            '  environments:' \
+            '  - name: test' \
+            '    path: environments/test' \
+            '    update:' \
+            '      strategy: kustomize' \
+            '    approval: auto' \
+            '    health:' \
+            '      type: resource' \
+            '      timeout: 30s' \
+            '      resource:' \
+            '        kind: Deployment' \
+            '        name: s9-test-app' \
+            '        namespace: s9-health-test' \
+            | kubectl apply -f -
           sleep 5
           S9_BUNDLE_OUTPUT=$(kardinal create bundle s9-health-test --image "ghcr.io/pnz1990/kardinal-test-app:sha-aaa0001" 2>&1 || true)
           echo "S9 bundle output: $S9_BUNDLE_OUTPUT"


### PR DESCRIPTION
## Summary

- **Root cause**: `PEOF` heredoc terminator at column 0 (line 310) was parsed as a YAML key by the workflow parser, causing `pdca.yml` to fail with `could not find expected ':'`.
- **Fix**: Replace `cat <<'PEOF' | kubectl apply -f -` with `printf '%s\n' ... | kubectl apply -f -` which produces equivalent output without a bare identifier at column 0.
- **Scope**: Only scenario 9 (health check failure) was affected.

## Design doc

N/A — infrastructure change with no user-visible behavior.

## Verification

YAML parses cleanly: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pdca.yml'))" && echo OK`