### PR TITLE
feat(agent): add kardinal-agent binary for spoke-cluster distributed mode (14.5)

### DIFF
--- a/.specify/specs/issue-14-5-kardinal-agent/spec.md
+++ b/.specify/specs/issue-14-5-kardinal-agent/spec.md
@@ -1,0 +1,70 @@
+# Spec: kardinal-agent binary (item 14.5)
+
+## Design reference
+- **Design doc**: `docs/design/07-distributed-architecture.md`
+- **Section**: `§ Binaries — kardinal-agent (per shard)`
+- **Implements**: 14.5 — kardinal-agent binary: separate `cmd/kardinal-agent/` entry point for
+  spoke-cluster distributed mode; reads shard assignments, runs PromotionStep reconciler only.
+
+---
+
+## Zone 1 — Obligations
+
+**O1 — `cmd/kardinal-agent/main.go` exists and compiles.**
+`go build ./cmd/kardinal-agent/` must succeed with zero errors.
+
+**O2 — The agent registers only the PromotionStep reconciler.**
+The agent must NOT register: BundleReconciler, PipelineReconciler, PolicyGateReconciler,
+MetricCheckReconciler, PRStatusReconciler, RollbackPolicyReconciler, ScheduleClockReconciler,
+SubscriptionReconciler. Each of these is a control-plane concern.
+
+**O3 — The `--shard` flag is required.**
+If `--shard` is empty (or `KARDINAL_SHARD` env var unset), the agent must log a fatal error
+and exit with code 1. An agent without a shard label would compete with the controller for
+all PromotionSteps — this is invalid configuration.
+
+**O4 — The PromotionStep reconciler receives the shard value.**
+`psreconciler.Reconciler.Shard` must be set to the `--shard` flag value, which causes it
+to filter to only PromotionSteps with matching `kardinal.io/shard` label.
+
+**O5 — The agent does NOT embed the UI, webhook server, or bundle API.**
+None of the HTTP servers from `cmd/kardinal-controller/` appear in `cmd/kardinal-agent/`.
+
+**O6 — The agent does NOT import `web` package or `web/embed.go`.**
+That package embeds the compiled React assets. The agent binary must stay small.
+
+**O7 — `make build` includes the agent binary.**
+Makefile must have a `build-agent` target and `build` must depend on it.
+`BINARY_AGENT = bin/kardinal-agent` defined in Makefile.
+
+**O8 — The design doc is updated.**
+`docs/design/14-v060-roadmap.md` item 14.5 is moved from 🔲 Future to ✅ Present.
+`docs/design/07-distributed-architecture.md` §Present section updated.
+
+**O9 — Tests: at least one table-driven test for the agent's shard requirement.**
+`cmd/kardinal-agent/main_test.go` must exist with a test that verifies the shard=empty
+fatal-exit behavior (tested via integration or by testing the validation function, not
+the binary startup itself — we test the pure validation function, not flag parsing).
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- The agent shares the scheme setup (kardinalv1alpha1 + clientgoscheme) with the controller.
+- SCM credentials (--github-token) are still needed: PromotionStep reconciler opens PRs.
+- Metrics and health probe ports default to different values than the controller
+  (`:8085` and `:8086`) to allow co-location on the same node during testing.
+- Leader election is optional (default off for agent — only one agent per shard).
+- The agent logs `[kardinal-agent]` in startup messages to distinguish from controller logs.
+
+---
+
+## Zone 3 — Scoped out
+
+- The agent does NOT implement shard auto-discovery or label watching.
+  Shard assignment is via `--shard` flag or `KARDINAL_SHARD` env var (already in controller).
+- Health adapter HTTP calls are NOT moved into the agent in this PR.
+  The existing PromotionStepReconciler already handles them; the agent just re-uses the same code.
+- Helm chart changes for a separate agent Deployment are scoped out.
+  The Helm chart is a separate PR (tracked in docs/design/07).
+- The agent Dockerfile is scoped out — tracked as a follow-up.

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,14 @@ LOCALBIN               ?= $(shell pwd)/bin
 # Build
 BINARY_CONTROLLER = bin/kardinal-controller
 BINARY_CLI        = bin/kardinal
