### PR TITLE
fix(workflow): App token validation — use /repos/:repo not /user

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -78,7 +78,7 @@ jobs:
               --label "needs-human" 2>/dev/null || true
             exit 1
           fi
-          if ! GH_TOKEN="$GH_TOKEN" gh api user --jq '.login' >/dev/null 2>&1; then
+          if ! GH_TOKEN="$GH_TOKEN" gh api "repos/$REPO" --jq '.full_name' >/dev/null 2>&1; then
             echo "::error::GH_TOKEN is invalid or expired."
             GH_TOKEN="" gh issue create --repo "$REPO" \
               --title "[NEEDS HUMAN] GH_TOKEN expired — otherness cannot run" \
@@ -107,7 +107,7 @@ jobs:
             fi
             exit 1
           fi
-          echo "[preflight] GH_TOKEN valid for: $(GH_TOKEN="$GH_TOKEN" gh api user --jq '.login') — scopes OK (repo + workflow)"
+          echo "[preflight] GH_TOKEN valid for: $(GH_TOKEN="$GH_TOKEN" gh api "repos/$REPO" --jq '.full_name') — scopes OK (repo + workflow)"
 
       # ── Step 3: Install agent files ──────────────────────────────────────
       # Clones pnz1990/otherness to ~/.otherness on the runner.


### PR DESCRIPTION
App installation tokens cannot call `/user`. Fixes auth step failing immediately after token generation.