### PR TITLE
fix(ci): explicitly add push trigger to security workflow

### DIFF
--- a/.github/workflows/otherness-security-checks.yml
+++ b/.github/workflows/otherness-security-checks.yml
@@ -5,20 +5,20 @@ name: otherness security checks
 #   M10: otherness label restriction — prevent external queue injection
 
 on:
+  push:
+    branches: [main, "feat/**", "fix/**"]
   pull_request:
     types: [opened, synchronize, reopened]
   issues:
     types: [labeled]
 
 jobs:
-  # ── No-op: handle push/other events gracefully ────────────────────────────
-  # GitHub evaluates all workflow files on every push to the default branch.
-  # When no jobs match (all have if: conditions for pull_request/issues),
-  # GitHub reports the run as failed. This no-op job runs on push to prevent
-  # that false failure while keeping security checks scoped to their events.
+  # ── No-op: handle push events gracefully ─────────────────────────────────
+  # Security checks only apply on pull_request (M8) and issues (M10) events.
+  # This no-op job runs on push so GitHub doesn't report a failed 0-job run.
   noop:
-    name: no-op (push/other events)
-    if: github.event_name != 'pull_request' && github.event_name != 'issues'
+    name: no-op (push — security checks are PR/issue only)
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - run: echo "Security checks only run on pull_request and issues events."

--- a/docs/design/13-scheduled-execution.md
+++ b/docs/design/13-scheduled-execution.md
@@ -109,7 +109,7 @@ If secrets expire or need rotation:
 
 ## Present (✅)
 
-- ✅ `.github/workflows/otherness-scheduled.yml` — 6-hourly cron (`0 */6 * * *`) + workflow_dispatch; Bedrock via OIDC; GH_TOKEN PAT; five job permissions (id-token, contents, pull-requests, issues, statuses) (PR #828, #834, 2026-04-19)
+- ✅ `.github/workflows/otherness-scheduled.yml` — 6-hourly cron (`0 */6 * * *`) + workflow_dispatch; Bedrock via OIDC; GH_TOKEN PAT; five job permissions (id-token, contents, pull-requests, issues, statuses) (PR #828, #834, 2026-04-19) ⚠️ Stale — referenced file not found
 - ✅ `AWS_ROLE_ARN` secret set — `arn:aws:iam::569190534191:role/github-bedrock-key` (2026-04-19)
 - ✅ `AWS_ACCOUNT_ID` secret set — `569190534191` (2026-04-19)
 - ✅ `AWS_DEFAULT_REGION` secret set — `us-east-1` (2026-04-19)


### PR DESCRIPTION
## Summary

- Fixes the persistent false failure of `otherness-security-checks.yml` on every push to main
- Follow-up to PR #869 which used the wrong approach

## Root cause

PR #869 added a no-op job with `if: github.event_name != 'pull_request' && ...` but GitHub was still reporting the workflow as failed (0 jobs). 

The actual fix: **GitHub only triggers a workflow on push if the workflow explicitly declares `push` in its `on:` section**. Previously the workflow only had `pull_request` and `issues` triggers, so GitHub was trying to evaluate it for push via workflow-change discovery and finding 0 runnable jobs.

## Fix

1. Add `push` to the workflow's `on:` triggers (scoped to `main`, `feat/**`, `fix/**`)
2. Add a no-op job with `if: github.event_name == 'push'` — runs successfully and exits 0

Security checks (M8/M10) are unchanged — they still only run for `pull_request` and `issues` events.

## Design doc

- N/A — infrastructure change with no user-visible behavior change