### PR TITLE
security(m2): pin agent_version — close attack vector 3B (otherness clone unversioned)

### DIFF
--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -5,6 +5,7 @@
 project:
   name: kardinal-promoter
   repo: pnz1990/kardinal-promoter
+  agent_version: 4daf5ea695f0147ac255dc434ccf703055e85a1c  # pin otherness to this SHA (security: doc 27 §M2)
   report_issue: 1
   board_url: https://github.com/users/pnz1990/projects/1
   pr_label: kardinal


### PR DESCRIPTION
**Attack vector 3B** (design doc 27): the otherness `git clone` was unpinned. A compromise of the otherness repo would have propagated malicious agent instructions on the next session startup, affecting every project simultaneously.

**Fix**: set `agent_version: 4daf5ea695f0147ac255dc434ccf703055e85a1c` in `otherness-config.yaml`. The install step checks this and runs `git checkout <sha>` after cloning.

Security: job zero.