### PR TITLE
chore(ci): reduce scheduled cadence from 1h to 6h (steady-state)

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -2,10 +2,8 @@ name: otherness scheduled run
 
 # ── SECURITY HARDENED — see docs/design/27-security-model.md ─────────────────
 #
-# ⚠️  CRON IS LOCKED TO HOURLY. DO NOT CHANGE TO */6 OR ANY SLOWER CADENCE.
-# Hourly runs are required to make progress on the backlog. Slower cadence
-# means the agent ships 1/6th as much work. The vision requires the loop to
-# run continuously. If you need to pause, disable the workflow — do not slow it.
+# Cadence: every 6 hours (steady-state). All 7 journeys pass, queue is empty.
+# When active backlog work resumes, change back to hourly (0 * * * *).
 #
 # Security controls applied:
 #   M1: All action dependencies pinned to SHAs (no @latest, no @vN tags)
@@ -15,7 +13,7 @@ name: otherness scheduled run
 #
 on:
   schedule:
-    - cron: "0 * * * *"   # HOURLY — DO NOT CHANGE. See comment above.
+    - cron: "0 */6 * * *"   # Every 6 hours — steady-state standby cadence.
   workflow_dispatch:        # manual trigger for immediate runs and testing
 
 # ── Concurrency: cancel in-progress runs when a new one starts ────────────────

--- a/.specify/specs/833/spec.md
+++ b/.specify/specs/833/spec.md
@@ -1,0 +1,19 @@
+# Spec: chore(ci): reduce scheduled cadence to 6h (issue #833)
+
+## Design reference
+- N/A — infrastructure change with no user-visible behavior
+
+## Zone 1 — Obligations
+
+- O1: `.github/workflows/otherness-scheduled.yml` cron schedule changes from `0 * * * *` (hourly) to `0 */6 * * *` (every 6 hours).
+- O2: The locked-cron comment block (lines 4-8) is updated to reflect the new steady-state cadence and remove the "DO NOT CHANGE" warning.
+- O3: No functional behavior changes — only the schedule frequency changes.
+
+## Zone 2 — Implementer's judgment
+
+- The comment update should explain WHY the cadence is now 6h (project in steady-state, all journeys passing, queue empty).
+
+## Zone 3 — Scoped out
+
+- otherness-config.yaml does not have a cron field — no change needed there.
+- No logic changes to the agent itself.


### PR DESCRIPTION
## Summary

- All 7 journeys pass, queue is empty — project is in steady-state standby.
- Reduces the scheduled agent run from hourly to every 6 hours.
- Reduces Bedrock token spend by ~6x while maintaining continuous loop operation.
- The comment block is updated to reflect the new standby cadence and document how to revert when new backlog opens.

## Changes

- `.github/workflows/otherness-scheduled.yml`: cron `0 * * * *` → `0 */6 * * *`, comment updated

## Design doc

N/A — infrastructure change with no user-visible behavior.

Closes #833.