### PR TITLE
fix(ci): add no-op job to prevent false failure on push events

### DIFF
--- a/.github/workflows/otherness-security-checks.yml
+++ b/.github/workflows/otherness-security-checks.yml
@@ -11,6 +11,18 @@ on:
     types: [labeled]
 
 jobs:
+  # ── No-op: handle push/other events gracefully ────────────────────────────
+  # GitHub evaluates all workflow files on every push to the default branch.
+  # When no jobs match (all have if: conditions for pull_request/issues),
+  # GitHub reports the run as failed. This no-op job runs on push to prevent
+  # that false failure while keeping security checks scoped to their events.
+  noop:
+    name: no-op (push/other events)
+    if: github.event_name != 'pull_request' && github.event_name != 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Security checks only run on pull_request and issues events."
+
   # ── M8: AGENTS.md change detection ────────────────────────────────────────
   agents-md-guard:
     name: M8 — AGENTS.md security check


### PR DESCRIPTION
## Summary

- Fixes the `otherness-security-checks.yml` workflow failing on every push to main

## Root cause

GitHub evaluates all workflow files on every push to the default branch. When all jobs have `if:` conditions scoped to `pull_request`/`issues` events, the run produces 0 jobs and GitHub reports it as failed with 'This run likely failed because of a workflow file issue'.

## Fix

Add a no-op job that runs on push/other events with a simple `echo` step. The security checks (M8/M10) are unaffected — they still only run for `pull_request` and `issues` events respectively.

## Design doc

- N/A — infrastructure change with no user-visible behavior change

## Testing

The noop job will run on the next push to main and should report success.