### PR TITLE
fix(ci): wait for Pipeline CRD established before applying; fix Flux pipeline cluster context

### DIFF
--- a/.specify/specs/issue-891/spec.md
+++ b/.specify/specs/issue-891/spec.md
@@ -1,0 +1,25 @@
+# Spec: fix(ci): Demo E2E fails — Pipeline CRD not registered in demo cluster
+
+## Design reference
+- N/A — infrastructure fix, no user-visible behavior change
+
+## Zone 1 — Obligations
+
+**O1** — After the fix, `kubectl apply -f demo/manifests/flux/pipeline.yaml` MUST be executed with the `kind-kardinal-control` kubeconfig context active (not `kind-kardinal-dev`). Violation: `demo/scripts/setup.sh` applies the flux pipeline.yaml while the context is still set to the dev cluster.
+
+**O2** — After the fix, `demo/scripts/setup.sh` MUST wait for the Pipeline CRD to be established before applying any Pipeline resources. The wait command: `kubectl wait --for=condition=established crd/pipelines.kardinal.io --timeout=60s`. Violation: any Pipeline resource applied before this wait completes causes "no matches for kind Pipeline" errors.
+
+**O3** — All other Flux resources (`kustomizations.yaml`) MUST continue to be applied on the dev cluster. Only `pipeline.yaml` moves to the control cluster context.
+
+**O4** — The fix MUST be idempotent: running setup.sh twice must not fail.
+
+## Zone 2 — Implementer's judgment
+
+- Whether to use `--ignore-not-found=true` on the wait command (not needed — CRD is always present after Helm install)
+- The exact placement of the wait step (before Step 6 is correct per the issue description)
+
+## Zone 3 — Scoped out
+
+- Changes to validate.sh or teardown.sh
+- EKS path modifications
+- CRD installation changes

--- a/demo/scripts/setup.sh
+++ b/demo/scripts/setup.sh
@@ -384,6 +384,13 @@ success "[5/7] Test app deployed to prod cluster"
 info "[6/7] Applying pipelines and PolicyGates on control cluster..."
 kubectl config use-context "kind-${CONTROL_CLUSTER}"
 
+# Wait for Pipeline CRD to be established before applying any Pipeline resources.
+# The Helm install is async — the CRD must be fully registered before kubectl apply.
+kubectl wait --for=condition=established \
+  crd/pipelines.kardinal.io \
+  crd/policygates.kardinal.io \
+  --timeout=60s
+
 # Org-level PolicyGates (platform team owns these)
 kubectl apply -f "${DEMO_DIR}/manifests/policy-gates/"
 
@@ -430,8 +437,12 @@ if [[ "$INSTALL_FLUX" == "true" ]]; then
       --dry-run=client -o yaml | kubectl apply -f -
   fi
 
-  # Apply Flux Kustomizations
-  kubectl apply -f "${DEMO_DIR}/manifests/flux/"
+  # Apply Flux Kustomizations (on dev cluster — Kustomization resources live here)
+  kubectl apply -f "${DEMO_DIR}/manifests/flux/kustomizations.yaml"
+
+  # Apply the Flux pipeline on the control cluster (Pipeline CRD is only registered there)
+  kubectl config use-context "kind-${CONTROL_CLUSTER}"
+  kubectl apply -f "${DEMO_DIR}/manifests/flux/pipeline.yaml"
   success "[8/13] Flux installed and Kustomizations applied"
 else
   info "[8/13] Flux install skipped (INSTALL_FLUX=false)"


### PR DESCRIPTION
## Summary

Fixes two root causes of the Demo E2E validation failure (#891):

**Fix 1 — CRD registration wait:**  
Add `kubectl wait --for=condition=established` for `pipelines.kardinal.io` and `policygates.kardinal.io` CRDs before applying Pipeline resources in Step 6. The `helm upgrade --install` uses `--wait=false`, so CRDs may not yet be established when `kubectl apply` runs.

**Fix 2 — Flux pipeline cluster context:**  
In Step 8 (Flux), `kubectl apply -f demo/manifests/flux/` was applying ALL files — including `pipeline.yaml` — while the kubeconfig context was still pointing at the dev cluster. The dev cluster has no kardinal CRDs. Only `kustomizations.yaml` belongs on the dev cluster; `pipeline.yaml` (a `kardinal.io/v1alpha1/Pipeline`) must be applied on the control cluster, matching the pattern already used for Rollouts (Step 9) and Flagger (Step 10).

## Design doc
N/A — infrastructure fix, no user-visible behavior change.

## Customer doc
N/A.

Closes #891.