+BINARY_AGENT      = bin/kardinal-agent
 GO                = go
 GOPROXY          ?= https://proxy.golang.org
 
 # Docker image
 IMG ?= kardinal-promoter:dev
 
-.PHONY: all build build-controller build-cli ui ui-test ui-test-e2e test test-integration lint vet generate manifests \
+.PHONY: all build build-controller build-cli build-agent ui ui-test ui-test-e2e test test-integration lint vet generate manifests \
         install uninstall docker-build helm-lint \
         install-krocodile \
         test-e2e test-e2e-journey-1 test-e2e-journey-2 test-e2e-journey-3 \
@@ -26,13 +27,16 @@ IMG ?= kardinal-promoter:dev
 all: generate build test lint
 
 ## Build
-build: build-controller build-cli
+build: build-controller build-cli build-agent
 
 build-controller:
 	$(GO) build -o $(BINARY_CONTROLLER) ./cmd/kardinal-controller/
 
 build-cli:
 	$(GO) build -o $(BINARY_CLI) ./cmd/kardinal/
+
+build-agent:
+	$(GO) build -o $(BINARY_AGENT) ./cmd/kardinal-agent/
 
 ## UI
 ui: ## Build the embedded React UI (requires Node.js and npm)

--- a/cmd/kardinal-agent/main.go
+++ b/cmd/kardinal-agent/main.go
@@ -1,0 +1,205 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main is the entry point for the kardinal-agent binary.
+//
+// kardinal-agent runs in a spoke (workload) cluster and handles PromotionSteps
+// that carry a matching `kardinal.io/shard` label. The control-plane
+// kardinal-controller assigns shard labels during Pipeline-to-Graph translation;
+// the agent uses them to claim only its own work.
+//
+// The agent is intentionally minimal:
+//   - Only the PromotionStep reconciler is registered.
+//   - No Bundle, Pipeline, PolicyGate, or UI components.
+//   - SCM credentials are read from the local cluster (not the control plane).
+//
+// See docs/design/07-distributed-architecture.md for the full architecture.
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/rs/zerolog"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	czap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	kardinalv1alpha1 "github.com/kardinal-promoter/kardinal-promoter/api/v1alpha1"
+	healthpkg "github.com/kardinal-promoter/kardinal-promoter/pkg/health"
+	psreconciler "github.com/kardinal-promoter/kardinal-promoter/pkg/reconciler/promotionstep"
+	"github.com/kardinal-promoter/kardinal-promoter/pkg/scm"
+
+	// Import built-in steps to register them via init().
+	_ "github.com/kardinal-promoter/kardinal-promoter/pkg/steps/steps"
+)
+
+// AgentVersion is the agent version string, overridable at build time via ldflags.
+//
+//nolint:gochecknoglobals // Build-time constant, analogous to ControllerVersion in kardinal-controller.
+var AgentVersion = "v0.1.0-dev"
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kardinalv1alpha1.AddToScheme(scheme))
+}
+
+func main() {
+	var (
+		shard                  string
+		zerologLevel           string
+		metricsBindAddress     string
+		healthProbeBindAddress string
+		leaderElect            bool
+		githubToken            string
+		scmProviderType        string
+		scmAPIURL              string
+		webhookSecret          string
+	)
+
+	flag.StringVar(&shard, "shard", os.Getenv("KARDINAL_SHARD"),
+		"[Required] Shard name for this agent. The agent only processes PromotionSteps "+
+			"with kardinal.io/shard=<shard>. Must not be empty.")
+	flag.StringVar(&zerologLevel, "log-level", "info",
+		"Log level for zerolog. One of: debug, info, warn, error.")
+	flag.StringVar(&metricsBindAddress, "metrics-bind-address", ":8085",
+		"The address the metric endpoint binds to. Defaults to :8085 to avoid "+
+			"port collision with kardinal-controller (:8080) during co-location testing.")
+	flag.StringVar(&healthProbeBindAddress, "health-probe-bind-address", ":8086",
+		"The address the health probe endpoint binds to. Defaults to :8086 to avoid "+
+			"port collision with kardinal-controller (:8081) during co-location testing.")
+	flag.BoolVar(&leaderElect, "leader-elect", false,
+		"Enable leader election for the agent. Typically not needed — one agent per shard.")
+	flag.StringVar(&githubToken, "github-token", os.Getenv("GITHUB_TOKEN"),
+		"SCM token for API operations (GitHub PAT or GitLab private token). "+
+			"Stored in the spoke cluster, not the control plane.")
+	flag.StringVar(&scmProviderType, "scm-provider", os.Getenv("KARDINAL_SCM_PROVIDER"),
+		"SCM provider type: \"github\" (default) or \"gitlab\".")
+	flag.StringVar(&scmAPIURL, "scm-api-url", os.Getenv("KARDINAL_SCM_API_URL"),
+		"SCM API base URL override (e.g. for GitHub Enterprise or self-managed GitLab).")
+	flag.StringVar(&webhookSecret, "webhook-secret", os.Getenv("KARDINAL_WEBHOOK_SECRET"),
+		"Webhook secret — unused by the agent but accepted to allow identical env injection with the controller.")
+
+	opts := czap.Options{Development: false}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	// Configure zerolog level.
+	level, err := zerolog.ParseLevel(zerologLevel)
+	if err != nil {
+		level = zerolog.InfoLevel
+	}
+	zerolog.SetGlobalLevel(level)
+	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
+
+	// O3: shard is required. An agent without a shard would compete with the controller.
+	if err := validateShard(shard); err != nil {
+		logger.Fatal().Err(err).Msg("[kardinal-agent] --shard is required for distributed mode")
+	}
+
+	logger.Info().
+		Str("shard", shard).
+		Str("version", AgentVersion).
+		Msg("[kardinal-agent] starting")
+
+	ctrl.SetLogger(czap.New(czap.UseFlagOptions(&opts)))
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: metricsBindAddress,
+		},
+		HealthProbeBindAddress: healthProbeBindAddress,
+		LeaderElection:         leaderElect,
+		LeaderElectionID:       "kardinal-agent-" + shard,
+	})
+	if err != nil {
+		logger.Fatal().Err(err).Msg("[kardinal-agent] unable to create manager")
+	}
+
+	// SCM provider — same as controller but credentials come from the spoke cluster.
+	scmProvider, err := scm.NewProvider(scmProviderType, githubToken, scmAPIURL, webhookSecret)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("[kardinal-agent] unable to create SCM provider")
+	}
+	gitClient := scm.NewGoGitClient()
+
+	// O4: Only register the PromotionStep reconciler, with the shard value.
+	if err := (&psreconciler.Reconciler{
+		Client:         mgr.GetClient(),
+		SCM:            scmProvider,
+		GitClient:      gitClient,
+		HealthDetector: newHealthDetector(mgr.GetConfig(), mgr.GetClient(), logger),
+		Shard:          shard,
+	}).SetupWithManager(mgr); err != nil {
+		logger.Fatal().Err(err).Msg("[kardinal-agent] unable to set up PromotionStepReconciler")
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		logger.Fatal().Err(err).Msg("[kardinal-agent] unable to set up health check")
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		logger.Fatal().Err(err).Msg("[kardinal-agent] unable to set up ready check")
+	}
+
+	logger.Info().
+		Str("shard", shard).
+		Str("metrics", metricsBindAddress).
+		Str("health", healthProbeBindAddress).
+		Msg("[kardinal-agent] manager started — watching PromotionSteps for shard")
+
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		logger.Fatal().Err(err).Msg("[kardinal-agent] problem running manager")
+	}
+}
+
+// validateShard returns an error if shard is empty or whitespace-only.
+// This is a separate function so it can be unit-tested without starting the manager.
+func validateShard(shard string) error {
+	if len(shard) == 0 {
+		return errShardRequired
+	}
+	for _, r := range shard {
+		if r != ' ' && r != '\t' {
+			return nil
+		}
+	}
+	return errShardRequired
+}
+
+// errShardRequired is returned when --shard is not provided.
+var errShardRequired = shardError("--shard is required: the agent must have a shard name to filter PromotionSteps")
+
+type shardError string
+
+func (e shardError) Error() string { return string(e) }
+
+// newHealthDetector constructs an AutoDetector for health checking using dynamic client.
+func newHealthDetector(cfg *rest.Config, k8s sigs_client.Client, log zerolog.Logger) *healthpkg.AutoDetector {
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		log.Fatal().Err(err).Msg("[kardinal-agent] unable to create dynamic client for health detection")
+	}
+	return healthpkg.NewAutoDetector(k8s, dynClient)
+}

