### PR TITLE
feat(ci): add OAuth scope check to GH_TOKEN preflight

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -65,7 +65,7 @@ jobs:
 
       # ── Step 2: Token preflight ──────────────────────────────────────────
       # Validates GH_TOKEN before spending Bedrock tokens on a run that will fail.
-      # Posts a [NEEDS HUMAN] issue if the token is missing or expired.
+      # Posts a [NEEDS HUMAN] issue if the token is missing, expired, or lacks scopes.
       - name: Validate GH_TOKEN
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -88,7 +88,28 @@ jobs:
               --label "needs-human" 2>/dev/null || true
             exit 1
           fi
-          echo "[preflight] GH_TOKEN valid for: $(GH_TOKEN="$GH_TOKEN" gh api user --jq '.login')"
+          # Check OAuth scopes: GH_TOKEN must have repo + workflow scopes.
+          # gh api /user -i returns response headers; X-OAuth-Scopes lists granted scopes.
+          SCOPES=$(GH_TOKEN="$GH_TOKEN" gh api /user -i 2>/dev/null \
+            | grep -i '^x-oauth-scopes:' | head -1 || true)
+          echo "[preflight] OAuth scopes header: $SCOPES"
+          MISSING=""
+          echo "$SCOPES" | grep -qi '\brepo\b' || MISSING="${MISSING}repo "
+          echo "$SCOPES" | grep -qi '\bworkflow\b' || MISSING="${MISSING}workflow "
+          if [ -n "$MISSING" ]; then
+            echo "::error::GH_TOKEN is missing required OAuth scopes: $MISSING"
+            EXISTING=$(GH_TOKEN="" gh issue list --repo "$REPO" --state open \
+              --search "[NEEDS HUMAN] GH_TOKEN expired or missing scopes" \
+              --json number --jq 'length' 2>/dev/null || echo "0")
+            if [ "${EXISTING:-0}" -eq 0 ]; then
+              GH_TOKEN="" gh issue create --repo "$REPO" \
+                --title "[NEEDS HUMAN] GH_TOKEN expired or missing scopes — scheduled run blocked" \
+                --body "The otherness scheduled workflow detected that GH_TOKEN is missing required scopes ($MISSING). Generate a new PAT at https://github.com/settings/tokens with repo + workflow scopes, then run: echo NEW_TOKEN | gh secret set GH_TOKEN --repo $REPO" \
+                --label "needs-human" 2>/dev/null || true
+            fi
+            exit 1
+          fi
+          echo "[preflight] GH_TOKEN valid for: $(GH_TOKEN="$GH_TOKEN" gh api user --jq '.login') — scopes OK (repo + workflow)"
 
       # ── Step 3: Install agent files ──────────────────────────────────────
       # Clones pnz1990/otherness to ~/.otherness on the runner.

--- a/.specify/specs/832/spec.md
+++ b/.specify/specs/832/spec.md
@@ -1,0 +1,24 @@
+# Spec: feat(ci): GH_TOKEN scope preflight (issue #832)
+
+## Design reference
+- **Design doc**: `docs/design/13-scheduled-execution.md`
+- **Section**: `§ Future` (was ✅ Present in PR #836, then removed by PR #845 which rewrote the workflow)
+- **Implements**: Token expiry/scope preflight (🔲 → ✅)
+
+## Zone 1 — Obligations
+
+- O1: The `Validate GH_TOKEN` step in `otherness-scheduled.yml` must check that the token has `repo` and `workflow` OAuth scopes via `X-OAuth-Scopes` header.
+- O2: If scopes are missing, the step must post a `[NEEDS HUMAN]` issue using GITHUB_TOKEN (not GH_TOKEN) and exit 1.
+- O3: The scope check must NOT break the workflow when the token has the correct scopes (exit 0).
+- O4: Must not touch GITHUB_TOKEN or OIDC/AWS credentials (O1 from issue #832).
+- O5: Duplicate issue prevention — check for existing open `[NEEDS HUMAN] GH_TOKEN` issue before creating.
+
+## Zone 2 — Implementer's judgment
+
+- Enhance the existing `Validate GH_TOKEN` step (line 69) to add scope checking after the token validity check.
+- Use `gh api /user -i` to get headers and grep for scopes.
+
+## Zone 3 — Scoped out
+
+- No change to OIDC or AWS credentials.
+- No change to GITHUB_TOKEN handling.

--- a/docs/design/13-scheduled-execution.md
+++ b/docs/design/13-scheduled-execution.md
@@ -116,7 +116,7 @@ If secrets expire or need rotation:
 - ✅ `GH_TOKEN` secret set — PAT with `repo` + `workflow` scopes (2026-04-19)
 - ✅ `otherness-config.yaml` `schedule.cron` field — `0 * * * *` (existing)
 - ✅ Cadence reduced to `0 */6 * * *` (every 6h) — all 7 journeys passing, steady-state standby (PR #834, 2026-04-19)
-- ✅ Token expiry preflight step — `Verify GH_TOKEN scopes` step before `Run otherness`; posts `[NEEDS HUMAN]` issue on expired/missing-scope token (PR #836, 2026-04-19)
+- ✅ Token expiry and scope preflight step — `Validate GH_TOKEN` step checks token validity AND `repo`/`workflow` OAuth scopes via `X-OAuth-Scopes` header; posts `[NEEDS HUMAN]` issue on expired/missing-scope token (PR #836 added, PR #845 removed in rewrite, re-added PR #862, 2026-04-20)
 
 ## Future (🔲)
 


### PR DESCRIPTION
## Summary

The `Validate GH_TOKEN` step previously checked token validity (is the token set, can it make API calls) but NOT OAuth scopes. PR #836 added scope checking via `X-OAuth-Scopes` header, but PR #845 (security hardening rewrite) removed it.

This re-adds the check:
1. After verifying the token authenticates successfully via `gh api user`
2. Calls `gh api /user -i` to get response headers
3. Greps for `repo` and `workflow` in the `X-OAuth-Scopes` header
4. Missing scopes → post `[NEEDS HUMAN]` issue (dedup check first) + `exit 1`
5. Correct scopes → continue

## Design doc

Updated `docs/design/13-scheduled-execution.md`: scope check history corrected (PR #836 added, PR #845 removed in rewrite, this PR re-adds).

Closes #832.