### PR TITLE
fix(workflow): commit agent_version upgrade to session branch

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -168,24 +168,30 @@ jobs:
               if git -C ~/.otherness checkout "$NEWEST" --quiet 2>/dev/null; then
                 RESOLVED_VERSION="$NEWEST"
                 python3 -c "import re,sys; c=open('otherness-config.yaml').read(); c=re.sub(r'(\s+agent_version:\s*)[\"\'\'']?v[0-9]+\.[0-9]+\.[0-9]+[\"\'\'']?',lambda m:m.group(1)+sys.argv[1],c,count=1); open('otherness-config.yaml','w').write(c); print('[otherness] agent_version -> '+sys.argv[1])" "$NEWEST" 2>/dev/null || echo "::warning::Could not rewrite agent_version"
+                # Commit the rewrite to the working tree so the session branch PR includes it.
+                # Without this the upgrade fires every session forever (file is never persisted).
+                git config user.name "otherness[bot]" 2>/dev/null || true
+                git config user.email "otherness[bot]@users.noreply.github.com" 2>/dev/null || true
+                git add otherness-config.yaml 2>/dev/null && \
+                  git commit -m "chore(config): auto-upgrade agent_version $AGENT_VERSION -> $NEWEST" \
+                  2>/dev/null && echo "[otherness] upgrade committed to session branch" || true
               else
                 echo "::warning::Could not checkout $NEWEST -- staying on $AGENT_VERSION"
               fi
             else
               echo "[otherness] Already at newest allowed version ($AGENT_VERSION)"
             fi
-          fi
-
           if [ -n "$AGENT_VERSION" ] && [ "$RESOLVED_VERSION" = "$AGENT_VERSION" ]; then
             git -C ~/.otherness fetch --tags --quiet 2>/dev/null || true
             git -C ~/.otherness checkout "$AGENT_VERSION" --quiet 2>/dev/null \
               && echo "[otherness] Pinned to $AGENT_VERSION" \
               || echo "::warning::Could not checkout $AGENT_VERSION -- using HEAD"
           elif [ -z "$AGENT_VERSION" ]; then
-            echo "[otherness] Using HEAD: $(git -C ~/.otherness rev-parse --short HEAD)"
+            echo "[otherness] Using HEAD (no pin set)"
           fi
 
-          echo "[otherness] Active version: $(git -C ~/.otherness describe --tags --exact-match 2>/dev/null || git -C ~/.otherness rev-parse --short HEAD)"
+          ACTIVE=$(git -C ~/.otherness describe --tags --exact-match 2>/dev/null || git -C ~/.otherness rev-parse --short HEAD)
+          echo "[otherness] Active version: $ACTIVE"
 
       # ── Step 4: Sync command files ───────────────────────────────────────
       - name: Sync otherness command files


### PR DESCRIPTION
Without this fix the upgrade fires every session forever. The config rewrite now gets committed so §4g merges it and next session sees the new pin.