### PR TITLE
docs(security): add UI API Access Control section

### DIFF
--- a/.specify/specs/926/spec.md
+++ b/.specify/specs/926/spec.md
@@ -1,0 +1,35 @@
+# Spec: docs security guide UI API auth (Issue #926)
+
+## Design reference
+- **Design doc**: `docs/design/06-kardinal-ui.md`
+- **Section**: `§ Future — UI authentication gaps`
+- **Implements**: In-cluster kubectl port-forward UX doc + security guide entry (docs companion to #924)
+
+---
+
+## Zone 1 — Obligations (falsifiable)
+
+**O1** — `docs/guides/security.md` MUST have a section covering `/api/v1/ui/*` authentication
+with the `--ui-auth-token` / `KARDINAL_UI_TOKEN` flag shipped in PR #924.
+
+**O2** — The section MUST document the recommended access method (kubectl port-forward)
+for production clusters without TLS configured.
+
+**O3** — The section MUST include a table distinguishing open paths (`/ui/*`) from
+protected paths (`/api/v1/ui/*`).
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Add a new `## UI API Access Control` section before `## Further Reading`.
+- Include example Helm values and env var usage.
+- Cross-link issues #911 (TLS) and #913 (port-forward UX).
+
+---
+
+## Zone 3 — Scoped out
+
+- Adding `controller.uiAuthToken` to the Helm chart values.yaml (separate enhancement).
+- TLS configuration (issue #911).
+- CORS configuration (issue #912).

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -350,6 +350,62 @@ helm upgrade kardinal ... --set validatingAdmissionPolicy.enabled=false
 
 ---
 
+## UI API Access Control
+
+The embedded UI server runs on port `:8082` and serves two surfaces:
+
+| Path prefix | Content | Default |
+|---|---|---|
+| `/ui/*` | React app (HTML/JS/CSS) | Open — no sensitive data |
+| `/api/v1/ui/*` | Pipeline state, Bundle history, gate details | Open — unprotected by default |
+
+Without authentication, any pod in the cluster that can reach `:8082` can read all pipeline state. Enable Bearer token protection for production deployments.
+
+### Enabling Bearer token authentication
+
+Set the `--ui-auth-token` flag (or `KARDINAL_UI_TOKEN` environment variable):
+
+```bash
+# Helm values
+helm upgrade kardinal oci://ghcr.io/pnz1990/kardinal-promoter/chart \
+  --set controller.uiAuthToken="$(openssl rand -hex 32)"
+```
+
+Or set it directly in the Deployment:
+
+```yaml
+env:
+  - name: KARDINAL_UI_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: kardinal-ui-token
+        key: token
+```
+
+When set, all `/api/v1/ui/*` requests must include:
+
+```
+Authorization: Bearer <token>
+```
+
+Requests without a valid Bearer token receive `HTTP 401` with a `Www-Authenticate: Bearer realm="kardinal-ui"` header.
+
+The static React assets at `/ui/*` are **not** gated — they contain no sensitive data and must load before the browser can supply a token.
+
+### Accessing the UI securely (before TLS is configured)
+
+Until TLS is added (tracked in [#911](https://github.com/pnz1990/kardinal-promoter/issues/911)), the recommended access method is:
+
+```bash
+kubectl port-forward svc/kardinal-kardinal-promoter 8082:8082 -n kardinal-system
+```
+
+Then access the UI at `http://localhost:8082/ui/`. The browser will display a warning when accessed over plain HTTP (`window.location.protocol != 'https:'`).
+
+> **Production note**: Do not expose port 8082 via a LoadBalancer or Ingress without TLS and auth enabled. Use port-forward for operator access until TLS is configured.
+
+---
+
 ## Further Reading
 
 - [Installation](../installation.md) — Helm values reference


### PR DESCRIPTION
## Summary

Documents the Bearer token authentication added in PR #924.

## Changes

Added `## UI API Access Control` section to `docs/guides/security.md`:
- Table distinguishing open `/ui/*` (static assets) from protected `/api/v1/ui/*` (pipeline state)
- `--ui-auth-token` / `KARDINAL_UI_TOKEN` configuration with Helm and env var examples
- `kubectl port-forward` as recommended access method before TLS is configured
- Warning about not exposing 8082 via LoadBalancer/Ingress without TLS + auth
- Cross-links to issues #911 (TLS) and #913 (port-forward UX)

Closes #926