--- a/cmd/kardinal-agent/main_test.go
+++ b/cmd/kardinal-agent/main_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The kardinal-promoter Authors.
+// Licensed under the Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestValidateShard verifies that an empty shard returns an error and a non-empty
+// shard returns nil.
+//
+// Design ref: docs/design/07-distributed-architecture.md §Agent filtering
+// Spec O3: --shard is required; empty shard must return an error.
+func TestValidateShard(t *testing.T) {
+	tests := []struct {
+		name    string
+		shard   string
+		wantErr bool
+	}{
+		{
+			name:    "empty shard returns error",
+			shard:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only shard returns error",
+			shard:   "   ",
+			wantErr: true,
+		},
+		{
+			name:    "valid shard returns nil",
+			shard:   "eu-cluster",
+			wantErr: false,
+		},
+		{
+			name:    "shard with hyphens is valid",
+			shard:   "prod-us-east-1",
+			wantErr: false,
+		},
+		{
+			name:    "single character shard is valid",
+			shard:   "a",
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateShard(tc.shard)
+			if tc.wantErr {
+				assert.Error(t, err, "expected error for shard %q", tc.shard)
+			} else {
+				assert.NoError(t, err, "expected no error for shard %q", tc.shard)
+			}
+		})
+	}
+}
+
+// TestErrShardRequired verifies the error message is informative.
+func TestErrShardRequired(t *testing.T) {
+	err := validateShard("")
+	assert.Contains(t, err.Error(), "--shard is required")
+}


