### PR TITLE
chore(config): hourly cron + session_item_limit 5 — v0.6.0 work queued

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -13,7 +13,7 @@ name: otherness scheduled run
 #
 on:
   schedule:
-    - cron: "0 */6 * * *"   # Every 6 hours — steady-state standby cadence.
+    - cron: "0 * * * *"     # HOURLY — active development (v0.6.0 work queued).
   workflow_dispatch:        # manual trigger for immediate runs and testing
 
 # ── Concurrency: cancel in-progress runs when a new one starts ────────────────

--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -22,7 +22,7 @@ maqa:
 
   # Max items to complete per session before SM/PM gate fires.
   # See docs/design/21-session-throughput.md (otherness repo).
-  session_item_limit: 10
+  session_item_limit: 5    # 5 items ~50min, fits hourly window
 
   # Executive project status update to GitHub Projects board every N cycles.
   # Only the unbounded standalone posts these. 0 = disabled.


### PR DESCRIPTION
6h cadence was set for steady-state standby. Design doc 14 has 8 v0.6.0 items. Run hourly at limit 5 (~50min sessions).