### PR TITLE
docs(roadmap): kardinal-agent shipped — remove Near-Term section; update design docs

### DIFF
--- a/.specify/specs/issue-888/spec.md
+++ b/.specify/specs/issue-888/spec.md
@@ -1,0 +1,27 @@
+# Spec: docs(roadmap): kardinal-agent shipped — docs drift fix
+
+## Design reference
+- N/A — documentation update only, no user-visible behavior change
+
+## Zone 1 — Obligations
+
+**O1** — `docs/roadmap.md` MUST remove the "## Near-Term (v0.9.0 — planned) / kardinal-agent standalone binary" section. That section described planned work that has shipped. Violation: any mention of kardinal-agent as planned/near-term when it's already in `cmd/kardinal-agent/`.
+
+**O2** — `docs/roadmap.md` line referencing distributed mode MUST say kardinal-agent is available (not near-term). Violation: the old text said "is near-term (#508)".
+
+**O3** — `docs/changelog.md` Unreleased→Added section MUST include a kardinal-agent entry describing the binary, its behavior, and PR #886. Violation: changelog doesn't mention kardinal-agent shipped feature.
+
+**O4** — `docs/design/14-v060-roadmap.md` MUST show all items 14.1–14.5 as ✅ Present (not 🔲 Future). Violation: any of 14.1–14.5 remaining as 🔲.
+
+**O5** — `docs/design/07-distributed-architecture.md` MUST have a ## Present section recording the kardinal-agent binary and shard routing as shipped. Violation: Present section absent.
+
+## Zone 2 — Implementer's judgment
+
+- Exact wording of changelog entry (follows existing format: bold name, dash, description, PR reference)
+- Whether to add PR references for 14.1-14.4 (they predate the current tracking; "shipped in earlier release" is sufficient)
+
+## Zone 3 — Scoped out
+
+- Changes to vision.md or roadmap.md in docs/aide/ (protected files)
+- Updating the public website directly (docs.yml deploys on push to main)
+- Adding test coverage for docs validation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`kardinal-agent` standalone binary** — separate binary for spoke-cluster distributed mode (`cmd/kardinal-agent/`); runs only the PromotionStep reconciler for a specific shard, without Bundle, Pipeline, PolicyGate, UI, or webhook components. Required flag: `--shard`. Defaults to ports :8085/:8086 to avoid collision with the controller. (#886)
 - **Shell completion** — `kardinal completion bash|zsh|fish|powershell` (#731)
 - **Color output for `kardinal explain`** — `--color` flag, auto-detected TTY; Pass=green, Block=red, Pending=yellow (#730)
 - **Dark/light mode** — system-aware theme with manual toggle in the embedded UI (#734)

--- a/docs/design/07-distributed-architecture.md
+++ b/docs/design/07-distributed-architecture.md
@@ -4,6 +4,15 @@
 > Depends on: 01-graph-integration, 03-promotionstep-reconciler
 > Blocks: nothing (additive to standalone mode)
 
+## Present
+
+- ✅ `kardinal-agent` standalone binary — `cmd/kardinal-agent/main.go` ships as a separate entry point for spoke-cluster distributed mode. Reads shard assignments via `--shard` flag, runs only the PromotionStep reconciler for matching steps. No Bundle, Pipeline, PolicyGate, UI, or webhook components. Defaults to ports :8085/:8086 to avoid collision with the controller. (PR #886, 2026-04-20)
+- ✅ Shard routing — `kardinal.io/shard` label on PromotionStep resources. Pipeline translator sets the label from `environment.shard`. Controller skips sharded steps; agent handles only matching-shard steps.
+
+## Future
+
+*(No outstanding future items in this area.)*
+
 ## Purpose
 
 This spec defines how kardinal-promoter scales to multi-cluster enterprise environments by splitting the controller into a control plane component and per-shard agents. The agent runs behind firewalls in workload clusters, connecting outbound to the control plane. The control plane retains all state and provides a single pane of glass.

--- a/docs/design/14-v060-roadmap.md
+++ b/docs/design/14-v060-roadmap.md
@@ -1,6 +1,6 @@
 # 14 — v0.6.0 Roadmap Items
 
-> Status: Active | Created: 2026-04-20
+> Status: Complete | Created: 2026-04-20 | Closed: 2026-04-20
 > Milestone: v0.6.0
 
 ---
@@ -8,24 +8,26 @@
 ## Summary
 
 This design doc tracks the concrete v0.6.0 near-term items from the vision.
-All stages 0-29 are complete. These are the next incremental improvements.
+All stages 0-29 are complete. All v0.6.0 items (14.1–14.8) are now ✅ Present.
 
 ---
 
 ## Present
 
+- ✅ 14.1 — Subscription OCI source watcher: `pkg/source/oci.go` — polls OCI registry for new image tags, creates Bundle automatically (shipped in earlier release, issue #491)
+- ✅ 14.2 — Subscription Git source watcher: `pkg/source/git.go` — watches Git repo for config changes, creates Bundle automatically (shipped in earlier release, issue #493)
+- ✅ 14.3 — Pipeline deployment metrics: `pkg/reconciler/pipeline/metrics.go` — persists `rolloutsLast30Days`, `p50CommitToProdMinutes`, `p90CommitToProdMinutes`, `autoRollbackRate` to `Pipeline.status.deploymentMetrics` (shipped in earlier release, issue #498)
+- ✅ 14.4 — ChangeWindow CEL functions: `changewindow.isAllowed()` / `changewindow.isBlocked()` implemented in `pkg/reconciler/policygate/reconciler.go` (shipped in earlier release, issue #506)
+- ✅ 14.5 — kardinal-agent binary: `cmd/kardinal-agent/main.go` — separate entry point for spoke-cluster distributed mode; reads shard assignments, runs PromotionStep reconciler only (PR #886, 2026-04-20)
 - ✅ 14.6 — PDCA: Playwright rollback button tests un-skipped — added `data-testid="node-detail"` to `NodeDetail` root element, enabling E2E Playwright test `web/test/e2e/journeys/011-rollback-button.spec.ts` Steps 2 and 3 (PR #881, 2026-04-20)
+- ✅ 14.7 — Security hardening: `trivy-fs` job added to CI — scans Go modules for HIGH/CRITICAL CVEs with `exit-code: 1`, `ignore-unfixed: true`; blocks CI on findings (PR #882, 2026-04-20)
 - ✅ 14.8 — NEEDS HUMAN resolved — security-checks workflow now succeeds on push; issue #871 closed (2026-04-20)
 
 ---
 
 ## Future
-- 🔲 14.1 — Subscription OCI source watcher: implement `pkg/subscription/oci_watcher.go` — polls OCI registry for new image tags, creates Bundle automatically (issue #491)
-- 🔲 14.2 — Subscription Git source watcher: implement `pkg/subscription/git_watcher.go` — watches Git repo for config changes, creates Bundle automatically (issue #493)
-- 🔲 14.3 — Pipeline deployment metrics: persist `time-to-production`, `rollback-rate`, `operator-interventions` to `Pipeline.status.deploymentMetrics` after each Bundle completes (issue #498)
-- 🔲 14.4 — ChangeWindow CEL functions: implement `changewindow.isAllowed()` and `changewindow.isBlocked()` as named CEL functions on the Graph environment (issue #506)
-- 🔲 14.5 — kardinal-agent binary: separate `cmd/kardinal-agent/` entry point for spoke-cluster distributed mode; reads shard assignments, runs PromotionStep reconciler only (issue #508)
-- ✅ 14.7 — Security hardening: `trivy-fs` job added to CI — scans Go modules for HIGH/CRITICAL CVEs with `exit-code: 1`, `ignore-unfixed: true`; blocks CI on findings (PR #882, 2026-04-20)
+
+*(No outstanding Future items — all v0.6.0 items are shipped.)*
 
 ---
 
@@ -33,9 +35,11 @@ All stages 0-29 are complete. These are the next incremental improvements.
 
 **O1 — Items 14.1–14.5 ship in v0.6.0 before cutting the release.**
 The release is cut via `gh release create v0.6.0` once all items here are ✅ Present.
+**STATUS: ALL COMPLETE.**
 
 **O2 — PDCA (14.6) must pass before v0.6.0 is cut.**
 The PDCA workflow is the agent's own smoke test of the product.
+**STATUS: COMPLETE.**
 
 **O3 — No new logic leaks in 14.1–14.5.**
 Graph Purity rules from docs/design/10 apply. Any new time.Now(), external HTTP call,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -104,7 +104,7 @@ All of the following are implemented and shipped:
 
 **UI** — full control plane UI: fleet health dashboard, pipeline operations view, per-stage bake countdown, bundle promotion timeline, policy gate detail panel, release efficiency metrics bar, in-UI actions (approve/pause/resume/rollback/override)
 
-**Distributed mode** — shard routing: `shard:` field on Pipeline environments routes PromotionSteps to the correct controller instance. The `kardinal-agent` standalone binary (for running in spoke clusters without inbound connectivity) is near-term (#508).
+**Distributed mode** — shard routing: `shard:` field on Pipeline environments routes PromotionSteps to the correct controller instance. The `kardinal-agent` standalone binary for spoke clusters is available (PR #886).
 
 **Multi-tenant self-service** — ApplicationSet + Pipeline template bootstrap; team onboarding by committing a folder to Git; org PolicyGates automatically inherited; namespace isolation enforced by RBAC.
 
@@ -128,15 +128,6 @@ changewindow.isBlocked("holiday-freeze")    # true when the window IS currently 
 **Shell completion** — bash, zsh, fish, and PowerShell completion via `kardinal completion <shell>`. (#606)
 
 **PrometheusRule CRD in Helm chart** — 6 pre-built alerting rules: promotion stuck, high rollback rate, policy gate blocked, SCM errors. (#621)
-
----
-
-## Near-Term (v0.9.0 — planned)
-
-### `kardinal-agent` standalone binary
-
-Lightweight `kardinal-agent` binary for spoke clusters behind firewalls. The reconciler is
-already shard-aware; the agent is a thin wrapper around it.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes documentation drift after kardinal-agent shipped in PR #886. Three sources of drift were identified and corrected:

1. **`docs/roadmap.md`** — The Near-Term section described `kardinal-agent` as planned. Removed the section; updated the Distributed mode description to say it's available.

2. **`docs/changelog.md`** — No changelog entry for the kardinal-agent binary. Added to Unreleased→Added with full description matching the existing entry format.

3. **`docs/design/14-v060-roadmap.md`** — Items 14.1–14.5 were listed as 🔲 Future even though all five features are implemented. Moved all to ✅ Present. Doc status updated to Complete.

4. **`docs/design/07-distributed-architecture.md`** — Added `## Present` section recording the shipped kardinal-agent binary and shard routing (per design doc conventions).

## Design doc
Updated `docs/design/14-v060-roadmap.md`: moved items 14.1–14.5 from 🔲 Future to ✅ Present.
Updated `docs/design/07-distributed-architecture.md`: added ## Present section.

## Customer doc
Updated `docs/roadmap.md` and `docs/changelog.md`.

Closes #887 #888.