### PR DESCRIPTION
## Summary

Implements design doc 07 (distributed architecture) item 14.5: a separate `cmd/kardinal-agent/` binary for spoke-cluster distributed mode.

The agent runs in a workload cluster and reconciles only PromotionSteps with a matching `kardinal.io/shard` label. All control-plane concerns (Bundle lifecycle, PolicyGate evaluation, UI, webhook server) remain in `kardinal-controller`.

## What changed

- **`cmd/kardinal-agent/main.go`** — new binary entry point. Registers only `PromotionStepReconciler`. Requires `--shard` flag (or `KARDINAL_SHARD` env var).
- **`cmd/kardinal-agent/main_test.go`** — table-driven tests for `validateShard()` (empty/whitespace/valid cases).
- **`Makefile`** — added `BINARY_AGENT`, `build-agent` target, and `build-agent` to the `build` dependency.
- **`.specify/specs/issue-14-5-kardinal-agent/spec.md`** — three-zone spec for this item.

## Design doc

References `docs/design/07-distributed-architecture.md` §Binaries. The 🔲 14.5 item in `docs/design/14-v060-roadmap.md` is tracked for update in a follow-up PR (this session is CODE zone only; doc updates require a separate session per the D4 gate in `standalone.md`).

## QA checklist

- [x] No new logic leaks: `validateShard()` is pure; `newHealthDetector` delegates to existing `AutoDetector`
- [x] `time.Now()` not introduced
- [x] No cross-CRD mutations — agent only processes PromotionSteps matching its shard
- [x] No `web` or UI package imported
- [x] No kro controller packages imported
- [x] Apache 2.0 header present
- [x] Table-driven tests with testify/assert
- [x] `go test -race` passes
- [x] `go vet ./...` passes
- [x] `make build-agent` produces `bin/kardinal-agent`
- [x] `go build ./...` succeeds (no circular deps)